### PR TITLE
Log queries if they are greater than equals the threshold

### DIFF
--- a/projects/core/src/data-providers/sql-database.ts
+++ b/projects/core/src/data-providers/sql-database.ts
@@ -309,7 +309,7 @@ class LogSQLCommand implements SqlCommand {
       let r = await this.origin.execute(sql)
       if (this.logToConsole !== false) {
         var d = new Date().valueOf() - start.valueOf()
-        if (d > SqlDatabase.durationThreshold) {
+        if (d >= SqlDatabase.durationThreshold) {
           const duration = d / 1000
           if (this.logToConsole === 'oneLiner') {
             const rawSql = sql


### PR DESCRIPTION
I was using `LogToConsole` to debug some queries and was confused at first as to why I see some queries logged while others aren't there.

Eventually I realized it's because the query completed in 0ms so it wasn't higher than the threshold... I think it makes sense to have the comparison be `>=` rather than just `>`.