### PR TITLE
feat: Added to the repo object the `insetWithRelations` method

### DIFF
--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -15,7 +15,7 @@ import type {
   LiveQueryStorage,
   SubscriptionServer,
 } from './live-query/SubscriptionServer.js'
-import { defaultFactory, remultStatic } from './remult-static.js'
+import { remultStatic } from './remult-static.js'
 import type { Repository } from './remult3/remult3.js'
 import { getInternalKey } from './remult3/repository-internals.js'
 
@@ -186,6 +186,11 @@ export class RemultProxy implements Remult {
           .remultFactory()
           .repo(...args)
           .getEntityRef(...args2),
+      insertWithRelations: (args2: any) =>
+        self
+          .remultFactory()
+          .repo(...args)
+          .insertWithRelations(args2),
       insert: (args2: any) =>
         self
           .remultFactory()

--- a/projects/core/src/remult3/RepositoryImplementation.ts
+++ b/projects/core/src/remult3/RepositoryImplementation.ts
@@ -20,6 +20,7 @@ import { Sort } from '../sort.js'
 import type {
   ControllerRef,
   ControllerRefForControllerBase,
+  DeepPartial,
   EntityFilter,
   EntityMetadata,
   EntityOrderBy,
@@ -320,6 +321,71 @@ export class RepositoryImplementation<entityType>
     if (!this._dataProvider.isProxy) await ref2.reload()
     return ref2.delete()
   }
+
+  insertWithRelations(
+    item: DeepPartial<MembersOnly<entityType>>,
+  ): Promise<entityType>
+  insertWithRelations(
+    item: DeepPartial<MembersOnly<entityType>>[],
+  ): Promise<entityType[]>
+  async insertWithRelations(
+    item:
+      | DeepPartial<MembersOnly<entityType>>
+      | DeepPartial<MembersOnly<entityType>>[],
+  ): Promise<entityType | entityType[]> {
+    if (Array.isArray(item)) {
+      return await Promise.all(
+        item.map(async (v) => await this.insertWithRelations(v)),
+      )
+    }
+
+    const relationalFields: {
+      key: keyof typeof item
+      type: ClassType<(typeof item)[any]>
+      isRelation: boolean
+    }[] = this.fields
+      .toArray()
+      .map((v) => ({
+        key: v.key as any as keyof typeof item,
+        type: v.options.valueType as ClassType<(typeof item)[any]>,
+        isRelation:
+          Boolean(getEntityKey(v.options.valueType)) &&
+          Boolean(v.options.valueType),
+      }))
+      .filter((v) => v.isRelation)
+
+    const refs: {
+      name: keyof typeof item
+      ref: EntityRef<(typeof item)[keyof typeof item]>
+    }[] = []
+
+    for (const field of relationalFields) {
+      const { key: key, type: type } = field
+      if (key in item && item[key]) {
+        const data = item[key]
+        delete item[key]
+        const repo = this._remult.repo(type)
+        refs.push({ name: key, ref: repo.getEntityRef(repo.create(data)) })
+      }
+    }
+
+    const results = (await Promise.all(refs.map((v) => v.ref.save()))).map(
+      (v, i) => ({ result: v, name: refs[i].name }),
+    )
+
+    results.forEach((r) => (item[r.name] = r.result))
+
+    let ref = getEntityRef(item, false) as unknown as EntityRef<entityType>
+    if (ref) {
+      if (!ref.isNew()) throw 'Item is not new'
+      return await ref.save()
+    } else {
+      return await this.getEntityRef(
+        this.create(item as Partial<MembersOnly<entityType>>),
+      ).save()
+    }
+  }
+
   insert(item: Partial<MembersOnly<entityType>>[]): Promise<entityType[]>
   insert(item: Partial<MembersOnly<entityType>>): Promise<entityType>
   async insert(
@@ -1168,7 +1234,7 @@ abstract class rowHelperBase<T> {
 
       if (ei && remult) {
         let lookup = new LookupColumn<T>(
-          remult.repo(col.valueType) as RepositoryImplementation<T>,
+          remult.repo<T>(col.valueType) as RepositoryImplementation<T>,
           Boolean(getRelationFieldInfo(col)),
           col.allowNull,
         )

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -304,6 +304,11 @@ export declare type MembersOnly<T> = {
     ? never
     : K]: T[K]
 }
+
+export declare type DeepPartial<T> = T extends Record<PropertyKey, any>
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : T
+
 //Pick<
 //   T,
 //   { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
@@ -409,6 +414,28 @@ export interface Repository<entityType> {
    */
   insert(item: Partial<MembersOnly<entityType>>[]): Promise<entityType[]>
   insert(item: Partial<MembersOnly<entityType>>): Promise<entityType>
+
+  /**Insert an item to the data source including all one-to-one relations attached
+   * @example
+   * await userRepo.insert({
+   *    name: "fellow",
+   *    task: {
+   *      title: "task a",
+   *      completed: false
+   *    }
+   *})
+   */
+  insertWithRelations(
+    item: DeepPartial<MembersOnly<entityType>>,
+  ): Promise<entityType>
+  insertWithRelations(
+    item: DeepPartial<MembersOnly<entityType>>[],
+  ): Promise<entityType[]>
+  insertWithRelations(
+    item:
+      | DeepPartial<MembersOnly<entityType>>
+      | DeepPartial<MembersOnly<entityType>>[],
+  ): Promise<entityType | entityType[]>
 
   /** Updates an item, based on its `id`
    * @example

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -426,16 +426,11 @@ export interface Repository<entityType> {
    *})
    */
   insertWithRelations(
-    item: DeepPartial<MembersOnly<entityType>>,
-  ): Promise<entityType>
-  insertWithRelations(
     item: DeepPartial<MembersOnly<entityType>>[],
   ): Promise<entityType[]>
   insertWithRelations(
-    item:
-      | DeepPartial<MembersOnly<entityType>>
-      | DeepPartial<MembersOnly<entityType>>[],
-  ): Promise<entityType | entityType[]>
+    item: DeepPartial<MembersOnly<entityType>>,
+  ): Promise<entityType>
 
   /** Updates an item, based on its `id`
    * @example

--- a/projects/tests/tests/remult-3-entities.ts
+++ b/projects/tests/tests/remult-3-entities.ts
@@ -1,5 +1,5 @@
 import type { Repository } from '../../core/src/remult3/remult3'
-import { Entity, EntityBase, Field, Fields } from '../../core'
+import { Entity, EntityBase, Field, Fields, Relations } from '../../core'
 import { Status } from './testModel/models'
 
 @Entity('Products')
@@ -14,6 +14,8 @@ export class Products {
   archived!: boolean
   @Fields.date()
   availableFrom!: Date
+  @Relations.toOne(() => Categories)
+  category?: Categories
 }
 
 export interface CategoriesForTesting extends EntityBase {


### PR DESCRIPTION
The `insetrWithRelations` method implements an insert of an entity to a table, including all of it's 1-to-1 relations