### PR TITLE
:sparkles: NEW: add transaction test

### DIFF
--- a/projects/tests/dbs/postgres.spec.ts
+++ b/projects/tests/dbs/postgres.spec.ts
@@ -130,9 +130,11 @@ describe.skipIf(!postgresConnection)('Postgres Tests', () => {
         await remult.repo(ent).insert({ id: 1, name: 'a' })
         await remult.repo(ent).insert({ id: 2, name: 'a' })
       })
-    } catch (error) {}
-    // Bring back the old dataprovider
-    remult.dataProvider = old_dataProvider
+    } catch (error) {
+    } finally {
+      // Bring back the old dataprovider
+      remult.dataProvider = old_dataProvider
+    }
 
     // nothing should be inserted
     data = await remult.repo(ent).find()

--- a/projects/tests/dbs/postgres.spec.ts
+++ b/projects/tests/dbs/postgres.spec.ts
@@ -13,7 +13,6 @@ import { allDbTests } from './shared-tests'
 import { entityWithValidations } from './shared-tests/entityWithValidations'
 import { knexTests } from './shared-tests/test-knex'
 
-
 PostgresSchemaBuilder.logToConsole = false
 const postgresConnection = process.env.DATABASE_URL
 describe.skipIf(!postgresConnection)('Postgres Tests', () => {
@@ -93,55 +92,6 @@ describe.skipIf(!postgresConnection)('Postgres Tests', () => {
         )
         expect(r.rows[0].c).toBe('4')
       })
-  })
-  it('transaction should fully rollback if one faile', async () => {
-    const originalConsoleError = console.error
-    console.error = vi.fn()
-
-    const entityName = 'test_transaction'
-    await db.execute('Drop table if exists ' + entityName)
-    await db.execute(`create table ${entityName}(id int,name varchar UNIQUE)`)
-    const ent = class {
-      id = 0
-      name = ''
-    }
-    describeClass(ent, Entity(entityName), {
-      id: Fields.integer(),
-      name: Fields.string(),
-    })
-
-    await remult.repo(ent).insert({ id: 1, name: 'a' })
-    try {
-      // error expected
-      await remult.repo(ent).insert({ id: 2, name: 'a' })
-    } catch (error) {}
-
-    let data = await remult.repo(ent).find()
-    expect(data.length).toBe(1)
-
-    // remove everthing
-    await remult.repo(ent).delete(1)
-    data = await remult.repo(ent).find()
-    expect(data.length).toBe(0)
-
-    const old_dataProvider = remult.dataProvider
-    try {
-      await remult.dataProvider.transaction(async (trx) => {
-        remult.dataProvider = trx
-        await remult.repo(ent).insert({ id: 1, name: 'a' })
-        await remult.repo(ent).insert({ id: 2, name: 'a' })
-      })
-    } catch (error) {
-    } finally {
-      // Bring back the old dataprovider
-      remult.dataProvider = old_dataProvider
-    }
-
-    // nothing should be inserted
-    data = await remult.repo(ent).find()
-    expect(data.length).toBe(0)
-
-    console.error = originalConsoleError
   })
   it('default order by', async () => {
     let s = await entityWithValidations.create4RowsInDp(createEntity)

--- a/projects/tests/dbs/shared-tests/db-tests.ts
+++ b/projects/tests/dbs/shared-tests/db-tests.ts
@@ -877,19 +877,7 @@ export function commonDbTests(
 
       const entityName = 'test_transaction'
       let remult = new Remult(getDb())
-      // Was in the test before
-      // await getDb().execute('Drop table if exists ' + entityName)
-      // await getDb().execute(`create table ${entityName}(id int,name varchar UNIQUE)`)
-      // tentative 1
-      const sql = SqlDatabase.getDb(remult)
-      sql.execute('Drop table if exists ' + entityName)
-      sql.execute(`create table ${entityName}(id int,name varchar UNIQUE)`)
-      // tentative 2, working, but I need to set the UNIQUE db constraints! So not good
-      // await getDb().ensureSchema([remult.repo(ent).metadata])
-      // const all = await remult.repo(ent).find()
-      // for (let i = 0; i < all.length; i++) {
-      //   await remult.repo(ent).delete(all[i].id)
-      // }
+
       const ent = class {
         id = 0
         name = ''
@@ -899,10 +887,16 @@ export function commonDbTests(
         name: Fields.string(),
       })
 
+      await getDb().ensureSchema([remult.repo(ent).metadata])
+      const all = await remult.repo(ent).find()
+      for (let i = 0; i < all.length; i++) {
+        await remult.repo(ent).delete(all[i].id)
+      }
+
       await remult.repo(ent).insert({ id: 1, name: 'a' })
       try {
         // error expected
-        await remult.repo(ent).insert({ id: 2, name: 'a' })
+        await remult.repo(ent).insert({ id: 1, name: 'b' })
       } catch (error) {}
 
       let data = await remult.repo(ent).find()
@@ -918,7 +912,7 @@ export function commonDbTests(
         await remult.dataProvider.transaction(async (trx) => {
           remult.dataProvider = trx
           await remult.repo(ent).insert({ id: 1, name: 'a' })
-          await remult.repo(ent).insert({ id: 2, name: 'a' })
+          await remult.repo(ent).insert({ id: 1, name: 'b' })
         })
       } catch (error) {
       } finally {

--- a/projects/tests/dbs/shared-tests/db-tests.ts
+++ b/projects/tests/dbs/shared-tests/db-tests.ts
@@ -887,7 +887,7 @@ export function commonDbTests(
         name: Fields.string(),
       })
 
-      await getDb().ensureSchema([remult.repo(ent).metadata])
+      await createEntity(ent)
       const all = await remult.repo(ent).find()
       for (let i = 0; i < all.length; i++) {
         await remult.repo(ent).delete(all[i].id)


### PR DESCRIPTION
Adding a test acting more like a demo.

Focus on setting back `remult.dataProvider` to the previous dataProvider