### PR TITLE
fix(docs): update local db & jsonFiles usage docs

### DIFF
--- a/docs/tutorials/angular/deployment.md
+++ b/docs/tutorials/angular/deployment.md
@@ -80,7 +80,7 @@ If you're using angular version 16 or less, the result path is: `'../remult-angu
 ::: warning Note
 In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
 
-If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files.
 :::
 
 4. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.

--- a/docs/tutorials/angular/deployment.md
+++ b/docs/tutorials/angular/deployment.md
@@ -67,16 +67,23 @@ If you're using angular version 16 or less, the result path is: `'../remult-angu
    // src/server/api.ts
 
    //...
+   const DATABASE_URL = process.env["DATABASE_URL"];
+
    export const api = remultExpress({
-     //...
-     dataProvider: createPostgresDataProvider({
-       connectionString: process.env["DATABASE_URL"] || "your connection string"
-     })
-     //...
-   })
+    dataProvider: DATABASE_URL
+      ? createPostgresDataProvider({ connectionString: DATABASE_URL })
+      : undefined,
+      //...
+    })
    ```
 
-1. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.
+::: warning Note
+In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
+
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+:::
+
+4. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.
 
 ```json
 // tsconfig.server.json

--- a/docs/tutorials/angular/deployment.md
+++ b/docs/tutorials/angular/deployment.md
@@ -63,7 +63,7 @@ If you're using angular version 16 or less, the result path is: `'../remult-angu
 
 3. Modify the highlighted code in the api server module to prefer a `connectionString` provided by the production host's `DATABASE_URL` environment variable.
 
-   ```ts{7}
+   ```ts{4,7-9}
    // src/server/api.ts
 
    //...

--- a/docs/tutorials/react-next/database.md
+++ b/docs/tutorials/react-next/database.md
@@ -27,33 +27,33 @@ Don't worry if you don't have Postgres installed locally. In the next step of th
    DATABASE_URL=your connection string
    ```
 
-4) Add the highlighted code to the `api` server module.
+3. Add the highlighted code to the `api` server module.
 
-   ```ts{5,9}
+   ```ts{5,7,11-13}
    // src/app/api/[...remult]/route.ts
 
    //...
 
    import { createPostgresDataProvider } from "remult/postgres"
 
+   const DATABASE_URL = process.env["DATABASE_URL"]
+
    const api = remultNextApp({
      //...
-     dataProvider: createPostgresDataProvider()
+    dataProvider: DATABASE_URL
+      ? createPostgresDataProvider({ connectionString: DATABASE_URL })
+      : undefined,
    })
    ```
 
-   Once the application restarts, it'll use postgres as the data source for your application. It'll automatically create the `tasks` table for you - as you'll see in the `terminal` window.
+   Once the application restarts, it'll try to use postgres as the data source for your application.
+   
+   If `DATABASE_URL` env variable has found, it'll automatically create the `tasks` table for you - as you'll see in the `terminal` window.
 
-::: tip specifying the connection string
-You can specify a connection string, by setting the `connectionString` property, for example::
+   If no `DATABASE_URL` has found, it'll just fallback to our local JSON files.
 
-```ts
-createPostgresDataProvider({
-  connectionString: "your connection string"
-})
-```
-
-and You can set more options using the `configuration` property.
+::: tip Database configurations
+You can set more options using the `configuration` property.
 
 ```ts
 createPostgresDataProvider({

--- a/docs/tutorials/react/deployment.md
+++ b/docs/tutorials/react/deployment.md
@@ -51,16 +51,23 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
    // src/server/api.ts
 
    //...
+   const DATABASE_URL = process.env["DATABASE_URL"];
+
    export const api = remultExpress({
-     //...
-     dataProvider: createPostgresDataProvider({
-       connectionString: process.env["DATABASE_URL"] || "your connection string"
-     })
-     //...
-   })
+    dataProvider: DATABASE_URL
+      ? createPostgresDataProvider({ connectionString: DATABASE_URL })
+      : undefined,
+      //...
+    })
    ```
 
