### PR TITLE
createdAt tutorial corrections

### DIFF
--- a/docs/docs/ref_field.md
+++ b/docs/docs/ref_field.md
@@ -1,6 +1,6 @@
 # Field
 Decorates fields that should be used as fields.
-for more info see: [Field Types](https://remult.dev/docs/field-types.html)
+for more info see: [Field Types](../docs/field-types.md)
    
    
    *example*

--- a/docs/tutorials/angular/entities.md
+++ b/docs/tutorials/angular/entities.md
@@ -26,16 +26,16 @@ import { Entity, Fields } from "remult"
 })
 export class Task {
   @Fields.cuid()
-  id = "";
+  id = ""
 
   @Fields.string()
-  title = "";
+  title = ""
 
   @Fields.boolean()
-  completed = false;
+  completed = false
 
   @Fields.createdAt()
-  createdAt?: Date;
+  createdAt?: Date
 }
 ```
 
@@ -56,9 +56,15 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The `@Fields.autoIncrement` decorator tells Remult to automatically generate an id using the databases's auto increment capabilities.
+The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
 The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+
+The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+
+::: tip
+For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.
+:::
 
 ## Test the API
 

--- a/docs/tutorials/angular/entities.md
+++ b/docs/tutorials/angular/entities.md
@@ -56,11 +56,11 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
+The [@Fields.cuid](../../docs/field-types.md#fields-cuid) decorator tells Remult to automatically generate a short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
-The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+The [@Fields.string](../../docs/field-types.md#fields-string) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
 
-The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+The [@Fields.createdAt](../../docs/field-types.md#fields-createdat) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
 
 ::: tip
 For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.

--- a/docs/tutorials/angular/entities.md
+++ b/docs/tutorials/angular/entities.md
@@ -25,14 +25,17 @@ import { Entity, Fields } from "remult"
   allowApiCrud: true
 })
 export class Task {
-  @Fields.autoIncrement()
-  id = 0
+  @Fields.cuid()
+  id = "";
 
   @Fields.string()
-  title = ""
+  title = "";
 
   @Fields.boolean()
-  completed = false
+  completed = false;
+
+  @Fields.createdAt()
+  createdAt?: Date;
 }
 ```
 

--- a/docs/tutorials/angular/entities.md
+++ b/docs/tutorials/angular/entities.md
@@ -8,7 +8,7 @@ The `Task` entity class will be used:
 - As a model class for server-side code
 - By `remult` to generate API endpoints, API queries, and database commands
 
-The `Task` entity class we're creating will have an auto-increment `id` field a `title` field and a `completed` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
+The `Task` entity class we're creating will have an auto-generated `id` field, a `title` field, a `completed` field and an auto-generated `createdAt` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
 
 ## Define the Model
 

