### PR TITLE
Feat/migrate duckdb node api

### DIFF
--- a/docs/docs/installation/database/duckdb.md
+++ b/docs/docs/installation/database/duckdb.md
@@ -4,10 +4,10 @@ To use DuckDB as the database provider in your Remult-based application, follow 
 
 ### Step 1: Install DuckDB
 
-Run the following command to install `duckdb`:
+Run the following command to install `@duckdb/node-api`:
 
 ```sh
-npm i duckdb
+npm i @duckdb/node-api
 ```
 
 ### Step 2: Configure the `dataProvider`
@@ -18,7 +18,7 @@ In your `index.ts` (or server file), configure the `dataProvider` to use DuckDB:
 import express from 'express'
 import { remultApi } from 'remult/remult-express'
 import { SqlDatabase } from 'remult' // [!code highlight]
-import { Database } from 'duckdb' // [!code highlight]
+import { DuckDBInstance } from '@duckdb/node-api' // [!code highlight]
 import { DuckDBDataProvider } from 'remult/remult-duckdb' // [!code highlight]
 
 const app = express()
@@ -26,7 +26,9 @@ const app = express()
 app.use(
   remultApi({
     dataProvider: new SqlDatabase( // [!code highlight]
-      new DuckDBDataProvider(new Database(':memory:')), // [!code highlight]
+      new DuckDBDataProvider(
+        (await DuckDBInstance.create(':memory:')).connect(),
+      ), // [!code highlight]
     ), // [!code highlight]
   }),
 )
@@ -36,7 +38,7 @@ app.listen(3000, () => console.log('Server is running on port 3000'))
 
 ### Explanation:
 
