### PR TITLE
fix: where `$not` & `$and`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Changelog
-
 All notable changes to this project will be documented in this file.
+
+## [2.7.30] 2025-2-27
+
+- Fixed `where` containing a `$not` from `api` to work in addition with other filters.
 
 ## [2.7.29] 2025-2-9
 

--- a/projects/core/src/filter/filter-interfaces.ts
+++ b/projects/core/src/filter/filter-interfaces.ts
@@ -930,8 +930,12 @@ export function buildFilterFromRequestParameters(
         })
     }
 
-    if (not.length == 1 && !where.$not) {
-      where = not[0]
+    if (not.length == 1) {
+      if (!where.$not) {
+        where.$not = not[0].$not
+      } else {
+        where.$not.push(not[0].$not)
+      }
     } else {
       addAnd({
         $and: not,

--- a/projects/tests/tests/test-where-api.spec.ts
+++ b/projects/tests/tests/test-where-api.spec.ts
@@ -216,7 +216,7 @@ describe('test where stuff', () => {
         {
           "categoryName": "v2",
           "id": 2,
-        }
+        },
       ]
     `)
   })

--- a/projects/tests/tests/test-where-api.spec.ts
+++ b/projects/tests/tests/test-where-api.spec.ts
@@ -219,6 +219,23 @@ describe('test where stuff', () => {
         },
       ]
     `)
+
+    expect((await r.find({
+      where: {
+        $and: [
+          { $not: { id: 1 } },
+          { $not: { id: 5 } },
+          { categoryName: { $contains: "v" } },
+        ],
+      }
+    })).map(c => { return { id: c.id, categoryName: c.categoryName } })).toMatchInlineSnapshot(`
+      [
+        {
+          "categoryName": "v2",
+          "id": 2,
+        },
+      ]
+    `)
   })
 })
 
@@ -531,7 +548,7 @@ function x<
   CaseReducers extends SliceCaseReducers<{
     test?: WritableDraft<entityForrawFilter>[]
   }>,
->(what: CaseReducers) { }
+>(what: CaseReducers) {}
 //reproduce typescript bug with recursive types
 x<{
   addComment: (

--- a/projects/tests/tests/test-where-api.spec.ts
+++ b/projects/tests/tests/test-where-api.spec.ts
@@ -219,23 +219,6 @@ describe('test where stuff', () => {
         },
       ]
     `)
-
-    expect((await r.find({
-      where: {
-        $and: [
-          { $not: { id: 1 } },
-          { $not: { id: 5 } },
-          { categoryName: { $contains: "v" } },
-        ],
-      }
-    })).map(c => { return { id: c.id, categoryName: c.categoryName } })).toMatchInlineSnapshot(`
-      [
-        {
-          "categoryName": "v2",
-          "id": 2,
-        },
-      ]
-    `)
   })
 })
 


### PR DESCRIPTION
Fixed `where` containing a `$not` from `api` to work in addition with other filters.