### PR TITLE
:bug: FIX: Auth none is a choice NULL not undefined

### DIFF
--- a/projects/create-remult/src/AUTH.ts
+++ b/projects/create-remult/src/AUTH.ts
@@ -18,7 +18,7 @@ export type AuthInfo = {
   envVariables?: envVariable[];
 };
 
-export const Auths: Record<string, AuthInfo | undefined> = {
+export const Auths: Record<string, AuthInfo | null> = {
   ["better-auth"]: {
     name: "better-auth",
     componentInfo: {
@@ -132,7 +132,8 @@ export const Auths: Record<string, AuthInfo | undefined> = {
       { key: "AUTH_GITHUB_SECRET", optional: true },
     ],
   },
-  none: undefined,
+  // It's not that it's not defined, it's really null.
+  none: null,
 };
 
 function generateSecret() {


### PR DESCRIPTION
closes: https://github.com/remult/remult/issues/756

Because "prompts" lib fallback undfined to the index of the choice... While null is a valid value.