### PR TITLE
:tada: NEW: add vite plugin to remove BackendMethod in the client bundle

### DIFF
--- a/misc/dts-compare/vite/remult-vite.d.ts
+++ b/misc/dts-compare/vite/remult-vite.d.ts
@@ -1,0 +1,5 @@
+import type { Plugin } from 'vite';
+export type RemultViteOptions = {
+    debug?: boolean;
+};
+export declare function remult(options?: RemultViteOptions): Plugin;

--- a/misc/dts-compare/vite/transform.d.ts
+++ b/misc/dts-compare/vite/transform.d.ts
@@ -1,0 +1,6 @@
+export declare const transform: (code: string) => Promise<{
+    transformed: boolean;
+    code: string;
+    map?: any;
+    toString(): string;
+}>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "remult-mono-repo",
       "version": "0.22.7",
       "devDependencies": {
+        "@babel/parser": "^7.22.16",
         "@fastify/express": "^2.0.1",
         "@fastify/middie": "^8.0.0",
         "@fastify/swagger-ui": "^1.8.1",
@@ -56,6 +57,7 @@
         "next": "^13.1.6",
         "pg": "^8.3.0",
         "prettier": "^3.0.0",
+        "recast": "^0.23.4",
         "reflect-metadata": "^0.1.13",
         "swagger-ui-express": "^4.1.6",
         "tedious": "^14.1.0",
@@ -1182,6 +1184,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.22.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -4897,6 +4911,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/assertion-error": {
@@ -9035,6 +9062,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -9208,6 +9251,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negative-zero": {
@@ -10821,6 +10880,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12146,6 +12221,34 @@
       "dev": true,
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.4.tgz",
+      "integrity": "sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==",
+      "dev": true,
+      "dependencies": {
+        "assert": "^2.0.0",
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rechoir": {
@@ -14504,6 +14607,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16712,6 +16828,12 @@
           }
         }
       }
+    },
+    "@babel/parser": {
+      "version": "7.22.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "dev": true
     },
     "@babel/runtime": {
       "version": "7.22.11",
@@ -19558,6 +19680,19 @@
         "pvtsutils": "^1.3.2",
         "pvutils": "^1.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "assertion-error": {
@@ -22621,6 +22756,16 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -22734,6 +22879,16 @@
       "requires": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
+      }
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "is-negative-zero": {
@@ -23990,6 +24145,16 @@
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -24978,6 +25143,30 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "dev": true
+    },
+    "recast": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.4.tgz",
+      "integrity": "sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==",
+      "dev": true,
+      "requires": {
+        "assert": "^2.0.0",
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+          "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        }
+      }
     },
     "rechoir": {
       "version": "0.8.0",
@@ -26767,6 +26956,19 @@
       "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
       "integrity": "sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==",
       "dev": true
+    },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@babel/parser": "^7.22.16",
     "@fastify/express": "^2.0.1",
     "@fastify/middie": "^8.0.0",
     "@fastify/swagger-ui": "^1.8.1",
@@ -78,6 +79,7 @@
     "next": "^13.1.6",
     "pg": "^8.3.0",
     "prettier": "^3.0.0",
+    "recast": "^0.23.4",
     "reflect-metadata": "^0.1.13",
     "swagger-ui-express": "^4.1.6",
     "tedious": "^14.1.0",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -85,6 +85,14 @@
       },
       "import": "./esm/remult-sveltekit.js"
     },
