### PR TITLE
migrations: escape SQL queries when building migrations file

### DIFF
--- a/projects/core/migrations/generate-migrations.ts
+++ b/projects/core/migrations/generate-migrations.ts
@@ -64,7 +64,7 @@ export async function generateMigrations(options: {
   const code = {
     //https://marketplace.visualstudio.com/items?itemName=qufiwefefwoyn.inline-sql-syntax
     addSql: (sql) => {
-      steps.push('await sql(`--sql\n' + sql + '`)')
+      steps.push('await sql(`--sql\n' + escapeForTpl(sql) + '`)')
       hasSql = true
     },
     addTypescriptCode: (code) => steps.push(code),
@@ -102,3 +102,9 @@ export async function generateMigrations(options: {
   }
   return steps.length > 0
 }
+
+function escapeForTpl(str: string): string {
+    // escape backticks, dollar-signs and backslashes
+    return str.replace(/[`\\$]/g, (m) => "\\" + m);
+  }
+


### PR DESCRIPTION
SQL queries usually contains backticks, but the query itself is also wrapped into backticks in order to work with `sql` template function, so we need to escape "inner" backticks, otherwise an invalid TS code will be generated. This change also handles potential conflicting characters such as backslash (`/`) and dollar sign (`$`), which might also lead to invalid generated TS code when unescaped.

Tested with the following input:
```typescript
import { Entity, Fields } from "remult";

@Entity("tasks", {
  allowApiCrud: true,
})
export class Task {
  @Fields.cuid()
  id = "";

  @Fields.string()
  title = "";

  @Fields.boolean()
  completed = false;

  @Fields.createdAt()
  createdAt?: Date;

  @Fields.string({
    required: true,
    dbName: "Weird `column` name with ${placeholder}",
  })
  content = "";
}
```

Produced expected output were all the strings are escaped:
```typescript
import type { Migrations } from "remult/migrations";
export const migrations: Migrations = {
  0: async ({ sql }) => {
    await sql(`--sql
create table \`tasks\` (\`id\` varchar(255) not null default '', \`title\` varchar(255) not null default '', \`completed\` boolean not null default '0', \`createdAt\` datetime, \`Weird \`\`column\`\` name with \${placeholder}\` varchar(255) not null default '', primary key (\`id\`))`);
  },
};
```

Resolves #695 