### PR TITLE
Sveltekit & headers

### DIFF
--- a/projects/core/remult-sveltekit.ts
+++ b/projects/core/remult-sveltekit.ts
@@ -76,6 +76,7 @@ export function remultSveltekit(
           })
         return new Response(JSON.stringify(responseFromRemultHandler.data), {
           status: responseFromRemultHandler.statusCode,
+          headers: (await resolve(event)).headers,
         })
       }
     }


### PR DESCRIPTION
append sveltekit `headers` to remult response. (to enable `event.setHeaders(...)` and `event.cookies.set(...)`