+    "./vite": {
+      "require": "./vite/remult-vite.js",
+      "node": {
+        "require": "./vite/remult-vite.js",
+        "import": "./vite/remult-vite.js"
+      },
+      "import": "./vite/remult-vite.js"
+    },
     "./postgres": {
       "require": "./postgres/index.js",
       "node": {

--- a/projects/core/vite/remult-vite.ts
+++ b/projects/core/vite/remult-vite.ts
@@ -1,0 +1,54 @@
+import type { Plugin } from 'vite'
+import { transform } from './transform'
+
+export type RemultViteOptions = {
+  debug?: boolean
+}
+
+/**
+ * Add this vite plugin in your vite.config.ts as first one.
+ * 
+ * It should look like this:
+ * ```ts
+  import { sveltekit } from "@sveltejs/kit/vite";
+  import { defineConfig } from "vite";
+  import { remult } from "remult/vite";  // 👈
+  
+  export default defineConfig({
+    plugins: [
+      remult(),                           // 👈
+      sveltekit()
+    ],
+  });
+ * ```
+ * 
+ */
+export function remult(options?: RemultViteOptions): Plugin {
+  return {
+    name: 'vite:remult',
+    enforce: 'pre',
+
+    transform: async (code, filepath, option) => {
+      // Don't transform server-side code
+      if (option?.ssr) {
+        return
+      }
+      // remult files are only in ts
+      if (!filepath.endsWith('.ts')) {
+        return
+      }
+
+      const { transformed, ...rest } = await transform(code)
+
+      if (options?.debug && transformed) {
+        console.log(`
+----- Remult after transform of ${filepath}
+${rest.code}
+----- 
+`)
+      }
+
+      return rest
+    },
+  }
+}

--- a/projects/core/vite/transform.spec.ts
+++ b/projects/core/vite/transform.spec.ts
@@ -1,0 +1,145 @@
+import { expect, it } from 'vitest'
+import { transform } from './transform'
+
+it('should empty @BackendMethod and clean imports', async () => {
+  const code = `import { Allow, BackendMethod, remult } from "remult";
+import { Task } from "./task";
+import { AUTH_SECRET } from "$env/static/private";
+
+export class TasksController {
+	static async yop1(completed: boolean) {
+		const taskRepo = remult.repo(Task);
+	}
+
+	@BackendMethod({ allowed: Allow.authenticated })
+	static async setAllCompleted(completed: boolean) {
+		console.log("AUTH_SECRET", AUTH_SECRET);
+
+		const taskRepo = remult.repo(Task);
+		for (const task of await taskRepo.find()) {
+			await taskRepo.save({ ...task, completed });
+		}
+	}
+
+	@BackendMethod({ allowed: Allow.authenticated })
+	static async Yop(completed: boolean) {
+		// console.log("AUTH_SECRET", AUTH_SECRET);
+
+		const taskRepo = remult.repo(Task);
+		for (const task of await taskRepo.find()) {
+			await taskRepo.save({ ...task, completed });
+		}
+	}
+}
+	`
+
+  const transformed = await transform(code)
+
+  expect(transformed).toMatchInlineSnapshot(`
+    {
+      "code": "import { Allow, BackendMethod, remult } from \\"remult\\";
+    import { Task } from \\"./task\\";
+
+    export class TasksController {
+        static async yop1(completed: boolean) {
+            const taskRepo = remult.repo(Task);
+        }
+
+        @BackendMethod({
+            allowed: Allow.authenticated
+        })
+        static async setAllCompleted(completed: boolean) {}
+
+        @BackendMethod({
+            allowed: Allow.authenticated
+        })
+        static async Yop(completed: boolean) {}
+    }",
+      "transformed": true,
+    }
+  `)
+})
+
+it('should not crash if there is an error in the original file', async () => {
+  const code = `import { Allow, BackendMethod, remult } from "remult";
+import { Task } from "./task";
+import { AUTH_SECRET } from "$env/static/private";
+
+export class TasksController {
+	@BackendMethod({ allowed: Allow.authenticated })
+	static async setAllCompleted(completed: boolean) {
+		console.log("AUTH_SECRET", AUTH_SECRET);
+	//} LEAVE THIS ERROR TO SIMULATE A WRONG PARSED FILE
+}
+	`
+
+  const transformed = await transform(code)
+
+  expect(transformed).toMatchInlineSnapshot(`
+    {
+      "code": "import { Allow, BackendMethod, remult } from \\"remult\\";
+    import { Task } from \\"./task\\";
+    import { AUTH_SECRET } from \\"$env/static/private\\";
+
+    export class TasksController {
+    	@BackendMethod({ allowed: Allow.authenticated })
+    	static async setAllCompleted(completed: boolean) {
+    		console.log(\\"AUTH_SECRET\\", AUTH_SECRET);
+    	//} LEAVE THIS ERROR TO SIMULATE A WRONG PARSED FILE
+    }
+    	",
+      "transformed": false,
+    }
+  `)
+})
+
+it('should not do anything as there is no @BackendMethod', async () => {
+  const code = `import { Allow, BackendMethod, remult } from "remult";
+import { Task } from "./task";
+import { AUTH_SECRET } from "$env/static/private";
+
+export class TasksController {
+	static async yop1(completed: boolean) {
+		const taskRepo = remult.repo(Task);
+	}
+
+	static async setAllCompleted(completed: boolean) {
+		console.log("AUTH_SECRET", AUTH_SECRET);
+
+		const taskRepo = remult.repo(Task);
+		for (const task of await taskRepo.find()) {
+			await taskRepo.save({ ...task, completed });
+		}
+	}
+}
+	`
+
+  const transformed = await transform(code)
+
+  expect(transformed).toMatchInlineSnapshot(`
+    {
+      "code": "import { Allow, BackendMethod, remult } from \\"remult\\";
+    import { Task } from \\"./task\\";
+    import { AUTH_SECRET } from \\"$env/static/private\\";
+
+    export class TasksController {
+        static async yop1(completed: boolean) {
+            const taskRepo = remult.repo(Task);
+        }
+
+        static async setAllCompleted(completed: boolean) {
+            console.log(\\"AUTH_SECRET\\", AUTH_SECRET);
+            const taskRepo = remult.repo(Task);
+
+            for (const task of await taskRepo.find()) {
+                await taskRepo.save({
+                    ...task,
+                    completed
+                });
+            }
+        }
+    }",
+      "transformed": false,
+    }
+  `)
+})

--- a/projects/core/vite/transform.ts
+++ b/projects/core/vite/transform.ts
@@ -1,0 +1,86 @@
+import { parse } from '@babel/parser'
+import * as recast from 'recast'
+import { prettyPrint } from 'recast'
+const { visit } = recast.types
+
+export const transform = async (code: string) => {
+  try {
+    const codeParsed = parse(code ?? '', {
+      plugins: ['typescript', 'importAssertions', 'decorators-legacy'],
+      sourceType: 'module',
+    }).program as recast.types.namedTypes.Program
+
+    let transformed = false
+    // Empty functions with @BackendMethod decorator and strip the decorator
+    visit(codeParsed, {
+      visitFunction(path) {
+        // @ts-ignore
+        const decorators: any[] = path.node.decorators || []
+        let foundDecorator = false
+
+        // Filter out the BackendMethod decorator
+        // @ts-ignore
+        path.node.decorators = decorators.filter((decorator) => {
+          if (
+            decorator.expression.callee &&
+            decorator.expression.callee.name === 'BackendMethod'
+          ) {
+            foundDecorator = true
+            // We actually need to keep the decorator
+            // return false;
+          }
+          return true
+        })
+
+        // If the BackendMethod decorator was found, empty the function body
+        if (foundDecorator) {
+          transformed = true
+          path.node.body.body = []
+        }
+
+        this.traverse(path)
+      },
+    })
+
+    // remove imports only if we emptied some functions
+    if (transformed) {
+      const usedIdentifiersInCode = new Set()
+
+      // Traverse the AST to identify used identifiers
+      visit(codeParsed, {
+        visitIdentifier(path) {
+          // Let's not add identifiers from import specifiers
+          if (path.parentPath.value.type !== 'ImportSpecifier') {
+            usedIdentifiersInCode.add(path.node.name)
+          }
+
+          this.traverse(path)
+        },
+      })
+
+      // Remove unused identifiers within import statements from the AST
+      visit(codeParsed, {
+        visitImportDeclaration(path) {
+          const importSpecifiers = path.node.specifiers!.filter((specifier) =>
+            usedIdentifiersInCode.has(specifier.local!.name),
+          )
+
+          if (importSpecifiers.length === 0) {
+            // If no specifiers are left, prune the import statement
+            path.prune()
+          } else {
+            // Update the import statement with the remaining specifiers
+            path.node.specifiers = importSpecifiers
+          }
+
+          this.traverse(path)
+        },
+      })
+    }
+
+    return { ...prettyPrint(codeParsed, {}), transformed }
+  } catch (error) {
+    // if anything happens, just return the original code
+    return { code, transformed: false }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 
     include: [
       //   './projects/tests/tests/try-test.spec.ts',
+      './projects/core/**/*.spec.ts',
       './projects/tests/**/*.spec.ts',
       './projects/tests/**/*.backend-spec.ts',
       './projects/tests/dbs/sql-lite.spec.ts',


### PR DESCRIPTION
I've implemented a Vite plugin, primarily as an experiment, to omit BackendMethod from the client-side bundle. The results have been promising, and it seems to be functioning as expected.

## Regarding the naming and Vite conventions:
I'm having second thoughts about using "remult". I'm concerned that it might lead to confusion amongst users and potentially interfere with their code editors. Perhaps using an export default might be more straightforward and user-friendly.

```ts
import { remult } from "remult/vite"; // I did this today
import remult from "remult/vite"; // Maybe this is better?
```

## An Alternate Approach:
Another idea is to design a more generalized plugin. We could introduce it to the Vite community through platforms like vite-awesome-plugin. A name like `vite-function-striper` comes to mind. Users can then configure it to target specific functions, such as "backendMethod". This approach is more flexible and broadens its utility.

### Possible Vite Plugin Names:

`vite-backend-remover`
`vite-function-excluder`
`vite-method-striper`
`vite-backend-filter`
`vite-clean-bundler`

---

I hope this helps! If you have any other requirements, please let me know.
👀 @noam-honig @yoni-rapoport 