### PR TITLE
changed allowed for instance to receive remult as second parameter

### DIFF
--- a/core-api/src/context.d.ts
+++ b/core-api/src/context.d.ts
@@ -95,11 +95,11 @@ export interface UserInfo {
     name?: string;
     roles?: string[];
 }
-export declare type Allowed = boolean | string | string[] | ((c: Remult) => boolean);
-export declare type AllowedForInstance<T> = boolean | string | string[] | ((c: Remult, entity?: T) => boolean);
+export declare type Allowed = boolean | string | string[] | ((c?: Remult) => boolean);
+export declare type AllowedForInstance<T> = boolean | string | string[] | ((entity?: T, c?: Remult) => boolean);
 export declare class Allow {
     static everyone: () => boolean;
-    static authenticated: (remult: Remult) => boolean;
+    static authenticated: (...args: any[]) => any;
 }
 export declare const queryConfig: {
     defaultPageSize: number;

--- a/projects/core/server/expressBridge.ts
+++ b/projects/core/server/expressBridge.ts
@@ -18,6 +18,7 @@ export interface RemultServerOptions<RequestType extends GenericRequest> {
   */
   dataProvider?: DataProvider | Promise<DataProvider> | (() => Promise<DataProvider | undefined>);
   queueStorage?: QueueStorage;
+  //TODO - more remult to options
   initRequest?: (remult: Remult, origReq: RequestType) => Promise<void>;
   getUser?: (request: RequestType) => Promise<UserInfo>;
   initApi?: (remult: Remult) => void | Promise<void>;

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -181,7 +181,7 @@ export class Remult {
             }
         }
         else if (typeof (allowed) === "function") {
-            return allowed(this, instance)
+            return allowed(instance, this)
         } else return this.isAllowed(allowed as Allowed);
     }
     /* @internal */
@@ -309,17 +309,22 @@ export interface UserInfo {
 }
 
 
-export declare type Allowed = boolean | string | string[] | ((c: Remult) => boolean);
+export declare type Allowed = boolean | string | string[] | ((c?: Remult) => boolean);
 
-export declare type AllowedForInstance<T> = boolean | string | string[] | ((c: Remult, entity?: T) => boolean);
+export declare type AllowedForInstance<T> = boolean | string | string[] | ((entity?: T, c?: Remult) => boolean);
 export class Allow {
     static everyone = () => true;
-    static authenticated = (remult: Remult) => remult.authenticated();
+    static authenticated = (...args: any[]) => {
+        if (args.length > 1) {
+            return (args[1] as Remult).authenticated()
+        }
+        else if (args.length == 1) {
+            if (args[0].authenticated)
+                return args[0].authenticated();
+        }
+        return RepositoryImplementation.defaultRemult.authenticated();
+    }
 }
-
-
-
-
 
 
 

--- a/projects/core/src/tests/basicRowFunctionality.spec.ts
+++ b/projects/core/src/tests/basicRowFunctionality.spec.ts
@@ -1218,7 +1218,7 @@ describe("data api", () => {
     };
     Entity<typeof type.prototype>('', {
 
-      allowApiDelete: (c, t) => {
+      allowApiDelete: (t, c) => {
         return t.id == 1;
       }
     })(type);
@@ -1248,7 +1248,7 @@ describe("data api", () => {
     };
     Entity<typeof type.prototype>('', {
 
-      allowApiUpdate: (c, t) => {
+      allowApiUpdate: (t, c) => {
         return t.id == 1;
       }
     })(type);
@@ -1283,7 +1283,7 @@ describe("data api", () => {
     };
     Entity<typeof type.prototype>('', {
 
-      allowApiInsert: (c, t) => {
+      allowApiInsert: (t, c) => {
         return t.categoryName == 'ok';
       }
     })(type);
@@ -1792,7 +1792,7 @@ describe("test rest data provider translates data correctly", () => {
     let c = new Remult().repo(type);
     let z = new RestDataProvider(() => ({
       httpClient: {
-        delete: ()=>undefined,
+        delete: () => undefined,
         get: async () => {
           return [
             {
@@ -1801,8 +1801,8 @@ describe("test rest data provider translates data correctly", () => {
             }
           ]
         },
-        post: ()=>undefined,
-        put: ()=>undefined
+        post: () => undefined,
+        put: () => undefined
       }
     }));
     let x = z.getEntityDataProvider(c.metadata);
@@ -1868,15 +1868,15 @@ describe("test rest data provider translates data correctly", () => {
     let done = new Done();
     let z = new RestDataProvider(() => ({
       httpClient: {
-        delete: ()=>undefined,
-        get: ()=>undefined,
+        delete: () => undefined,
+        get: () => undefined,
         post: async (x, data) => {
           done.ok();
           expect(data.a).toBe(1);
           expect(data.b).toBe("2021-05-16T08:32:19.905Z");
           return data;
         },
-        put: ()=>undefined
+        put: () => undefined
       }
     }));
     let x = z.getEntityDataProvider(c.metadata);

--- a/projects/core/src/tests/test-data-api/test-put-with-validation.spec.ts
+++ b/projects/core/src/tests/test-data-api/test-put-with-validation.spec.ts
@@ -60,7 +60,7 @@ describe("data api", () => {
         Entity('allowcolumnupdatetest', { allowApiCrud: true })(type);
         Fields.integer()(type.prototype, 'id');
         Fields.string<EntityBase>({
-            allowApiUpdate: (c, x) => x._.isNew()
+            allowApiUpdate: (x, c) => x._.isNew()
         })(type.prototype, 'val');
         let remult = new Remult();
         remult.dataProvider = (new InMemoryDataProvider());
@@ -92,7 +92,7 @@ describe("data api", () => {
         Entity('allowcolumnupdatetest', { allowApiCrud: true })(type);
         Fields.integer()(type.prototype, 'id');
         Fields.string<typeof type.prototype>({
-            allowApiUpdate: (c, x) => x.val != "yael"
+            allowApiUpdate: (x, c) => x.val != "yael"
         })(type.prototype, 'val');
         let remult = new Remult();
         remult.dataProvider = (new InMemoryDataProvider());


### PR DESCRIPTION
Not sure if we should remove the remult second paramter all together.

I'm thinking of something without support for async_hooks, and allowed for backend method that has no way of getting remult