### PR TITLE
Fix typo

### DIFF
--- a/docs/docs/allowed.md
+++ b/docs/docs/allowed.md
@@ -30,7 +30,7 @@ or:
 ```
 
 # AllowedForInstance
-In some cases, the allowed ca be evaluated with regards to a specific instance, for example `allowApiUpdate` can consider specific row values.
+In some cases, the allowed can be evaluated with regards to a specific instance, for example `allowApiUpdate` can consider specific row values.
 The Allowed for Instance method accepts two parameters:
 1. The relevant `remult` object
 2. The relevant entity instance

--- a/docs/docs/ref_paginator.md
+++ b/docs/docs/ref_paginator.md
@@ -7,4 +7,4 @@ the items in the current page
 ## count
 the count of the total items in the `query`'s result
 ## nextPage
-Get's the next page in the query's result set
+Gets the next page in the `query`'s result set


### PR DESCRIPTION
Hi remult!
When I read the docs, I found some typo.

"ca" -> "can"
"get's" -> "gets"

And then, add the backtick to query for consistency with other examples.