### PR TITLE
Update live-queries.md - no variable needed

### DIFF
--- a/docs/tutorials/react-next/live-queries.md
+++ b/docs/tutorials/react-next/live-queries.md
@@ -45,7 +45,8 @@ Let's review the change:
 const addTask = async (e: FormEvent) => {
   e.preventDefault()
   try {
-    const newTask = await taskRepo.insert({ title: newTaskTitle })
+    await taskRepo.insert({ title: newTaskTitle })
+    // ^ this no longer needs to be a variable as we are not using it to set the state.
     // setTasks([...tasks, newTask])   <-- this line is no longer needed
     setNewTaskTitle("")
   } catch (error: any) {


### PR DESCRIPTION
Small thing, looks like the line below the variable was commented out but we no longer need it to be a variable to use to spread it into the useState setter.