--- a/docs/tutorials/angular/live-queries.md
+++ b/docs/tutorials/angular/live-queries.md
@@ -45,7 +45,7 @@ export class TodoComponent implements OnInit, OnDestroy {
     this.unsubscribe = this.taskRepo
       .liveQuery({
         limit: 20,
-        orderBy: { completed: "asc" }
+        orderBy: { createdAt: "asc" }
         //where: { completed: true },
       })
       .subscribe(info => (this.tasks = info.applyChanges(this.tasks)))

--- a/docs/tutorials/angular/sorting-filtering.md
+++ b/docs/tutorials/angular/sorting-filtering.md
@@ -39,7 +39,7 @@ Use "asc" and "desc" to determine the sort order.
 ngOnInit() {
   this.taskRepo.find({
     limit: 20,
-    orderBy: { completed:"asc" }
+    orderBy: { createdAt:"asc" }
   }).then((items) => (this.tasks = items));
 }
 ```
@@ -60,7 +60,7 @@ Adjust the `ngOnInit` method to fetch only `completed` tasks.
 ngOnInit() {
   this.taskRepo.find({
     limit: 20,
-    orderBy: { completed:"asc" },
+    orderBy: { createdAt:"asc" },
     where: { completed: true }
   }).then((items) => (this.tasks = items));
 }
@@ -76,7 +76,7 @@ Play with different filtering values, and eventually comment it out, since we do
 ngOnInit() {
   this.taskRepo.find({
     limit: 20,
-    orderBy: { completed:"asc" },
+    orderBy: { createdAt:"asc" },
     //where: { completed: true }
   }).then((items) => (this.tasks = items));
 }

--- a/docs/tutorials/angular/sorting-filtering.md
+++ b/docs/tutorials/angular/sorting-filtering.md
@@ -26,9 +26,9 @@ There aren't enough tasks in the database for this change to have an immediate e
 To query subsequent pages, use the [Repository.find()](../../docs/ref_repository.md#find) method's `page` option.
 :::
 
-## Show Active Tasks on Top
+## Sorting By Creation Date
 
-Uncompleted tasks are important and should appear above completed tasks in the todo app.
+We would like old tasks to appear first in the list, and new tasks to appear last. Let's sort the tasks by their `createdAt` field.
 
 In the `ngOnInit` method, set the `orderBy` property of the `find` method call's `option` argument to an object that contains the fields you want to sort by.
 Use "asc" and "desc" to determine the sort order.

--- a/docs/tutorials/angular/sorting-filtering.md
+++ b/docs/tutorials/angular/sorting-filtering.md
@@ -44,10 +44,6 @@ ngOnInit() {
 }
 ```
 
-::: warning Note
-By default, `false` is a "lower" value than `true`, and that's why uncompleted tasks are now showing at the top of the task list.
-:::
-
 ## Server side Filtering
 
 Remult supports sending filter rules to the server to query only the tasks that we need.

--- a/docs/tutorials/react-next/entities.md
+++ b/docs/tutorials/react-next/entities.md
@@ -56,11 +56,11 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
+The [@Fields.cuid](../../docs/field-types.md#fields-cuid) decorator tells Remult to automatically generate a short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
-The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+The [@Fields.string](../../docs/field-types.md#fields-string) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
 
-The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+The [@Fields.createdAt](../../docs/field-types.md#fields-createdat) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
 
 ::: tip
 For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.

--- a/docs/tutorials/react-next/entities.md
+++ b/docs/tutorials/react-next/entities.md
@@ -26,16 +26,16 @@ import { Entity, Fields } from "remult"
 })
 export class Task {
   @Fields.cuid()
-  id = "";
+  id = ""
 
   @Fields.string()
-  title = "";
+  title = ""
 
   @Fields.boolean()
-  completed = false;
+  completed = false
 
   @Fields.createdAt()
-  createdAt?: Date;
+  createdAt?: Date
 }
 ```
 
@@ -56,10 +56,15 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-
-The `@Fields.autoIncrement` decorator tells Remult to automatically generate an id using the databases's auto increment capabilities.
+The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
 The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+
+The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+
+::: tip
+For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.
+:::
 
 ## Test the API
 

--- a/docs/tutorials/react-next/entities.md
+++ b/docs/tutorials/react-next/entities.md
@@ -25,14 +25,17 @@ import { Entity, Fields } from "remult"
   allowApiCrud: true
 })
 export class Task {
-  @Fields.autoIncrement()
-  id = 0
+  @Fields.cuid()
+  id = "";
 
   @Fields.string()
-  title = ""
+  title = "";
 
   @Fields.boolean()
-  completed = false
+  completed = false;
+
+  @Fields.createdAt()
+  createdAt?: Date;
 }
 ```
 

--- a/docs/tutorials/react-next/entities.md
+++ b/docs/tutorials/react-next/entities.md
@@ -8,7 +8,7 @@ The `Task` entity class will be used:
 - As a model class for server-side code
 - By `remult` to generate API endpoints, API queries, and database commands
 
-The `Task` entity class we're creating will have an auto-increment `id` field a `title` field and a `completed` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
+The `Task` entity class we're creating will have an auto-generated `id` field, a `title` field, a `completed` field and an auto-generated `createdAt` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
 
 ## Define the Model
 

--- a/docs/tutorials/react-next/live-queries.md
+++ b/docs/tutorials/react-next/live-queries.md
@@ -21,7 +21,7 @@ useEffect(() => {
   return taskRepo
     .liveQuery({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
       //where: { completed: true },
     })
     .subscribe(info => setTasks(info.applyChanges))

--- a/docs/tutorials/react-next/sorting-filtering.md
+++ b/docs/tutorials/react-next/sorting-filtering.md
@@ -56,10 +56,6 @@ useEffect(() => {
 }, [])
 ```
 
-::: warning Note
-By default, `false` is a "lower" value than `true`, and that's why uncompleted tasks are now showing at the top of the task list.
-:::
-
 ## Server Side Filtering
 
 Remult supports sending filter rules to the server to query only the tasks that we need.

--- a/docs/tutorials/react-next/sorting-filtering.md
+++ b/docs/tutorials/react-next/sorting-filtering.md
@@ -36,10 +36,9 @@ There aren't enough tasks in the database for this change to have an immediate e
 To query subsequent pages, use the [Repository.find()](../../docs/ref_repository.md#find) method's `page` option.
 :::
 
+## Sorting By Creation Date
 
-## Show Active Tasks on Top
-
-Uncompleted tasks are important and should appear above completed tasks in the todo app.
+We would like old tasks to appear first in the list, and new tasks to appear last. Let's sort the tasks by their `createdAt` field.
 
 In the `useEffect` hook, set the `orderBy` property of the `find` method call's `option` argument to an object that contains the fields you want to sort by.
 Use "asc" and "desc" to determine the sort order.

--- a/docs/tutorials/react-next/sorting-filtering.md
+++ b/docs/tutorials/react-next/sorting-filtering.md
@@ -51,7 +51,7 @@ useEffect(() => {
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
     })
     .then(setTasks)
 }, [])
@@ -73,7 +73,7 @@ useEffect(() => {
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" },
+      orderBy: { createdAt: "asc" },
       where: { completed: true }
     })
     .then(setTasks)
@@ -91,7 +91,7 @@ Play with different filtering values, and eventually comment it out, since we do
     taskRepo
       .find({
         limit: 20,
-        orderBy: { completed: "asc" },
+        orderBy: { createdAt: "asc" },
         //where: { completed: true },
       })
       .then(setTasks);

--- a/docs/tutorials/react/entities.md
+++ b/docs/tutorials/react/entities.md
@@ -56,11 +56,11 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
+The [@Fields.cuid](../../docs/field-types.md#fields-cuid) decorator tells Remult to automatically generate a short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
-The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+The [@Fields.string](../../docs/field-types.md#fields-string) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
 
-The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+The [@Fields.createdAt](../../docs/field-types.md#fields-createdat) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
 
 ::: tip
 For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.

--- a/docs/tutorials/react/entities.md
+++ b/docs/tutorials/react/entities.md
@@ -25,14 +25,17 @@ import { Entity, Fields } from "remult"
   allowApiCrud: true
 })
 export class Task {
-  @Fields.autoIncrement()
-  id = 0
+  @Fields.cuid()
+  id = "";
 
   @Fields.string()
-  title = ""
+  title = "";
 
   @Fields.boolean()
-  completed = false
+  completed = false;
+
+  @Fields.createdAt()
+  createdAt?: Date;
 }
 ```
 

--- a/docs/tutorials/react/entities.md
+++ b/docs/tutorials/react/entities.md
@@ -26,16 +26,16 @@ import { Entity, Fields } from "remult"
 })
 export class Task {
   @Fields.cuid()
-  id = "";
+  id = ""
 
   @Fields.string()
-  title = "";
+  title = ""
 
   @Fields.boolean()
-  completed = false;
+  completed = false
 
   @Fields.createdAt()
-  createdAt?: Date;
+  createdAt?: Date
 }
 ```
 
@@ -56,10 +56,15 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The `@Fields.autoIncrement` decorator tells Remult to automatically generate an id using the databases's auto increment capabilities.
+The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
 The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
 
+The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+
+::: tip
+For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.
+:::
 ## Test the API
 
 Now that the `Task` entity is defined, we can start using the REST API to query and add a tasks.

--- a/docs/tutorials/react/entities.md
+++ b/docs/tutorials/react/entities.md
@@ -8,7 +8,7 @@ The `Task` entity class will be used:
 - As a model class for server-side code
 - By `remult` to generate API endpoints, API queries, and database commands
 
-The `Task` entity class we're creating will have an auto-increment `id` field a `title` field and a `completed` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
+The `Task` entity class we're creating will have an auto-generated `id` field, a `title` field, a `completed` field and an auto-generated `createdAt` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
 
 ## Define the Model
 

--- a/docs/tutorials/react/live-queries.md
+++ b/docs/tutorials/react/live-queries.md
@@ -21,7 +21,7 @@ useEffect(() => {
   return taskRepo
     .liveQuery({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
       //where: { completed: true },
     })
     .subscribe(info => setTasks(info.applyChanges))

--- a/docs/tutorials/react/sorting-filtering.md
+++ b/docs/tutorials/react/sorting-filtering.md
@@ -28,9 +28,9 @@ There aren't enough tasks in the database for this change to have an immediate e
 To query subsequent pages, use the [Repository.find()](../../docs/ref_repository.md#find) method's `page` option.
 :::
 
-## Show Active Tasks on Top
+## Sorting By Creation Date
 
-Uncompleted tasks are important and should appear above completed tasks in the todo app.
+We would like old tasks to appear first in the list, and new tasks to appear last. Let's sort the tasks by their `createdAt` field.
 
 In the `useEffect` hook, set the `orderBy` property of the `find` method call's `option` argument to an object that contains the fields you want to sort by.
 Use "asc" and "desc" to determine the sort order.

--- a/docs/tutorials/react/sorting-filtering.md
+++ b/docs/tutorials/react/sorting-filtering.md
@@ -47,11 +47,6 @@ useEffect(() => {
     .then(setTasks)
 }, [])
 ```
-
-::: warning Note
-By default, `false` is a "lower" value than `true`, and that's why uncompleted tasks are now showing at the top of the task list.
-:::
-
 ## Server side Filtering
 
 Remult supports sending filter rules to the server to query only the tasks that we need.

--- a/docs/tutorials/react/sorting-filtering.md
+++ b/docs/tutorials/react/sorting-filtering.md
@@ -42,7 +42,7 @@ useEffect(() => {
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
     })
     .then(setTasks)
 }, [])
