### PR TITLE
Export `initAsyncHooks` for use of `withRemult` in non API projects

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -361,7 +361,7 @@ const sidebar = tutorials.reduce(
             link: '/docs/ref_generatemigrations',
           },
           { text: 'migrate', link: '/docs/ref_migrate' },
-
+          { text: 'Async Hooks', link: '/docs/ref_initasynchooks' },
           { text: 'REST API Spec', link: '/docs/rest-api' },
           {
             text: 'Active Record & Mutable',

--- a/docs/docs/ref_initasynchooks.md
+++ b/docs/docs/ref_initasynchooks.md
@@ -1,0 +1,28 @@
+# initAsyncHooks
+Initializes async context tracking for the server.
+
+This should be called before handling any incoming requests or calling `withRemult()`.
+
+
+#### example:
+```ts
+import { remult, repo, withRemult } from 'remult';
+import { initAsyncHooks } from 'remult/async-hooks';
+
+import { Task } from './entities/Task.js';
+
+initAsyncHooks();
+
+// Thx to the `initAsyncHooks` above, 
+// we have isolated async contexts with multiple `withRemult()`, 
+// without needing to initialize a `remultApi` all the time!
+withRemult(async () => {
+    remult.user = { id: '42' };
+    repo(Task).find()
+});
+
+withRemult(async () => {
+    remult.user = { id: '21' };
+    repo(Task).find()
+});
+```

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -10345,6 +10345,39 @@ Arguments:
 
 
 
+# API Reference - Async Hooks
+
+# initAsyncHooks
+Initializes async context tracking for the server.
+
+This should be called before handling any incoming requests or calling `withRemult()`.
+
+
+#### example:
+```ts
+import { remult, repo, withRemult } from 'remult';
+import { initAsyncHooks } from 'remult/async-hooks';
+
+import { Task } from './entities/Task.js';
+
+initAsyncHooks();
+
+// Thx to the `initAsyncHooks` above, 
+// we have isolated async contexts with multiple `withRemult()`, 
+// without needing to initialize a `remultApi` all the time!
+withRemult(async () => {
+    remult.user = { id: '42' };
+    repo(Task).find()
+});
+
+withRemult(async () => {
+    remult.user = { id: '21' };
+    repo(Task).find()
+});
+```
+
+
+
 # API Reference - REST API Spec
 
 # Entity Rest Api Breakdown

--- a/docs/public/llms-small.txt
+++ b/docs/public/llms-small.txt
@@ -10345,6 +10345,39 @@ Arguments:
 
 
 
+# API Reference - Async Hooks
+
+# initAsyncHooks
+Initializes async context tracking for the server.
+
+This should be called before handling any incoming requests or calling `withRemult()`.
+
+
+#### example:
+```ts
+import { remult, repo, withRemult } from 'remult';
+import { initAsyncHooks } from 'remult/async-hooks';
+
+import { Task } from './entities/Task.js';
+
+initAsyncHooks();
+
+// Thx to the `initAsyncHooks` above, 
+// we have isolated async contexts with multiple `withRemult()`, 
+// without needing to initialize a `remultApi` all the time!
+withRemult(async () => {
+    remult.user = { id: '42' };
+    repo(Task).find()
+});
+
+withRemult(async () => {
+    remult.user = { id: '21' };
+    repo(Task).find()
+});
+```
+
+
+
 # API Reference - REST API Spec
 
 # Entity Rest Api Breakdown

--- a/docs/tools/build-ref.sh
+++ b/docs/tools/build-ref.sh
@@ -15,7 +15,7 @@ rm -rf src/shared-tests/*
 rm -f src/live-query/*.spec.ts
 
 # Generate TypeDoc JSON
-npx typedoc index.ts server/index.ts migrations/index.ts --json the.json
+npx typedoc index.ts server/index.ts migrations/index.ts async-hooks.ts --json the.json
 
 # Return to original directory and run build-ref-ts
 cd ../..

--- a/docs/tools/docs-work.ts
+++ b/docs/tools/docs-work.ts
@@ -234,6 +234,7 @@ try {
     'getEntityRef',
     'getFields',
     'SqlDatabase',
+    'initAsyncHooks',
 
     //    'PreprocessFilterEvent',
   ]) {

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -1075,7 +1075,10 @@ export interface FieldOptions<entityType = unknown, valueType = unknown> {
   caption?: string
   /** If it can store null in the database */
   allowNull?: boolean
-  /** If a value is required */
+  /** If a value is required. Short-cut to say `validate: Validators.required`.
+        @see option [validate](https://remult.dev/docs/ref_field#validate) below
+        @see validator [required](https://remult.dev/docs/ref_validators#required)
+     */
   required?: boolean
   /**
    * Specifies whether this field should be included in the API. This can be configured
@@ -3536,6 +3539,12 @@ export type RemultNextServer = RemultServerCore<NextApiRequest> &
      */
     handle<T>(handler: NextApiHandler<T>): NextApiHandler<T>
   }