-1. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.
+::: warning Note
+In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
+
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+:::
+
+4. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.
 
 ```json
 // tsconfig.server.json

--- a/docs/tutorials/react/deployment.md
+++ b/docs/tutorials/react/deployment.md
@@ -47,7 +47,7 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
 
 3. Modify the highlighted code in the api server module to prefer a `connectionString` provided by the production host's `DATABASE_URL` environment variable.
 
-   ```ts{7}
+   ```ts{4,7-9}
    // src/server/api.ts
 
    //...

--- a/docs/tutorials/react/deployment.md
+++ b/docs/tutorials/react/deployment.md
@@ -64,7 +64,7 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
 ::: warning Note
 In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
 
-If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files.
 :::
 
 4. In the root folder, create a TypeScript configuration file `tsconfig.server.json` for the build of the server project using TypeScript.

--- a/docs/tutorials/sveltekit/database.md
+++ b/docs/tutorials/sveltekit/database.md
@@ -43,10 +43,19 @@ import { DATABASE_URL } from '$env/static/private' // [!code ++]
 export const handleRemult = remultSveltekit({
   entities: [Task],
   controllers: [TasksController],
-  dataProvider: createPostgresDataProvider({ connectionString: DATABASE_URL }), // [!code ++]
+  dataProvider: DATABASE_URL // [!code ++]
+    ? createPostgresDataProvider({ connectionString: DATABASE_URL }) // [!code ++]
+    : undefined, // [!code ++]
   getUser: async (event) =>
     (await event?.locals?.getSession())?.user as UserInfo,
 })
 ```
+
+Once the application restarts, it'll try to use postgres as the data source for your application.
+
+If `DATABASE_URL` has found, it'll automatically create the tasks table for you - as you'll see in the terminal window.
+
+If no `DATABASE_URL` has found, it'll just fallback to our local JSON files.
+
 
 :::

--- a/docs/tutorials/vue/deployment.md
+++ b/docs/tutorials/vue/deployment.md
@@ -47,7 +47,7 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
 
 3. Modify the highlighted code in the api server module to prefer a `connectionString` provided by the production host's `DATABASE_URL` environment variable.
 
-   ```ts{7}
+   ```ts{4,7-9}
    // src/server/api.ts
 
    //...

--- a/docs/tutorials/vue/deployment.md
+++ b/docs/tutorials/vue/deployment.md
@@ -64,7 +64,7 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
 ::: warning Note
 In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
 
-If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files.
 :::
 
 4. Modify the project's `build` npm script to additionally transpile the API server's TypeScript code to JavaScript (using `tsc`).

--- a/docs/tutorials/vue/deployment.md
+++ b/docs/tutorials/vue/deployment.md
@@ -51,14 +51,21 @@ app.listen(process.env["PORT"] || 3002, () => console.log("Server started"))
    // src/server/api.ts
 
    //...
+   const DATABASE_URL = process.env["DATABASE_URL"];
+
    export const api = remultExpress({
-     //...
-     dataProvider: createPostgresConnection({
-       connectionString: process.env["DATABASE_URL"] || "your connection string"
-     })
-     //...
-   })
+    dataProvider: DATABASE_URL
+      ? createPostgresDataProvider({ connectionString: DATABASE_URL })
+      : undefined,
+      //...
+    })
    ```
+
+::: warning Note
+In order to connect to a local PostgresDB, add `DATABASE_URL` to an .env file, or simply replace `process.env["DATABASE_URL"]` with your `connectionString`.
+
+If no `DATABASE_URL` has found, it'll fallback to our local JSON files
+:::
 
 4. Modify the project's `build` npm script to additionally transpile the API server's TypeScript code to JavaScript (using `tsc`).
 


### PR DESCRIPTION
In the previous database section, there's this note, which mentions the user would be still able to keep using the JSON files db locally.
<img width="681" alt="image" src="https://github.com/remult/remult/assets/54068415/a1cd5a1e-83d2-460e-aff6-2f982259cb46">

However, right now it seems that this "JSON files" option is not really implemented, and it's just trying to use another `connection string`:
<img width="730" alt="image" src="https://github.com/remult/remult/assets/54068415/6b530645-2fb0-4cb6-b895-fbc76d3c3653">

I updated the docs so it'd make sense, now it looks like that (`React`, `Angular`, `Vue`): 
<img width="753" alt="image" src="https://github.com/remult/remult/assets/54068415/ea7f17d5-4443-49bb-8486-2054cd8484f6">

`Svelte`:
<img width="712" alt="image" src="https://github.com/remult/remult/assets/54068415/64a91463-6d3a-47c0-b33c-05869915636d">

`Next`:
<img width="564" alt="image" src="https://github.com/remult/remult/assets/54068415/71a64afa-b1d2-4958-b501-252da696413a">