@@ -65,7 +65,7 @@ useEffect(() => {
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" },
+      orderBy: { createdAt: "asc" },
       where: { completed: true }
     })
     .then(setTasks)
@@ -83,7 +83,7 @@ useEffect(() => {
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
       //where: { completed: true },
     })
     .then(setTasks)

--- a/docs/tutorials/vue/entities.md
+++ b/docs/tutorials/vue/entities.md
@@ -26,16 +26,16 @@ import { Entity, Fields } from "remult"
 })
 export class Task {
   @Fields.cuid()
-  id = "";
+  id = ""
 
   @Fields.string()
-  title = "";
+  title = ""
 
   @Fields.boolean()
-  completed = false;
+  completed = false
 
   @Fields.createdAt()
-  createdAt?: Date;
+  createdAt?: Date
 }
 ```
 
@@ -56,9 +56,15 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The `@Fields.autoIncrement` decorator tells Remult to automatically generate an id using the databases's auto increment capabilities.
+The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
 The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+
+The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+
+::: tip
+For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.
+:::
 
 ## Test the API
 

--- a/docs/tutorials/vue/entities.md
+++ b/docs/tutorials/vue/entities.md
@@ -56,11 +56,11 @@ The [@Entity](../../docs/ref_entity.md) decorator tells Remult this class is an 
 
 To initially allow all CRUD operations for tasks, we set the option [allowApiCrud](../../docs/ref_entity.md#allowapicrud) to `true`.
 
-The [@Fields.cuid](../../docs/ref_field.md) decorator tells Remult to automatically generate an short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
+The [@Fields.cuid](../../docs/field-types.md#fields-cuid) decorator tells Remult to automatically generate a short random id using the [cuid](https://github.com/paralleldrive/cuid) library. This value can't be changed after the entity is created.
 
-The [@Fields.string](../../docs/ref_field.md) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
+The [@Fields.string](../../docs/field-types.md#fields-string) decorator tells Remult the `title` property is an entity data field of type `String`. This decorator is also used to define field-related properties and operations, discussed in the next sections of this tutorial and the same goes for `@Fields.boolean` and the `completed` property.
 
-The [@Fields.createdAt](../../docs/ref_field.md) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
+The [@Fields.createdAt](../../docs/field-types.md#fields-createdat) decorator tells Remult to automatically generate a `createdAt` field with the current date and time.
 
 ::: tip
 For a complete list of supported field types, see the [Field Types](../../docs/field-types.md) section in the Remult documentation.

--- a/docs/tutorials/vue/entities.md
+++ b/docs/tutorials/vue/entities.md
@@ -25,14 +25,17 @@ import { Entity, Fields } from "remult"
   allowApiCrud: true
 })
 export class Task {
-  @Fields.autoIncrement()
-  id = 0
+  @Fields.cuid()
+  id = "";
 
   @Fields.string()
-  title = ""
+  title = "";
 
   @Fields.boolean()
-  completed = false
+  completed = false;
+
+  @Fields.createdAt()
+  createdAt?: Date;
 }
 ```
 

