### PR TITLE
Live query wait before close connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fixed error when id was not found in ArrayEntityDataProvider to include the entity name
 - Fixed filterToRaw to use the current database `wrapIdentifier` when none is provided.
 - Fixed endless retry on error 500 - now it'll retry 4 times 500ms apart.
+- Fixed live query to not disconnect and reconnect if unsubscribe and resubscribe happen in the same second
 
 ## [0.26.10] 2024-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Fixed filterToRaw to use the current database `wrapIdentifier` when none is provided.
 - Fixed endless retry on error 500 - now it'll retry 4 times 500ms apart.
 - Fixed live query to not disconnect and reconnect if unsubscribe and resubscribe happen in the same second
+- Fixed live query when subscribe is forbidden - the query still runs after the renew process
 
 ## [0.26.10] 2024-05-02
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2725,7 +2725,7 @@ export declare function remultExpress(
     bodySizeLimit?: string
   },
 ): RemultExpressServer
-//[ ] RemultServerOptions from ./server/expressBridge.js is not exported
+//[ ] RemultServerOptions from ./server/remult-api-server.js is not exported
 export type RemultExpressServer = express.RequestHandler &
   RemultServerCore<express.Request> & {
     withRemult: (
@@ -2734,8 +2734,8 @@ export type RemultExpressServer = express.RequestHandler &
       next: VoidFunction,
     ) => void
   } & Pick<RemultServer<express.Request>, "withRemultAsync">
-//[ ] RemultServerCore from ./server/expressBridge.js is not exported
-//[ ] RemultServer from ./server/expressBridge.js is not exported
+//[ ] RemultServerCore from ./server/remult-api-server.js is not exported
+//[ ] RemultServer from ./server/remult-api-server.js is not exported
 ```
 
 ## ./remult-next.js
@@ -2788,7 +2788,7 @@ export declare function createRemultServer<RequestType>(
   options: RemultServerOptions<RequestType>,
   serverCoreOptions?: ServerCoreOptions<RequestType>,
 ): RemultServer<RequestType>
-//[ ] ServerCoreOptions from ./expressBridge.js is not exported
+//[ ] ServerCoreOptions from ./remult-api-server.js is not exported
 export declare class DataProviderLiveQueryStorage
   implements LiveQueryStorage, Storage
 {
@@ -3196,13 +3196,13 @@ export declare class SseSubscriptionServer implements SubscriptionServer {
 export declare function remultFastify(
   options: RemultServerOptions<FastifyRequest>,
 ): RemultFastifyServer
-//[ ] RemultServerOptions from ./server/expressBridge.js is not exported
+//[ ] RemultServerOptions from ./server/remult-api-server.js is not exported
 export type RemultFastifyServer = FastifyPluginCallback &
   RemultServerCore<FastifyRequest> & {
     withRemult: RemultServer<FastifyRequest>["withRemultAsync"]
   }
-//[ ] RemultServerCore from ./server/expressBridge.js is not exported
-//[ ] RemultServer from ./server/expressBridge.js is not exported
+//[ ] RemultServerCore from ./server/remult-api-server.js is not exported
+//[ ] RemultServer from ./server/remult-api-server.js is not exported
 ```
 
 ## ./remult-hapi.js
@@ -3257,7 +3257,7 @@ export declare function remultFresh(
   options: RemultServerOptions<FreshRequest>,
   response: FreshResponse,
 ): RemultFresh
-//[ ] RemultServerOptions from ./server/expressBridge.js is not exported
+//[ ] RemultServerOptions from ./server/remult-api-server.js is not exported
 export interface RemultFresh extends RemultServerCore<FreshRequest> {
   handle(req: FreshRequest, ctx: FreshContext): Promise<any>
 }
@@ -3371,7 +3371,7 @@ export declare class PostgresSchemaBuilder {
 //[ ] Remult from TBD is not exported
 export declare function preparePostgresQueueStorage(
   sql: SqlDatabase,
-): Promise<import("../server/expressBridge.js").EntityQueueStorage>
+): Promise<import("../server/remult-api-server.js").EntityQueueStorage>
 ```
 
 ## ./postgres/schema-builder.js
@@ -3725,6 +3725,9 @@ export declare function decorateColumnSettings<valueType>(
   remult: Remult,
 ): FieldOptions<any, valueType>
 //[ ] FieldOptions from TBD is not exported
+export const flags: {
+  error500RetryCount: number
+}
 export declare function getControllerRef<fieldsContainerType>(
   container: fieldsContainerType,
   remultArg?: Remult,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "0.26.11-next.0",
+  "version": "0.26.11-next.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "0.26.11-next.0",
+      "version": "0.26.11-next.1",
       "devDependencies": {
         "@fastify/express": "^2.0.1",
         "@fastify/middie": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "0.26.11-next.0",
+  "version": "0.26.11-next.1",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -206,7 +206,7 @@ export class LiveQueryClient {
       this.interval = setInterval(async () => {
         const ids: string[] = []
         for (const q of this.queries.values()) {
-          ids.push(q.queryChannel)
+          if (q.gotAnyResult) ids.push(q.queryChannel)
         }
         if (ids.length > 0) {
           let p = this.apiProvider()

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -84,8 +84,7 @@ export class LiveQueryClient {
       onUnsubscribe = () => {}
     }
   }
-
-  private closeIfNoListeners() {
+  private _actuallyClose() {
     if (this.client)
       if (this.queries.size === 0 && this.channels.size === 0) {
         this.runPromise(this.client.then((x) => x.close()))
@@ -93,6 +92,12 @@ export class LiveQueryClient {
         clearInterval(this.interval)
         this.interval = undefined
       }
+  }
+  keepAliveMs = 1000
+  private closeIfNoListeners() {
+    setTimeout(() => {
+      this._actuallyClose()
+    }, this.keepAliveMs)
   }
 
   subscribe<entityType>(

--- a/projects/core/src/live-query/SubscriptionChannel.ts
+++ b/projects/core/src/live-query/SubscriptionChannel.ts
@@ -20,10 +20,12 @@ export class LiveQuerySubscriber<entityType> {
       ),
     )
   }
+  gotAnyResult = false
   queryChannel: string
   subscribeCode: () => void
   unsubscribe: VoidFunction = () => {}
   async setAllItems(result: any[]) {
+    this.gotAnyResult = true
     const items = await getRepositoryInternals(this.repo)._fromJsonArray(
       result,
       this.query.options,

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -932,7 +932,6 @@ export const flags = {
 
 //p1 - adjust angular tutorial starter kit for latest angular (as is in tutorial)
 
-//p2 - when subscribe is forbidden - the query still runs after the renew process
 //p2 - 'update tasks set  where id = $1
 
 //p2 - type metadata.key - to keyof entity - based on cwis input

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -831,6 +831,7 @@ export const flags = {
 
 //y2 - soft-delete-discussion https://discord.com/channels/975754286384418847/1230386433093533698/1230386433093533698
 //y1 - live query with count #436
+//y1 - live query errort that appears in tests but I can't understand why - `open connection error `
 
 //y1 TODO - In the esm version of our tutorial - the imports are automatically .ts and not .js in react and not in vue
 //y1 TODO - consider id to also support keyof (id:['company','index']) - had problem with | (keyof Partial<entityType>)[] & `entity`


### PR DESCRIPTION
- [ ] When using vite & proxy, the connection doesn't close on api restart - causing updates not to reach the client