### PR TITLE
fix auth.ts import for Next.js tutorial

### DIFF
--- a/docs/tutorials/react-next/auth.md
+++ b/docs/tutorials/react-next/auth.md
@@ -126,7 +126,7 @@ Let's set-up `NextAuth.js` to authenticate users to our app.
    ```ts
    // src/app/api/auth/[...nextauth]/route.ts
 
-   import type { auth } from '../../../../auth'
+   import { auth } from '../../../../auth'
 
    export { auth as GET, auth as POST }
    ```


### PR DESCRIPTION
Should fix the Next.js tutorial error:

No HTTP methods exported in 'C:\Users\user\source\remult-nextjs-todo\src\app\api\auth\[...nextauth]\route.ts'. Export a named export for each HTTP method.