--- a/docs/tutorials/vue/entities.md
+++ b/docs/tutorials/vue/entities.md
@@ -8,7 +8,7 @@ The `Task` entity class will be used:
 - As a model class for server-side code
 - By `remult` to generate API endpoints, API queries, and database commands
 
-The `Task` entity class we're creating will have an auto-increment `id` field a `title` field and a `completed` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
+The `Task` entity class we're creating will have an auto-generated `id` field, a `title` field, a `completed` field and an auto-generated `createdAt` field. The entity's API route ("tasks") will include endpoints for all `CRUD` operations.
 
 ## Define the Model
 

--- a/docs/tutorials/vue/live-queries.md
+++ b/docs/tutorials/vue/live-queries.md
@@ -22,7 +22,7 @@ onMounted(() =>
     taskRepo
       .liveQuery({
         limit: 20,
-        orderBy: { completed: "asc" }
+        orderBy: { createdAt: "asc" }
         //where: { completed: true },
       })
       .subscribe(info => (tasks.value = info.applyChanges(tasks.value)))

--- a/docs/tutorials/vue/sorting-filtering.md
+++ b/docs/tutorials/vue/sorting-filtering.md
@@ -42,7 +42,7 @@ onMounted(() =>
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
     })
     .then(items => (tasks.value = items))
 )