-- **DuckDB setup**: The database is initialized with `new Database(':memory:')` to create an in-memory database. Replace `':memory:'` with a file path if you want to persist the database to disk.
+- **DuckDB setup**: The database is initialized with `DuckDBInstance.create(':memory:')` to create an in-memory database. Replace `':memory:'` with a file path if you want to persist the database to disk.
 - **SqlDatabase**: `SqlDatabase` is used to connect Remult with DuckDB through the `DuckDBDataProvider`.
 
 This setup allows you to use DuckDB as your database provider in a Remult project.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -540,7 +540,7 @@ app.use(
 Install DuckDB:
 
 ```sh
-npm i duckdb
+npm i @duckdb/node-api
 ```
 
 Set the `dataProvider` property:
@@ -549,7 +549,7 @@ Set the `dataProvider` property:
 import express from 'express'
 import { remultApi } from 'remult/remult-express'
 import { SqlDatabase } from 'remult' // [!code highlight]
-import { Database } from 'duckdb' // [!code highlight]
+import { DuckDBInstance } from '@duckdb/node-api' // [!code highlight]
 import { DuckDBDataProvider } from 'remult/remult-duckdb' // [!code highlight]
 
 const app = express()
@@ -557,7 +557,9 @@ const app = express()
 app.use(
   remultApi({
     dataProvider: new SqlDatabase( // [!code highlight]
-      new DuckDBDataProvider(new Database(':memory:')), // [!code highlight]
+      new DuckDBDataProvider(
+        (await DuckDBInstance.create(':memory:')).connect(),
+      ), // [!code highlight]
     ), // [!code highlight]
   }),
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "remult-mono-repo",
       "version": "3.0.0",
       "devDependencies": {
+        "@duckdb/node-api": "^1.2.2-alpha.18",
         "@fastify/express": "^2.0.1",
         "@fastify/middie": "^8.0.0",
         "@fastify/swagger-ui": "^1.8.1",
@@ -46,7 +47,6 @@
         "copyfiles": "^2.4.1",
         "dependency-cruiser": "^13.1.5",
         "dotenv": "^8.1.0",
-        "duckdb": "^1.0.0",
         "eslint": "^8.56.0",
         "eslint-plugin-file-extension-in-import-ts": "^1.0.2",
         "eventsource": "^2.0.2",
@@ -1547,6 +1547,100 @@
         "node": ">=14"
       }
     },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-9ke/DF7ZZzj6pzlswF34DDytYUn8fhAe4JdZGEvXpNJxnccf1l1Aisqg0fUtOxZkYrO4ALgSZHR0i3i4RLndUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.2.2-alpha.18"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-1O/yBDevwMNGlv559sn3myOds0lM0D4e8ilHsDzOs3rDnpzEdzK6aSTPVG8APjjFjPjk+pEzBxUse7UsP6objA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-darwin-x64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-linux-arm64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-linux-x64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-win32-x64": "1.2.2-alpha.18"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-xNzfi/+swRiA1Rye25f33tKXmFYbyQcslN6bpB3nR/Wkiotjlu3dAc5wvTpUDiiJwNeZRTRdJM/OXtUO0YaAfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-9vXgAJ2LFKRa53E7RmvGdhWtisLLPKIpSzeE/L3X4aD5zv1V4YnhYHuMOTgxZguj+eOT1pvG99geH1WQb3DdNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-WcgfkPDGRsMcKAVzDhL14BJB1lYD9YY7wEIoPdyXYwkK+c4WT7ublsx7diFqBk/jO0jFYTRmXIqpNyqGT0Lwjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-dPqVJwpu9SmKxuw7ZfebUzOLBMrZz24UzFXuHX0uwSXZS1ndUuHnqk7SWGcWafNJeDlMKV//uMQke+MGXt2LmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-0BSRNH3JbvHDYd2LM/25uQlSaXzeJaJvBCJQZoIXttY5vq6stLknfQ9zWADLa8jwFYU+p87Ajqg415zs4SfMFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -2223,7 +2317,8 @@
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@graphql-tools/executor": {
       "version": "0.0.18",
@@ -7208,14 +7303,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "dev": true,
@@ -9530,6 +9617,7 @@
       "version": "4.5.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -9541,6 +9629,7 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -9553,6 +9642,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10882,6 +10972,7 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -12721,375 +12812,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/duckdb": {
-      "version": "1.0.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "node-addon-api": "^7.0.0",
-        "node-gyp": "^9.3.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/cacache": {
-      "version": "16.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/cacache/node_modules/glob": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/duckdb/node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/duckdb/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/duckdb/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/duckdb/node_modules/gauge": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/duckdb/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/duckdb/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/duckdb/node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/duckdb/node_modules/node-gyp": {
-      "version": "9.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^6.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/duckdb/node_modules/nopt": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^1.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/npmlog": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/duckdb/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/duckdb/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/duckdb/node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/duckdb/node_modules/ssri": {
-      "version": "9.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/duckdb/node_modules/unique-filename": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/duckdb/node_modules/unique-slug": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "dev": true,
@@ -13290,6 +13012,7 @@
       "version": "2.2.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13297,7 +13020,8 @@
     "node_modules/err-code": {
       "version": "2.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -14206,11 +13930,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "4.20.0",
@@ -15884,19 +15603,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/http-shutdown": {
       "version": "1.2.2",
       "dev": true,
@@ -15949,6 +15655,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -16119,7 +15826,8 @@
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/inflation": {
       "version": "2.0.0",
@@ -16444,7 +16152,8 @@
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -18029,6 +17738,7 @@
       "version": "1.0.5",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -18040,6 +17750,7 @@
       "version": "3.3.6",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -18051,6 +17762,7 @@
       "version": "1.2.4",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -18062,6 +17774,7 @@
       "version": "3.3.6",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -18073,6 +17786,7 @@
       "version": "1.0.3",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -18084,6 +17798,7 @@
       "version": "3.3.6",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22137,6 +21852,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -23415,12 +23131,14 @@
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -24215,6 +23933,7 @@
       "version": "0.12.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -31531,6 +31250,63 @@
         "node-source-walk": "^6.0.1"
       }
     },
+    "@duckdb/node-api": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-9ke/DF7ZZzj6pzlswF34DDytYUn8fhAe4JdZGEvXpNJxnccf1l1Aisqg0fUtOxZkYrO4ALgSZHR0i3i4RLndUQ==",
+      "dev": true,
+      "requires": {
+        "@duckdb/node-bindings": "1.2.2-alpha.18"
+      }
+    },
+    "@duckdb/node-bindings": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-1O/yBDevwMNGlv559sn3myOds0lM0D4e8ilHsDzOs3rDnpzEdzK6aSTPVG8APjjFjPjk+pEzBxUse7UsP6objA==",
+      "dev": true,
+      "requires": {
+        "@duckdb/node-bindings-darwin-arm64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-darwin-x64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-linux-arm64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-linux-x64": "1.2.2-alpha.18",
+        "@duckdb/node-bindings-win32-x64": "1.2.2-alpha.18"
+      }
+    },
+    "@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-xNzfi/+swRiA1Rye25f33tKXmFYbyQcslN6bpB3nR/Wkiotjlu3dAc5wvTpUDiiJwNeZRTRdJM/OXtUO0YaAfw==",
+      "dev": true,
+      "optional": true
+    },
+    "@duckdb/node-bindings-darwin-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-9vXgAJ2LFKRa53E7RmvGdhWtisLLPKIpSzeE/L3X4aD5zv1V4YnhYHuMOTgxZguj+eOT1pvG99geH1WQb3DdNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@duckdb/node-bindings-linux-arm64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-WcgfkPDGRsMcKAVzDhL14BJB1lYD9YY7wEIoPdyXYwkK+c4WT7ublsx7diFqBk/jO0jFYTRmXIqpNyqGT0Lwjg==",
+      "dev": true,
+      "optional": true
+    },
+    "@duckdb/node-bindings-linux-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-dPqVJwpu9SmKxuw7ZfebUzOLBMrZz24UzFXuHX0uwSXZS1ndUuHnqk7SWGcWafNJeDlMKV//uMQke+MGXt2LmQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@duckdb/node-bindings-win32-x64": {
+      "version": "1.2.2-alpha.18",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.2.2-alpha.18.tgz",
+      "integrity": "sha512-0BSRNH3JbvHDYd2LM/25uQlSaXzeJaJvBCJQZoIXttY5vq6stLknfQ9zWADLa8jwFYU+p87Ajqg415zs4SfMFQ==",
+      "dev": true,
+      "optional": true
+    },
     "@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -31904,7 +31680,8 @@
     },
     "@gar/promisify": {
       "version": "1.1.3",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@graphql-tools/executor": {
       "version": "0.0.18",
@@ -35046,10 +34823,6 @@
       "dev": true,
       "requires": {}
     },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "dev": true