+```
+
+## ./async-hooks.js
+
+```ts
+export declare function initAsyncHooks(): void
 ```
 
 ## ./server/index.js

--- a/projects/core/async-hooks.ts
+++ b/projects/core/async-hooks.ts
@@ -1,0 +1,1 @@
+export { initAsyncHooks } from './server/initAsyncHooks.js';

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -29,6 +29,7 @@
     ".": "./index.js",
     "./remult-express": "./remult-express.js",
     "./remult-next": "./remult-next.js",
+    "./async-hooks": "./async-hooks.js",
     "./server": "./server/index.js",
     "./server/core": "./server/core.js",
     "./remult-fastify": "./remult-fastify.js",

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -8,7 +8,12 @@ import { remultStatic } from '../src/remult-static.js'
 let init = false
 
 /**
- * Add an example of how to use it.
+ * Initializes async context tracking for the server.
+ * 
+ * This should be called before handling any incoming requests or calling `withRemult()`.
+ * @example
+ * import { initAsyncHooks } from 'remult/async-hooks';
+ * initAsyncHooks();
  */
 export function initAsyncHooks() {
   if (init) return

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -7,6 +7,9 @@ import { remultStatic } from '../src/remult-static.js'
 
 let init = false
 
+/**
+ * Add an example of how to use it.
+ */
 export function initAsyncHooks() {
   if (init) return
   init = true

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -12,8 +12,23 @@ let init = false
  * 
  * This should be called before handling any incoming requests or calling `withRemult()`.
  * @example
+ * import { remult, repo, withRemult } from 'remult';
  * import { initAsyncHooks } from 'remult/async-hooks';
+ * 
+ * import { Task } from './entities/Task.js';
+ * 
  * initAsyncHooks();
+ * 
+ * // Now we have isolated async contexts with multiple `withRemult()`, without needing to initialize a `remultApi`!
+ * withRemult(async () => {
+ *     remult.user = { id: '42' };
+ *     repo(Task).find()
+ * });
+ * 
+ * withRemult(async () => {
+ *     remult.user = { id: '21' };
+ *     repo(Task).find()
+ * });
  */
 export function initAsyncHooks() {
   if (init) return

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -19,7 +19,9 @@ let init = false
  * 
  * initAsyncHooks();
  * 
- * // Now we have isolated async contexts with multiple `withRemult()`, without needing to initialize a `remultApi`!
+ * // Thx to the `initAsyncHooks` above, 
+ * // we have isolated async contexts with multiple `withRemult()`, 
+ * // without needing to initialize a `remultApi` all the time!
  * withRemult(async () => {
  *     remult.user = { id: '42' };
  *     repo(Task).find()


### PR DESCRIPTION
Simply exports the `initAsyncHooks()` function from `projects/core/server/initAsyncHooks.ts` to allow properly using `withRemult` in projects that do not use any `remultApi`.

```ts
import { initAsyncHooks } from 'remult/async-hooks';

initAsyncHooks();
```