### PR TITLE
chore(typing): placeholder interface to custom EntityFilter and IdFilter

### DIFF
--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -51,6 +51,8 @@ export {
   EntityRefForEntityBase,
   IdMetadata,
   FindFirstOptionsBase,
+  CustomEntityFilter,
+  CustomIdFilter,
 } from './src/remult3/remult3.js'
 export {
   EntityBase,

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -575,7 +575,7 @@ export declare type EntityFilter<entityType> = {
 } & {
   $or?: EntityFilter<entityType>[]
   $and?: EntityFilter<entityType>[]
-}
+} & CustomEntityFilter<entityType>
 
 export type ValueFilter<valueType> =
   | valueType
@@ -600,12 +600,15 @@ export interface ContainsStringValueFilter {
   $contains?: string
   $notContains?: string
 }
-export type IdFilter<valueType> =
+export type IdFilter<valueType> = (
   | ValueFilter<valueType>
   | {
       $id: ValueFilter<valueType extends { id?: number } ? number : string>
     }
-
+) &
+  CustomIdFilter<valueType>
+export type CustomEntityFilter<entityType> = {}
+export type CustomIdFilter<valueType> = {}
 export interface LoadOptions<entityType> {
   /**
    * @deprecated The 'load' option is deprecated and will be removed in future versions.


### PR DESCRIPTION
- Context: I am implementing `PrismaEntityDataProvider` (will be open source). Prisma supports richer [operators](https://www.prisma.io/docs/orm/reference/prisma-client-reference#is) like:`startsWith`, `endsWith`, `search`, `is` ...

- Problem: `EntityFilter`, `IdFilter` are implemented as TS's `type` so I can't extend

- Suggest: declare `interface CustomEntityFilter` `interface CustomIdFilter`, then merge to original types. Developers can declare an interface merging later.

```ts
//types.d.ts
import { ValueFilter, EntityFilter, FindFirstOptions } from "remult";

export {};

declare module "remult" {
    export interface CustomIdFilter<valueType> {
        $is?: valueType | EntityFilter<valueType>;
    }
}
```

```ts
//business.controller.ts
// ...
class BusinessController {
    @CustomBackendMethod({ allowed: true, schema: getBusinessUserSchema })
    static async getBusinessUser(input: Static<typeof getBusinessUserSchema>) {
        const business = await repo(BusinessUser).findFirst({
            ...input,
            user: {
                $is: { status: STATUS_ACTIVE }, // <-- `$is` the new operator
            },
            business: {
                $is: { status: STATUS_ACTIVE }, // <-- `$is` the new operator
            },
        });

        return business?.user;
    }
}
```