@@ -65,7 +65,7 @@ onMounted(() =>
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" },
+      orderBy: { createdAt: "asc" },
       where: { completed: true }
     })
     .then(items => (tasks.value = items))
@@ -83,7 +83,7 @@ onMounted(() =>
   taskRepo
     .find({
       limit: 20,
-      orderBy: { completed: "asc" }
+      orderBy: { createdAt: "asc" }
       //where: { completed: true }
     })
     .then(items => (tasks.value = items))

--- a/docs/tutorials/vue/sorting-filtering.md
+++ b/docs/tutorials/vue/sorting-filtering.md
@@ -48,10 +48,6 @@ onMounted(() =>
 )
 ```
 
-::: warning Note
-By default, `false` is a "lower" value than `true`, and that's why uncompleted tasks are now showing at the top of the task list.
-:::
-
 ## Server side Filtering
 
 Remult supports sending filter rules to the server to query only the tasks that we need.

--- a/docs/tutorials/vue/sorting-filtering.md
+++ b/docs/tutorials/vue/sorting-filtering.md
@@ -28,9 +28,9 @@ There aren't enough tasks in the database for this change to have an immediate e
 To query subsequent pages, use the [Repository.find()](../../docs/ref_repository.md#find) method's `page` option.
 :::
 
-## Show Active Tasks on Top
+## Sorting By Creation Date
 
-Uncompleted tasks are important and should appear above completed tasks in the todo app.
+We would like old tasks to appear first in the list, and new tasks to appear last. Let's sort the tasks by their `createdAt` field.
 
 In the `onMounted` hook, set the `orderBy` property of the `find` method call's `option` argument to an object that contains the fields you want to sort by.
 Use "asc" and "desc" to determine the sort order.


### PR DESCRIPTION
a corrected entity on all tutorials:

- id is cuid()
- added createdAt as date
- changed the sorting examples on sorting & liveQuery pages to createdAt