@@ -36688,6 +36461,7 @@
     "agentkeepalive": {
       "version": "4.5.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "humanize-ms": "^1.2.1"
       }
@@ -36695,6 +36469,7 @@
     "aggregate-error": {
       "version": "3.1.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -36702,7 +36477,8 @@
       "dependencies": {
         "indent-string": {
           "version": "4.0.0",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -37574,7 +37350,8 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cli-boxes": {
       "version": "3.0.0",
@@ -38735,265 +38512,6 @@
       "version": "3.1.4",
       "dev": true
     },
-    "duckdb": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "node-addon-api": "^7.0.0",
-        "node-gyp": "^9.3.0"
-      },
-      "dependencies": {
-        "@npmcli/fs": {
-          "version": "2.1.2",
-          "dev": true,
-          "requires": {
-            "@gar/promisify": "^1.1.3",
-            "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/move-file": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "mkdirp": "^1.0.4",
-            "rimraf": "^3.0.2"
-          }
-        },
-        "are-we-there-yet": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "cacache": {
-          "version": "16.1.3",
-          "dev": true,
-          "requires": {
-            "@npmcli/fs": "^2.1.0",
-            "@npmcli/move-file": "^2.0.0",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.1.0",
-            "glob": "^8.0.1",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^7.7.1",
-            "minipass": "^3.1.6",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "mkdirp": "^1.0.4",
-            "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^9.0.0",
-            "tar": "^6.1.11",
-            "unique-filename": "^2.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "8.1.0",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-              }
-            },
-            "minimatch": {
-              "version": "5.1.6",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            }
-          }
-        },
-        "chownr": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "dev": true
-        },
-        "gauge": {
-          "version": "4.0.4",
-          "dev": true,
-          "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.3",
-            "console-control-strings": "^1.1.0",
-            "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.5"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "make-fetch-happen": {
-          "version": "10.2.1",
-          "dev": true,
-          "requires": {
-            "agentkeepalive": "^4.2.1",
-            "cacache": "^16.1.0",
-            "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^5.0.0",
-            "https-proxy-agent": "^5.0.0",
-            "is-lambda": "^1.0.1",
-            "lru-cache": "^7.7.1",
-            "minipass": "^3.1.6",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^2.0.3",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.3",
-            "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^7.0.0",
-            "ssri": "^9.0.0"
-          }
-        },
-        "minipass": {
-          "version": "3.3.6",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minipass-collect": {
-          "version": "1.0.2",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-fetch": {
-          "version": "2.1.2",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.13",
-            "minipass": "^3.1.6",
-            "minipass-sized": "^1.0.3",
-            "minizlib": "^2.1.2"
-          }
-        },
-        "node-gyp": {
-          "version": "9.4.1",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "exponential-backoff": "^3.1.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^10.0.3",
-            "nopt": "^6.0.0",
-            "npmlog": "^6.0.0",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
-            "tar": "^6.1.2",
-            "which": "^2.0.2"
-          }
-        },
-        "nopt": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "abbrev": "^1.0.0"
-          }
-        },
-        "npmlog": {
-          "version": "6.0.2",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "^3.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.3",
-            "set-blocking": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "signal-exit": {
-          "version": "3.0.7",
-          "dev": true
-        },
-        "socks-proxy-agent": {
-          "version": "7.0.0",
-          "dev": true,
-          "requires": {
-            "agent-base": "^6.0.2",
-            "debug": "^4.3.3",
-            "socks": "^2.6.2"
-          }
-        },
-        "ssri": {
-          "version": "9.0.1",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.1.1"
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "unique-filename": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "unique-slug": "^3.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
-        }
-      }
-    },
     "duplexer": {
       "version": "0.1.2",
       "dev": true
@@ -39145,11 +38663,13 @@
     },
     "env-paths": {
       "version": "2.2.1",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "err-code": {
       "version": "2.0.3",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -39660,10 +39180,6 @@
     },
     "expect-type": {
       "version": "1.2.1",
-      "dev": true
-    },
-    "exponential-backoff": {
-      "version": "3.1.1",
       "dev": true
     },
     "express": {
@@ -40787,15 +40303,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "http-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "http-shutdown": {
       "version": "1.2.2",
       "dev": true
@@ -40829,6 +40336,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "dev": true,
+      "optional": true,
       "requires": {
         "ms": "^2.0.0"
       }
@@ -40926,7 +40434,8 @@
     },
     "infer-owner": {
       "version": "1.0.4",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "inflation": {
       "version": "2.0.0",
@@ -41111,7 +40620,8 @@
     },
     "is-lambda": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-module": {
       "version": "1.0.0",
@@ -42172,6 +41682,7 @@
     "minipass-flush": {
       "version": "1.0.5",
       "dev": true,
+      "optional": true,
       "requires": {
         "minipass": "^3.0.0"
       },
@@ -42179,6 +41690,7 @@
         "minipass": {
           "version": "3.3.6",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -42188,6 +41700,7 @@
     "minipass-pipeline": {
       "version": "1.2.4",
       "dev": true,
+      "optional": true,
       "requires": {
         "minipass": "^3.0.0"
       },
@@ -42195,6 +41708,7 @@
         "minipass": {
           "version": "3.3.6",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -42204,6 +41718,7 @@
     "minipass-sized": {
       "version": "1.0.3",
       "dev": true,
+      "optional": true,
       "requires": {
         "minipass": "^3.0.0"
       },
@@ -42211,6 +41726,7 @@
         "minipass": {
           "version": "3.3.6",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -44574,6 +44090,7 @@
     "p-map": {
       "version": "4.0.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -45373,11 +44890,13 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "promise-retry": {
       "version": "2.0.1",
       "dev": true,
+      "optional": true,
       "requires": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -45879,7 +45398,8 @@
     },
     "retry": {
       "version": "0.12.0",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "copyfiles": "^2.4.1",
     "dependency-cruiser": "^13.1.5",
     "dotenv": "^8.1.0",
-    "duckdb": "^1.0.0",
+    "@duckdb/node-api": "^1.2.2-alpha.18",
     "eslint": "^8.56.0",
     "eslint-plugin-file-extension-in-import-ts": "^1.0.2",
     "eventsource": "^2.0.2",

--- a/projects/tests/dbs/duckdb.spec.ts
+++ b/projects/tests/dbs/duckdb.spec.ts
@@ -3,14 +3,16 @@ import { Remult, SqlDatabase } from '../../core'
 import { DuckDBDataProvider } from '../../core/remult-duckdb.js'
 import { SqlDbTests } from './shared-tests/sql-db-tests.js'
 import type { DbTestProps } from './shared-tests/db-tests-props.js'
-import { Database } from 'duckdb'
+import { DuckDBInstance } from '@duckdb/node-api'
 import { allDbTests } from './shared-tests/index.js'
 
 describe.skipIf(process.env['SKIP_DUCKDB_TESTS'])('duckdb', () => {
   let db: SqlDatabase
   let remult: Remult
   beforeEach(async () => {
-    db = new SqlDatabase(new DuckDBDataProvider(new Database(':memory:')))
+    const instance = await DuckDBInstance.create(':memory:')
+    const connection = await instance.connect()
+    db = new SqlDatabase(new DuckDBDataProvider(connection))
     remult = new Remult(db)
   })
   const props: DbTestProps = {


### PR DESCRIPTION
Update DuckDB docs to use new @duckdb/node-api package

- Changed installation package from `duckdb` to `@duckdb/node-api`
- Updated code examples to use new DuckDB API
- Updated both quickstart guide and DuckDB installation docs

Resolves #693 