### PR TITLE
feat: Implement `StandardSchemaV1` spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## [3.1.1] 2025-7-30
+
+- Add `standardSchema` implementing the [Standard Schema](https://standardschema.dev/) specification. Check [Remult Standard Schema](https://remult.dev/docs/standard-schema) for more details.
+
 ## [3.1.0] 2025-7-29
 
 - Fix by @LazyShpee for `initAsyncHooks` without `remultApi`
@@ -32,7 +36,7 @@ Then, globally, in a shared code file:
 import { createId } from '@paralleldrive/cuid2'
 import { Fields } from 'remult'
 
-Fields.defaultIdFactory = createId()
+Fields.defaultIdFactory = () => createId()
 ```
 
 Finally, replace `@Fields.cuid()` with `@Fields.id()`

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -335,6 +335,7 @@ const sidebar = tutorials.reduce(
         items: [
           { text: 'Open API', link: '/docs/adding-swagger' },
           { text: 'GraphQL', link: '/docs/adding-graphql' },
+          { text: 'Standard Schema', link: '/docs/standard-schema' },
           { text: 'LLMs', link: '/docs/llms' },
         ],
       },

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -381,16 +381,16 @@ const logout = async () => {
 }
 ```
 
-## Remote Functions
+## Extra - Remote Functions
 
-This is an exciting new feature of SvelteKit xxx, and you can make full use of it with Remult!
+SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
 
-Here is the default doc example:
+Here is the default doc example (zod & drizzle or valibot & prisma, ...):
 
 ```ts
-import z from 'zod'
+import z from 'zod' // or valibot, ... any standard schema library
 import { query } from '$app/server'
-import * as db from '$lib/server/db'
+import * as db from '$lib/server/db' // with drizzle, prisma, pg, ... any database library
 
 export const getLikes = query(z.string(), async (id) => {
   const [row] = await db.sql`select likes from item where id = ${id}`
@@ -398,11 +398,16 @@ export const getLikes = query(z.string(), async (id) => {
 })
 ```
 
-And with remult
+With remult library, you have both:
+
+- the database layer
+- the standard schema layer
+
+So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
-import { std, repo } from 'remult'
 import { query } from '$app/server'
+import { std, repo } from 'remult'
 import { Item } from '$lib/entities'
 
 export const getLikes = query(std(Item, 'id'), async (id) => {
@@ -410,3 +415,5 @@ export const getLikes = query(std(Item, 'id'), async (id) => {
   return item.likes
 })
 ```
+
+We are excited to see how you will use it 🚀

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -407,10 +407,10 @@ So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
 import { query } from '$app/server'
-import { std, repo } from 'remult'
+import { standardSchema, repo } from 'remult'
 import { Item } from '$lib/entities'
 
-export const getLikes = query(std(Item, 'id'), async (id) => {
+export const getLikes = query(standardSchema(repo(Item), 'id'), async (id) => {
   const item = await repo(Item).findId(id)
   return item.likes
 })

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -380,3 +380,33 @@ const logout = async () => {
   }
 }
 ```
+
+## Remote Functions
+
+This is an exciting new feature of SvelteKit xxx, and you can make full use of it with Remult!
+
+Here is the default doc example:
+
+```ts
+import z from 'zod'
+import { query } from '$app/server'
+import * as db from '$lib/server/db'
+
+export const getLikes = query(z.string(), async (id) => {
+  const [row] = await db.sql`select likes from item where id = ${id}`
+  return row.likes
+})
+```
+
+And with remult
+
+```ts [src/lib/server/functions.ts]
+import { std, repo } from 'remult'
+import { query } from '$app/server'
+import { Item } from '$lib/entities'
+
+export const getLikes = query(std(Item, 'id'), async (id) => {
+  const item = await repo(Item).findId(id)
+  return item.likes
+})
+```

--- a/docs/docs/standard-schema.md
+++ b/docs/docs/standard-schema.md
@@ -13,7 +13,7 @@ Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effec
 Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
 
 ```ts
-import { std, Entity, Fields } from 'remult'
+import { standardSchema, Entity, Fields, repo } from 'remult'
 
 @Entity('User')
 class User {
@@ -28,7 +28,7 @@ class User {
 }
 
 // Create a Standard Schema validator for the entire entity
-const userSchema = std(User)
+const userSchema = standardSchema(repo(User))
 
 // Validate data with any Standard Schema library
 const result = await validateWithAnyLibrary(userSchema, {
@@ -49,13 +49,13 @@ You can create validators that only check specific fields by passing field names
 
 ```ts
 // Validate only the age field
-const ageSchema = std(User, 'age')
+const ageSchema = standardSchema(repo(User), 'age')
 
 const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
 // Returns: { value: { age: 30 } }
 
 // Validate multiple specific fields
-const nameAndAgeSchema = std(User, 'name', 'age')
+const nameAndAgeSchema = standardSchema(repo(User), 'name', 'age')
 
 const result = await validateWithAnyLibrary(nameAndAgeSchema, {
   name: 'John Doe',
@@ -82,7 +82,7 @@ class UserMail {
 }
 
 // Email validation will be enforced
-const emailSchema = std(UserMail, 'email')
+const emailSchema = standardSchema(repo(UserMail), 'email')
 
 const result = await validateWithAnyLibrary(emailSchema, {
   email: 'invalid-email',
@@ -117,7 +117,7 @@ class Task {
   userId = ''
 }
 
-const taskSchema = std(Task)
+const taskSchema = standardSchema(repo(Task))
 
 const result = await validateWithAnyLibrary(taskSchema, {
   title: 'My Task',

--- a/docs/docs/standard-schema.md
+++ b/docs/docs/standard-schema.md
@@ -1,0 +1,137 @@
+# Standard Schema
+
+Remult now supports the [Standard Schema](https://standardschema.dev/) specification, allowing you to use your Remult entities as type-safe validators that are compatible with any Standard Schema library.
+
+## Overview
+
+The Standard Schema specification provides a common interface for TypeScript validation libraries. By implementing this standard, Remult entities can be used as validators in any ecosystem that supports Standard Schema, making it easier to integrate with third-party tools and libraries.
+
+Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effect,... to your project, you can use Remult entities as validators with any library that supports the Standard Schema specification.
+
+## Basic Usage
+
+Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
+
+```ts
+import { std, Entity, Fields } from 'remult'
+
+@Entity('User')
+class User {
+  @Fields.id()
+  id!: string
+
+  @Fields.string({ required: true })
+  name!: string
+
+  @Fields.number()
+  age?: number
+}
+
+// Create a Standard Schema validator for the entire entity
+const userSchema = std(User)
+
+// Validate data with any Standard Schema library
+const result = await validateWithAnyLibrary(userSchema, {
+  name: 'John Doe',
+  age: 30,
+})
+
+if (result.issues) {
+  console.log('Validation errors:', result.issues)
+} else {
+  console.log('Valid data:', result.value)
+}
+```
+
+## Field-Specific Validation
+
+You can create validators that only check specific fields by passing field names as additional arguments:
+
+```ts
+// Validate only the age field
+const ageSchema = std(User, 'age')
+
+const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
+// Returns: { value: { age: 30 } }
+
+// Validate multiple specific fields
+const nameAndAgeSchema = std(User, 'name', 'age')
+
+const result = await validateWithAnyLibrary(nameAndAgeSchema, {
+  name: 'John Doe',
+  age: 30,
+  id: 'ignored', // This will be filtered out
+})
+// Returns: { value: { name: 'John Doe', age: 30 } }
+```
+
+## Validation with Custom Rules
+
+The Standard Schema validator respects all your entity's validation rules, including custom validators and entity-level validation:
+
+```ts
+import { Validators } from 'remult'
+
+@Entity('UserMail')
+class UserMail {
+  @Fields.string({ validate: [Validators.email] })
+  email!: string
+
+  @Fields.string()
+  job = ''
+}
+
+// Email validation will be enforced
+const emailSchema = std(UserMail, 'email')
+
+const result = await validateWithAnyLibrary(emailSchema, {
+  email: 'invalid-email',
+})
+// Returns: { issues: [{ message: 'Invalid Email', path: ['email'] }] }
+
+const validResult = await validateWithAnyLibrary(emailSchema, {
+  email: 'user@example.com',
+})
+// Returns: { value: { email: 'user@example.com' } }
+```
+
+## Entity-Level Validation
+
+Entity-level validation is also supported:
+
+```ts
+@Entity('Task', {
+  validation(item) {
+    if (item.userId && !item.userId.startsWith('user:')) {
+      throw new Error(
+        `Task ${item.title} must be assigned with someone starting with [user:]`,
+      )
+    }
+  },
+})
+class Task {
+  @Fields.string()
+  title = ''
+
+  @Fields.string({ required: true })
+  userId = ''
+}
+
+const taskSchema = std(Task)
+
+const result = await validateWithAnyLibrary(taskSchema, {
+  title: 'My Task',
+  userId: '123', // Invalid format
+})
+// Returns: { issues: [{ message: 'Task My Task must be assigned with someone starting with [user:]', path: [] }] }
+```
+
+## Benefits
+
+- **Interoperability**: Use Remult entities with any Standard Schema compatible library
+- **Type Safety**: Full TypeScript support with inferred types
+- **Consistency**: Same validation rules across your entire application
+- **Flexibility**: Validate entire entities or specific fields
+- **Standards Compliance**: Follows the official Standard Schema specification
+
+The Standard Schema integration makes Remult entities more versatile and easier to integrate with the broader TypeScript ecosystem while maintaining all the benefits of Remult's validation system.

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -1,11 +1,11 @@
 # Validation
 
-Validation is a key part of any application, and you will see that it's builtin Remult ! Let's dive into it...
+Validation is a key part of any application, and you will see that it's builtin Remult !
 
 First of all, some props brings automatic validation, for example `required` and `minLength` for strings :
 
 ```ts
-@Fields.string({ minLength: 5 })
+@Fields.string({ required: true, minLength: 5 })
 title = ''
 ```
 
@@ -91,3 +91,7 @@ If you want to customize the error message, you can do it globally :
 ```ts
 Validators.unique.defaultMessage = 'Existe déjà!'
 ```
+
+::: tip
+Remult entities can also be used as [Standard Schema](./standard-schema.md) compatible validators, making them interoperable with other validation libraries.
+:::

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1519,10 +1519,6 @@ export class Contact {
 
 # Entities - Relations
 
----
-outline: [2, 3]
----
-
 # Relations Between Entities
 
 ::: tip **Interactive Learning Available! 🚀**
@@ -2364,7 +2360,6 @@ Utilizing an intermediate table for managing many-to-many relationships in Remul
 ---
 
 In this guide, we've explored the essential concepts of managing entity relations within the Remult library. From one-to-one to many-to-many relationships, we've covered the declaration, customization, and querying of these relations. By understanding the nuances of entity relations, users can harness the full potential of Remult to build robust TypeScript applications with ease.
-
 
 
 # Relations - Filtering and Relations
@@ -6967,14 +6962,6 @@ Accessing the underlying database directly in Remult provides the flexibility to
 
 # Escape Hatches - Using in Non-Remult Routes
 
----
-keywords:
-  [
-    Error: remult object was requested outside of a valid context,
-    try running it within initApi or a remult request cycle,
-  ]
----
-
 # Using Remult in Non-Remult Routes
 
 When using the CRUD api or [BackendMethods](./backendMethods.md), `remult` is automatically available. Still, there are many use cases where you may want to user remult in your own routes or other code without using `BackendMethods` but would still want to take advantage of `Remult` as an ORM and use it to check for user validity, etc...
@@ -7225,7 +7212,6 @@ import { remultApi } from 'remult/remult-hapi'
 :::
 
 
-
 # Escape Hatches - Avoiding Decorators
 
 # Working without decorators
@@ -7308,18 +7294,6 @@ This is the same backend method that is detailed in the [Backend methods of the 
 
 
 # Escape Hatches - Extensibility
-
----
-tags:
-  - options
-  - bespoke options
-  - customizing options
-  - type augmentation
-  - module augmentation
-  - UserInfo
-  - RemultContext
-  - context
----
 
 # Extensibility
 
@@ -7470,7 +7444,6 @@ or in an entity's saving event:
 ```
 
 By leveraging module augmentation, you can tailor Remult to your specific needs, adding custom options and extending interfaces to suit your application's requirements.
-
 
 
 # Integrations - Open API
@@ -7688,6 +7661,148 @@ const yogaApp = createYoga<RequestEvent>({
 
 export { yogaApp as GET, yogaApp as OPTIONS, yogaApp as POST }
 ```
+
+
+
+# Integrations - Standard Schema
+
+# Standard Schema
+
+Remult now supports the [Standard Schema](https://standardschema.dev/) specification, allowing you to use your Remult entities as type-safe validators that are compatible with any Standard Schema library.
+
+## Overview
+
+The Standard Schema specification provides a common interface for TypeScript validation libraries. By implementing this standard, Remult entities can be used as validators in any ecosystem that supports Standard Schema, making it easier to integrate with third-party tools and libraries.
+
+Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effect,... to your project, you can use Remult entities as validators with any library that supports the Standard Schema specification.
+
+## Basic Usage
+
+Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
+
+```ts
+import { std, Entity, Fields } from 'remult'
+
+@Entity('User')
+class User {
+  @Fields.id()
+  id!: string
+
+  @Fields.string({ required: true })
+  name!: string
+
+  @Fields.number()
+  age?: number
+}
+
+// Create a Standard Schema validator for the entire entity
+const userSchema = std(User)
+
+// Validate data with any Standard Schema library
+const result = await validateWithAnyLibrary(userSchema, {
+  name: 'John Doe',
+  age: 30,
+})
+
+if (result.issues) {
+  console.log('Validation errors:', result.issues)
+} else {
+  console.log('Valid data:', result.value)
+}
+```
+
+## Field-Specific Validation
+
+You can create validators that only check specific fields by passing field names as additional arguments:
+
+```ts
+// Validate only the age field
+const ageSchema = std(User, 'age')
+
+const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
+// Returns: { value: { age: 30 } }
+
+// Validate multiple specific fields
+const nameAndAgeSchema = std(User, 'name', 'age')
+
+const result = await validateWithAnyLibrary(nameAndAgeSchema, {
+  name: 'John Doe',
+  age: 30,
+  id: 'ignored', // This will be filtered out
+})
+// Returns: { value: { name: 'John Doe', age: 30 } }
+```
+
+## Validation with Custom Rules
+
+The Standard Schema validator respects all your entity's validation rules, including custom validators and entity-level validation:
+
+```ts
+import { Validators } from 'remult'
+
+@Entity('UserMail')
+class UserMail {
+  @Fields.string({ validate: [Validators.email] })
+  email!: string
+
+  @Fields.string()
+  job = ''
+}
+
+// Email validation will be enforced
+const emailSchema = std(UserMail, 'email')
+
+const result = await validateWithAnyLibrary(emailSchema, {
+  email: 'invalid-email',
+})
+// Returns: { issues: [{ message: 'Invalid Email', path: ['email'] }] }
+
+const validResult = await validateWithAnyLibrary(emailSchema, {
+  email: 'user@example.com',
+})
+// Returns: { value: { email: 'user@example.com' } }
+```
+
+## Entity-Level Validation
+
+Entity-level validation is also supported:
+
+```ts
+@Entity('Task', {
+  validation(item) {
+    if (item.userId && !item.userId.startsWith('user:')) {
+      throw new Error(
+        `Task ${item.title} must be assigned with someone starting with [user:]`,
+      )
+    }
+  },
+})
+class Task {
+  @Fields.string()
+  title = ''
+
+  @Fields.string({ required: true })
+  userId = ''
+}
+
+const taskSchema = std(Task)
+
+const result = await validateWithAnyLibrary(taskSchema, {
+  title: 'My Task',
+  userId: '123', // Invalid format
+})
+// Returns: { issues: [{ message: 'Task My Task must be assigned with someone starting with [user:]', path: [] }] }
+```
+
+## Benefits
+
+- **Interoperability**: Use Remult entities with any Standard Schema compatible library
+- **Type Safety**: Full TypeScript support with inferred types
+- **Consistency**: Same validation rules across your entire application
+- **Flexibility**: Validate entire entities or specific fields
+- **Standards Compliance**: Follows the official Standard Schema specification
+
+The Standard Schema integration makes Remult entities more versatile and easier to integrate with the broader TypeScript ecosystem while maintaining all the benefits of Remult's validation system.
 
 
 
@@ -8376,12 +8491,12 @@ inputType = 'date';
 
 # Validation
 
-Validation is a key part of any application, and you will see that it's builtin Remult ! Let's dive into it...
+Validation is a key part of any application, and you will see that it's builtin Remult !
 
 First of all, some props brings automatic validation, for example `required` and `minLength` for strings :
 
 ```ts
-@Fields.string({ minLength: 5 })
+@Fields.string({ required: true, minLength: 5 })
 title = ''
 ```
 
@@ -8467,6 +8582,10 @@ If you want to customize the error message, you can do it globally :
 ```ts
 Validators.unique.defaultMessage = 'Existe déjà!'
 ```
+
+::: tip
+Remult entities can also be used as [Standard Schema](./standard-schema.md) compatible validators, making them interoperable with other validation libraries.
+:::
 
 
 
@@ -9714,14 +9833,6 @@ remultApi({
 
 # API Reference - EntityFilter
 
----
-tags:
-  - Where
-  - Filter
-  - Entity Where
-  - Entity Filter
----
-
 # EntityFilter
 
 Used to filter the desired result set
@@ -9860,7 +9971,6 @@ where: {
   }
 }
 ```
-
 
 
 # API Reference - EntityMetadata
@@ -11193,13 +11303,7 @@ Arguments:
 
 
 
-# Remult Blog - Introducing Remult
-
----
-title: "Introducing Remult: The Backend to Frontend Framework You Always Wanted"
-sidebar: false
-editLink: false
----
+# Introducing Remult: The Backend to Frontend Framework You Always Wanted
 
 > March 14, 2023 | Noam Honig
 
@@ -11274,7 +11378,6 @@ So we open sourced the framework, to enable other lazy developers like us to be 
 Check out [Remult](https://remult.dev), and if you like it, give it a star.  Let us know what you’d like to see next, and also feel free to contribute to the project.
 
 In our next post, we’ll do a roundup of tools in the ecosystem looking to solve similar challenges though different approaches, and unpack where Remult fits in, and what it’s optimized for.
-
 
 
 # react - Tutorial - Setup
@@ -20672,14 +20775,7 @@ To see a larger more complex code base, visit our [CRM example project](https://
 Love Remult?&nbsp;<a href="https://github.com/remult/remult" target="_blank" rel="noopener"> Give our repo a star.⭐</a>
 
 
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Welcome to the Remult Tutorial
-template: after-backend-methods
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Introduction - Welcome to the Remult Tutorial
 
 # Welcome to the Remult Tutorial
 
@@ -20718,15 +20814,7 @@ Ready to dive in? Click on the next lesson to start building your app with Remul
 Happy coding! 🎉
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Entity
-focus: /shared/Task.ts
-template: before-entity
----
+# Interactive Tutorial - Basics - Introduction - Entity
 
 # The Entity
 
@@ -20767,15 +20855,7 @@ This entity will be used to define the database, API, frontend query language, v
 We've placed the entity's source code in the `shared` folder to indicate that it's shared between the frontend and the backend.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Rest Api
-focus: /backend/index.ts
-template: before-frontend
----
+# Interactive Tutorial - Basics - Introduction - Rest Api
 
 ## The Rest Api
 
@@ -20818,15 +20898,7 @@ await fetch('/api/tasks').then((result) => result.json())
 :::
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Insert Data on the Backend
-focus: /backend/index.ts
-template: before-frontend
----
+# Interactive Tutorial - Basics - Introduction - Insert Data on the Backend
 
 ## Insert Data on the Backend
 
@@ -20874,15 +20946,7 @@ Click on the `Test the API` button in the preview window. You should see a JSON 
 > **Note:** While Remult supports [many relational and non-relational databases](https://remult.dev/docs/installation/database/), in this tutorial we start by storing entity data in a backend **JSON file** stored in the `db` folder for the project. Later in this tutorial, we'll switch to using SQLite.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Display the Task List
-focus: /frontend/Todo.tsx
-autoReload: true
----
+# Interactive Tutorial - Basics - Introduction - Display the Task List
 
 ## Display the Task List
 
@@ -20932,23 +20996,7 @@ This code makes a REST API call to the backend at the `/api/tasks` URL to get th
 You can see the tasks in the preview window below.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Introduction
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Paging
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Querying Data - Paging
 
 # Paging
 
@@ -20977,14 +21025,7 @@ This code results in the following REST API request:
 Try playing with different values for `limit` and `page` to see the results in the preview window.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Sorting
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Querying Data - Sorting
 
 # Sorting
 
@@ -21014,14 +21055,7 @@ This code results in the following REST API request:
 Try changing the sort direction and sorting by different fields to see the results in the preview window.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Filtering
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Querying Data - Filtering
 
 # Filtering
 
@@ -21053,23 +21087,7 @@ You can experiment with other types of conditions like `$contains`, `$startsWith
 Try changing the filter condition to see the results in the preview window.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Querying Data
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Insert
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Manipulating Data - Insert
 
 # Inserting Data
 
@@ -21153,14 +21171,7 @@ This code results in the following REST API request to insert the new task:
 Try adding new tasks using the form in the preview window below.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Update
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Manipulating Data - Update
 
 # Updating Data
 
@@ -21212,14 +21223,7 @@ This code results in the following REST API request to update the task:
 Try toggling the completion status of tasks using the checkboxes in the preview window below.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Delete
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Manipulating Data - Delete
 
 # Deleting Data
 
@@ -21281,23 +21285,7 @@ This code results in the following REST API request to delete the task:
 Try deleting tasks using the delete buttons in the preview window below.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Manipulating Data
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Required
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Basics - Validation - Required
 
 # Validation Introduction
 
@@ -21390,14 +21378,7 @@ See the result error object that's returned
 :::
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Built-In Validations
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Basics - Validation - Built-In Validations
 
 # Built-In Validations
 
@@ -21480,14 +21461,7 @@ export class Task {
 Try adding tasks with titles that do not meet these validation requirements to see the validation in action. The errors returned will include the validation messages specified.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Custom Validations
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Basics - Validation - Custom Validations
 
 # Custom Validations
 
@@ -21519,23 +21493,7 @@ export class Task {
 Try adding tasks with titles shorter than 3 characters to see the custom validation in action. The error message `'too short'` will be returned if the validation fails.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Validation
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Live Query
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Live Query - Live Query
 
 # Introduction
 
@@ -21546,14 +21504,7 @@ Our todo list app can have multiple users using it at the same time. However, ch
 In the preview window below, we can see `user-a` and `user-b`. Try making changes to data as `user-a` and see how `user-b` needs to click `reload page` to see these changes.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Realtime Updates
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Live Query - Realtime Updates
 
 # Realtime Updates
 
@@ -21619,24 +21570,7 @@ async function deleteTask(task: Task) {
 - With `liveQuery`, the state updates automatically whenever there are changes to the tasks, simplifying our state management.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Live Query
-template: live-query
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Updating Multiple Tasks
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Backend Methods - Updating Multiple Tasks
 
 # Backend Methods
 
@@ -21694,14 +21628,7 @@ In the next lesson, we'll refactor this code to address these performance challe
 Would you like to proceed with another section or make further adjustments?
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Refactor to Backend
-focus: /shared/TasksController.ts
----
+# Interactive Tutorial - Basics - Backend Methods - Refactor to Backend
 
 # Refactor from Frontend to Backend
 
@@ -21775,24 +21702,7 @@ async function setAllCompleted(completed: boolean) {
 Click the "Set All Completed" and "Set All Uncompleted" buttons to see the improved performance with the backend method handling the updates.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Backend Methods
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Authentication and Authorization
-template: after-backend-methods
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Basics - Authentication & Authorization - Authentication and Authorization
 
 # Authentication and Authorization
 
@@ -21839,15 +21749,7 @@ export class TasksController {
 - We updated the `allowed` property in the `@BackendMethod` decorator to use `remult.authenticated`, ensuring that the `setAllCompleted` function requires an authenticated user to execute.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Authentication
-template: auth
-focus: /shared/AuthController.ts
----
+# Interactive Tutorial - Basics - Authentication & Authorization - Authentication
 
 ## Authentication
 
@@ -21999,15 +21901,7 @@ useEffect(() => {
 Try signing in as `Alex` or `Jane` and verify that you can perform CRUD operations on tasks. Sign out and ensure that you can no longer access the tasks.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Role-based Authorization
-template: auth-3
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Basics - Authentication & Authorization - Role-based Authorization
 
 ## Role-based Authorization
 
@@ -22084,15 +21978,7 @@ Sign in to the app as _"Alex"_ to test that actions restricted to `admin` users,
 Then, sign in as _"Jane"_ to confirm that these actions are permitted for admin users.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Role-based Authorization on the Frontend
-template: auth-3
-focus: /frontend/Todo.tsx
----
+# Interactive Tutorial - Basics - Authentication & Authorization - Role-based Authorization on the Frontend
 
 ## Role-based Authorization on the Frontend
 
@@ -22171,24 +22057,7 @@ By using these methods, we ensure that the frontend stays consistent with the AP
 Test the app by signing in as different users (e.g., as an admin and a regular user) and verify that the add and delete buttons appear or disappear based on the user's role.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Authentication & Authorization
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Database
-focus: /backend/index.ts
-template: after-backend-methods
----
+# Interactive Tutorial - Basics - Database - Database
 
 # Database
 
@@ -22225,33 +22094,7 @@ And that's it, now you use `sqlite` as the database.
 > Just don't forget to turn it off once you're done, to improve performance
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Database
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: part
-title: Basics
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Many to One
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Relations - Many to One
 
 # Relations
 
@@ -22322,15 +22165,7 @@ Here’s a polished version of the paragraph:
 Relations are seamlessly integrated into the [Remult Admin UI](https://remult.dev/docs/admin-ui). To explore how relations are displayed, simply click the "Remult Admin UI" link at the bottom.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: One to Many
-template: relations
-focus: /shared/Customer.ts
----
+# Interactive Tutorial - In Depth - Relations - One to Many
 
 # One to Many
 
@@ -22407,15 +22242,7 @@ In the Remult Admin UI, `one-to-many` relations are displayed directly within th
 To explore how this works, click the "Remult Admin UI" link at the bottom left of the interface.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Id Based Relations
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Relations - Id Based Relations
 
 # ID-Based Relations
 
@@ -22468,15 +22295,7 @@ By using ID-based relations, you have greater control over your data models and 
 Let me know if this works!
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Many to Many
-template: relations-with-products
-focus: /shared/ProductInOrder.ts
----
+# Interactive Tutorial - In Depth - Relations - Many to Many
 
 # Many-to-Many Relations
 
@@ -22541,24 +22360,7 @@ The reason is that most **many-to-many relationships** in real-world application
 In this lesson, we've learned how to model many-to-many relationships using an intermediate table. By creating the `ProductInOrder` entity, we've enabled a flexible many-to-many relationship between `Order` and `Product`. This approach allows us to include additional fields, such as quantity, in the relationship while maintaining optimal performance through the use of composite keys.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Relations
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Custom Filter
-template: relations
-focus: /frontend/Page.tsx
----
+# Interactive Tutorial - In Depth - Advanced Filtering - Custom Filter
 
 # Custom Filter
 
@@ -22655,15 +22457,7 @@ repo(Order).find({
 With composable custom filters, you can build modular, reusable filters that combine seamlessly with other conditions, making your code more flexible and maintainable. Whether you're filtering by status, date, or custom logic like order amount, custom filters allow you to easily manage complex queries with less effort.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Filter Based on Relation
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Advanced Filtering - Filter Based on Relation
 
 # Filter Based on Relation
 
@@ -22750,15 +22544,7 @@ Filtering based on relations is a common requirement in web applications, and cu
 The flexibility, efficiency, and composability of custom filters make them an essential tool for managing complex filtering scenarios in your applications.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Filter Based on Relation Using SQL
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Advanced Filtering - Filter Based on Relation Using SQL
 
 # Filter Based on Relation Using SQL
 
@@ -22935,15 +22721,7 @@ In this lesson, we've explored how to use raw SQL within custom filters to perfo
 By combining SQL-based filters with the power of Remult, you can create highly efficient and flexible filtering logic that runs on the backend, making it a powerful tool for building scalable and performant web applications.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Sql Relations Filter
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Advanced Filtering - Sql Relations Filter
 
 ### SQL Relations Filter
 
@@ -23027,24 +22805,7 @@ This SQL query:
 With `sqlRelationsFilter`, handling relation-based filtering in Remult becomes simpler, more efficient, and more powerful. Whether you’re working with large datasets or complex relational models, this utility helps you build queries that are both performant and easy to maintain.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Advanced Filtering
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Introduction
-template: relations
-focus: /shared/Customer.ts
----
+# Interactive Tutorial - In Depth - Sql Expression Entity Field - Introduction
 
 ### SQL Expressions for Entity Fields
 
@@ -23113,15 +22874,7 @@ In this query:
 With `sqlExpression` fields, you can incorporate powerful SQL computations into your entities, simplifying data aggregation and improving application performance. This feature is ideal for cases like summing order totals, calculating averages, or performing other backend-based calculations, all while keeping your code clean and efficient.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Getting a field from a relation
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Sql Expression Entity Field - Getting a field from a relation
 
 ### SQL Expressions for Fields Based on Relations
 
@@ -23190,15 +22943,7 @@ In this query:
 In this lesson, you’ve seen how `sqlExpression` can transform your data handling by enabling seamless access to fields from related entities. This feature is ideal for situations where you need to use related data for sorting, filtering, or displaying, all while keeping your code efficient and streamlined.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Sql Relations
-template: relations
-focus: /shared/Order.ts
----
+# Interactive Tutorial - In Depth - Sql Expression Entity Field - Sql Relations
 
 ### Leveraging `sqlRelations` for Advanced SQL-Based Relationships
 
@@ -23279,24 +23024,7 @@ For advanced calculations, such as summing up the total order amount for each cu
 This approach provides a powerful way to manage complex relationships and aggregations in Remult, bringing the flexibility of SQL into the realm of structured, type-safe TypeScript fields.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Sql Expression Entity Field
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Intro & Field-Level Authorization
-template: access-control
-focus: /shared/Task.ts
----
+# Interactive Tutorial - In Depth - Access Control - Intro & Field-Level Authorization
 
 # Field-Level Authorization in Remult
 
@@ -23421,15 +23149,7 @@ This flexibility with `includeInApi` allows you to apply fine-grained control ov
 By using `allowApiUpdate` and `includeInApi`, you have fine-grained control over which fields users can modify or view based on roles, data ownership, and custom conditions.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Row-Level Authorization
-template: access-control
-focus: /shared/Task.ts
----
+# Interactive Tutorial - In Depth - Access Control - Row-Level Authorization
 
 # Row-Level Authorization
 
@@ -23478,15 +23198,7 @@ Each of these options—`allowApiRead`, `allowApiInsert`, `allowApiDelete`, and 
 In the upcoming lesson, **"Filtering Rows Based on User Permissions"**, we’ll explore how to apply row-level access control dynamically, allowing each user to view only the rows they are permitted to access using specific filters.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Filtering Rows Based on User Permissions
-template: access-control
-focus: /shared/Task.ts
----
+# Interactive Tutorial - In Depth - Access Control - Filtering Rows Based on User Permissions
 
 # Filtering Rows Based on User Permissions
 
@@ -23536,15 +23248,7 @@ By switching between these accounts, you’ll observe how `apiPrefilter` limits 
 By combining `apiPrefilter` with row-specific rules in `allowApiUpdate`, `allowApiDelete`, and `allowApiInsert`, you gain a powerful framework for dynamic, row-level security based on user permissions. This approach protects data integrity and enhances security across various layers of application logic.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Filtering Related Rows Based on User Permissions
-template: access-control-2
-focus: /shared/TimeEntry.ts
----
+# Interactive Tutorial - In Depth - Access Control - Filtering Related Rows Based on User Permissions
 
 # Filtering Related Rows Based on User Permissions
 
@@ -23624,15 +23328,7 @@ To see this SQL-based filtering in action:
 Using SQL-based filters provides an optimized way to manage related access control by leveraging the database’s capabilities, especially useful when dealing with large datasets or complex access rules.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Sql Relations Filter for User Permissions
-template: access-control-2
-focus: /shared/TimeEntry.ts
----
+# Interactive Tutorial - In Depth - Access Control - Sql Relations Filter for User Permissions
 
 ### SQL Relations Filter for User Permissions
 
@@ -23676,24 +23372,7 @@ In this example, we want to ensure that users can only access `TimeEntry` rows a
 By leveraging `sqlRelationsFilter`, you can create highly performant and intuitive access control that directly uses SQL to enforce row-level permissions across related entities.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Access Control
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Field Metadata
-focus: /shared/Task.ts
-template: metadata
----
+# Interactive Tutorial - In Depth - Entities as a single source of truth - Field Metadata
 
 # Field Metadata
 
@@ -23819,15 +23498,7 @@ return (
 You can use these capabilities, together with the structured error model to create dynamic forms, dynamic grid and other dynamic uis that leverage
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Forms and Validation
-focus: /frontend/TodoItem.tsx
-template: metadata
----
+# Interactive Tutorial - In Depth - Entities as a single source of truth - Forms and Validation
 
 ### Forms and Validation
 
@@ -23987,14 +23658,7 @@ By utilizing field metadata, error handling, and dynamic rendering techniques, y
 Together, these strategies make it straightforward to construct forms and other UI components that are consistently styled, validated, and ready for reuse throughout the application.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Lifecycle Hooks
-focus: /shared/Task.ts
----
+# Interactive Tutorial - In Depth - Entities as a single source of truth - Lifecycle Hooks
 
 ## Introduction to Entity Lifecycle Hooks
 
@@ -24042,15 +23706,7 @@ For more information on how to leverage these hooks in your applications, refer 
 Click on the `Toggle Terminal` button on the right, make some changes to tasks, and observe the terminal output to see the messages generated in the saving and deleting hooks.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Select Fields
-focus: /shared/TaskLight.ts
-template: select-fields
----
+# Interactive Tutorial - In Depth - Entities as a single source of truth - Select Fields
 
 ## Introduction Select Fields
 
@@ -24085,15 +23741,7 @@ We showed that you can use `dbName` to point at an existing table in the databas
 You can also create a dynamic view, [Leveraging Database Capabilities with sqlExpression](https://remult.dev/docs/ref_entity#sqlexpression).
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Extend Entity (add fields)
-focus: /shared/TaskExtra.ts
-template: select-fields
----
+# Interactive Tutorial - In Depth - Entities as a single source of truth - Extend Entity (add fields)
 
 ## Introduction Extend Entity
 
@@ -24131,23 +23779,7 @@ await repo(TaskExtra).find()
 ```
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Entities as a single source of truth
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Introduction to Testing with Remult
-focus: /tests/validations.test.ts
----
+# Interactive Tutorial - In Depth - Testing - Introduction to Testing with Remult
 
 ---
 
@@ -24202,14 +23834,7 @@ In addition to in-memory testing, you can test with your actual database provide
 By using these techniques, you can write comprehensive tests covering all entity aspects, from validations to SQL expressions.
 
 
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Testing Api Rules
-focus: /tests/authorization.test.ts
----
+# Interactive Tutorial - In Depth - Testing - Testing Api Rules
 
 # Testing API Rules
 
@@ -24288,39 +23913,7 @@ For SQL-based tests, you can use the `SqlDatabase.LogToConsole = true` setting t
 Using these techniques allows you to simulate real API operations within tests, ensuring robust access control and proper handling of user permissions in your application.
 
 
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Testing
-template: tests
-previews: false
-terminal:
-  activePanel: 1
-  panels:
-    - ['output', 'Terminal']
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: part
-title: In Depth
-slug: in-depth
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: lesson
-title: Extending Existing Validations
-focus: /shared/Task.ts
----
+# Interactive Tutorial - Examples - Validations - Extending Existing Validations
 
 # Extending Existing Validations
 
@@ -24358,35 +23951,4 @@ export class Task {
 ### Try It Out
 
 Test this extended validation by trying to add tasks with duplicate titles. Notice that the validation prevents duplicates only when the title is not empty.
-
-
-
-# Interactive Tutorial - 
-
----
-type: chapter
-title: Validations
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: part
-title: Examples
----
-
-
-
-# Interactive Tutorial - 
-
----
-type: tutorial
-mainCommand: ['npm run dev', 'Starting http server']
-prepareCommands:
-  - ['npm install', 'Installing dependencies']
-editPageLink: https://github.com/remult/remult/blob/main/docs/interactive/src/content/tutorial/${path}?plain=1
----
-
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3979,6 +3979,41 @@ const logout = async () => {
 }
 ```
 
+## Remote Functions
+
+SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
+
+Here is the default doc example (zod & drizzle or valibot & prisma, ...):
+
+```ts
+import z from 'zod' // or valibot, ... any standard schema library
+import { query } from '$app/server'
+import * as db from '$lib/server/db' // with drizzle, prisma, pg, ... any database library
+
+export const getLikes = query(z.string(), async (id) => {
+  const [row] = await db.sql`select likes from item where id = ${id}`
+  return row.likes
+})
+```
+
+With remult library, you have both:
+
+- the database layer
+- the standard schema layer
+
+So you can replace the previous code with this:
+
+```ts [src/lib/server/functions.ts]
+import { std, repo } from 'remult'
+import { query } from '$app/server'
+import { Item } from '$lib/entities'
+
+export const getLikes = query(std(Item, 'id'), async (id) => {
+  const item = await repo(Item).findId(id)
+  return item.likes
+})
+```
+
 
 
 # Framework - Next.js
@@ -17869,6 +17904,41 @@ const logout = async () => {
     alert(error.message)
   }
 }
+```
+
+## Remote Functions
+
+SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
+
+Here is the default doc example (zod & drizzle or valibot & prisma, ...):
+
+```ts
+import z from 'zod' // or valibot, ... any standard schema library
+import { query } from '$app/server'
+import * as db from '$lib/server/db' // with drizzle, prisma, pg, ... any database library
+
+export const getLikes = query(z.string(), async (id) => {
+  const [row] = await db.sql`select likes from item where id = ${id}`
+  return row.likes
+})
+```
+
+With remult library, you have both:
+
+- the database layer
+- the standard schema layer
+
+So you can replace the previous code with this:
+
+```ts [src/lib/server/functions.ts]
+import { std, repo } from 'remult'
+import { query } from '$app/server'
+import { Item } from '$lib/entities'
+
+export const getLikes = query(std(Item, 'id'), async (id) => {
+  const item = await repo(Item).findId(id)
+  return item.likes
+})
 ```
 
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3979,7 +3979,7 @@ const logout = async () => {
 }
 ```
 
-## Remote Functions
+## Extra - Remote Functions
 
 SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
 
@@ -4004,15 +4004,17 @@ With remult library, you have both:
 So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
-import { std, repo } from 'remult'
 import { query } from '$app/server'
+import { standardSchema, repo } from 'remult'
 import { Item } from '$lib/entities'
 
-export const getLikes = query(std(Item, 'id'), async (id) => {
+export const getLikes = query(standardSchema(repo(Item), 'id'), async (id) => {
   const item = await repo(Item).findId(id)
   return item.likes
 })
 ```
+
+We are excited to see how you will use it 🚀
 
 
 
@@ -7716,7 +7718,7 @@ Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effec
 Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
 
 ```ts
-import { std, Entity, Fields } from 'remult'
+import { standardSchema, Entity, Fields, repo } from 'remult'
 
 @Entity('User')
 class User {
@@ -7731,7 +7733,7 @@ class User {
 }
 
 // Create a Standard Schema validator for the entire entity
-const userSchema = std(User)
+const userSchema = standardSchema(repo(User))
 
 // Validate data with any Standard Schema library
 const result = await validateWithAnyLibrary(userSchema, {
@@ -7752,13 +7754,13 @@ You can create validators that only check specific fields by passing field names
 
 ```ts
 // Validate only the age field
-const ageSchema = std(User, 'age')
+const ageSchema = standardSchema(repo(User), 'age')
 
 const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
 // Returns: { value: { age: 30 } }
 
 // Validate multiple specific fields
-const nameAndAgeSchema = std(User, 'name', 'age')
+const nameAndAgeSchema = standardSchema(repo(User), 'name', 'age')
 
 const result = await validateWithAnyLibrary(nameAndAgeSchema, {
   name: 'John Doe',
@@ -7785,7 +7787,7 @@ class UserMail {
 }
 
 // Email validation will be enforced
-const emailSchema = std(UserMail, 'email')
+const emailSchema = standardSchema(repo(UserMail), 'email')
 
 const result = await validateWithAnyLibrary(emailSchema, {
   email: 'invalid-email',
@@ -7820,7 +7822,7 @@ class Task {
   userId = ''
 }
 
-const taskSchema = std(Task)
+const taskSchema = standardSchema(repo(Task))
 
 const result = await validateWithAnyLibrary(taskSchema, {
   title: 'My Task',
@@ -17906,7 +17908,7 @@ const logout = async () => {
 }
 ```
 
-## Remote Functions
+## Extra - Remote Functions
 
 SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
 
@@ -17931,15 +17933,17 @@ With remult library, you have both:
 So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
-import { std, repo } from 'remult'
 import { query } from '$app/server'
+import { standardSchema, repo } from 'remult'
 import { Item } from '$lib/entities'
 
-export const getLikes = query(std(Item, 'id'), async (id) => {
+export const getLikes = query(standardSchema(repo(Item), 'id'), async (id) => {
   const item = await repo(Item).findId(id)
   return item.likes
 })
 ```
+
+We are excited to see how you will use it 🚀
 
 
 

--- a/docs/public/llms-small.txt
+++ b/docs/public/llms-small.txt
@@ -3979,6 +3979,41 @@ const logout = async () => {
 }
 ```
 
+## Remote Functions
+
+SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
+
+Here is the default doc example (zod & drizzle or valibot & prisma, ...):
+
+```ts
+import z from 'zod' // or valibot, ... any standard schema library
+import { query } from '$app/server'
+import * as db from '$lib/server/db' // with drizzle, prisma, pg, ... any database library
+
+export const getLikes = query(z.string(), async (id) => {
+  const [row] = await db.sql`select likes from item where id = ${id}`
+  return row.likes
+})
+```
+
+With remult library, you have both:
+
+- the database layer
+- the standard schema layer
+
+So you can replace the previous code with this:
+
+```ts [src/lib/server/functions.ts]
+import { std, repo } from 'remult'
+import { query } from '$app/server'
+import { Item } from '$lib/entities'
+
+export const getLikes = query(std(Item, 'id'), async (id) => {
+  const item = await repo(Item).findId(id)
+  return item.likes
+})
+```
+
 
 
 # Framework - Next.js
@@ -11763,6 +11798,41 @@ const logout = async () => {
     alert(error.message)
   }
 }
+```
+
+## Remote Functions
+
+SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
+
+Here is the default doc example (zod & drizzle or valibot & prisma, ...):
+
+```ts
+import z from 'zod' // or valibot, ... any standard schema library
+import { query } from '$app/server'
+import * as db from '$lib/server/db' // with drizzle, prisma, pg, ... any database library
+
+export const getLikes = query(z.string(), async (id) => {
+  const [row] = await db.sql`select likes from item where id = ${id}`
+  return row.likes
+})
+```
+
+With remult library, you have both:
+
+- the database layer
+- the standard schema layer
+
+So you can replace the previous code with this:
+
+```ts [src/lib/server/functions.ts]
+import { std, repo } from 'remult'
+import { query } from '$app/server'
+import { Item } from '$lib/entities'
+
+export const getLikes = query(std(Item, 'id'), async (id) => {
+  const item = await repo(Item).findId(id)
+  return item.likes
+})
 ```
 
 

--- a/docs/public/llms-small.txt
+++ b/docs/public/llms-small.txt
@@ -1519,10 +1519,6 @@ export class Contact {
 
 # Entities - Relations
 
----
-outline: [2, 3]
----
-
 # Relations Between Entities
 
 ::: tip **Interactive Learning Available! 🚀**
@@ -2364,7 +2360,6 @@ Utilizing an intermediate table for managing many-to-many relationships in Remul
 ---
 
 In this guide, we've explored the essential concepts of managing entity relations within the Remult library. From one-to-one to many-to-many relationships, we've covered the declaration, customization, and querying of these relations. By understanding the nuances of entity relations, users can harness the full potential of Remult to build robust TypeScript applications with ease.
-
 
 
 # Relations - Filtering and Relations
@@ -6967,14 +6962,6 @@ Accessing the underlying database directly in Remult provides the flexibility to
 
 # Escape Hatches - Using in Non-Remult Routes
 
----
-keywords:
-  [
-    Error: remult object was requested outside of a valid context,
-    try running it within initApi or a remult request cycle,
-  ]
----
-
 # Using Remult in Non-Remult Routes
 
 When using the CRUD api or [BackendMethods](./backendMethods.md), `remult` is automatically available. Still, there are many use cases where you may want to user remult in your own routes or other code without using `BackendMethods` but would still want to take advantage of `Remult` as an ORM and use it to check for user validity, etc...
@@ -7225,7 +7212,6 @@ import { remultApi } from 'remult/remult-hapi'
 :::
 
 
-
 # Escape Hatches - Avoiding Decorators
 
 # Working without decorators
@@ -7308,18 +7294,6 @@ This is the same backend method that is detailed in the [Backend methods of the 
 
 
 # Escape Hatches - Extensibility
-
----
-tags:
-  - options
-  - bespoke options
-  - customizing options
-  - type augmentation
-  - module augmentation
-  - UserInfo
-  - RemultContext
-  - context
----
 
 # Extensibility
 
@@ -7470,7 +7444,6 @@ or in an entity's saving event:
 ```
 
 By leveraging module augmentation, you can tailor Remult to your specific needs, adding custom options and extending interfaces to suit your application's requirements.
-
 
 
 # Integrations - Open API
@@ -7688,6 +7661,148 @@ const yogaApp = createYoga<RequestEvent>({
 
 export { yogaApp as GET, yogaApp as OPTIONS, yogaApp as POST }
 ```
+
+
+
+# Integrations - Standard Schema
+
+# Standard Schema
+
+Remult now supports the [Standard Schema](https://standardschema.dev/) specification, allowing you to use your Remult entities as type-safe validators that are compatible with any Standard Schema library.
+
+## Overview
+
+The Standard Schema specification provides a common interface for TypeScript validation libraries. By implementing this standard, Remult entities can be used as validators in any ecosystem that supports Standard Schema, making it easier to integrate with third-party tools and libraries.
+
+Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effect,... to your project, you can use Remult entities as validators with any library that supports the Standard Schema specification.
+
+## Basic Usage
+
+Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
+
+```ts
+import { std, Entity, Fields } from 'remult'
+
+@Entity('User')
+class User {
+  @Fields.id()
+  id!: string
+
+  @Fields.string({ required: true })
+  name!: string
+
+  @Fields.number()
+  age?: number
+}
+
+// Create a Standard Schema validator for the entire entity
+const userSchema = std(User)
+
+// Validate data with any Standard Schema library
+const result = await validateWithAnyLibrary(userSchema, {
+  name: 'John Doe',
+  age: 30,
+})
+
+if (result.issues) {
+  console.log('Validation errors:', result.issues)
+} else {
+  console.log('Valid data:', result.value)
+}
+```
+
+## Field-Specific Validation
+
+You can create validators that only check specific fields by passing field names as additional arguments:
+
+```ts
+// Validate only the age field
+const ageSchema = std(User, 'age')
+
+const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
+// Returns: { value: { age: 30 } }
+
+// Validate multiple specific fields
+const nameAndAgeSchema = std(User, 'name', 'age')
+
+const result = await validateWithAnyLibrary(nameAndAgeSchema, {
+  name: 'John Doe',
+  age: 30,
+  id: 'ignored', // This will be filtered out
+})
+// Returns: { value: { name: 'John Doe', age: 30 } }
+```
+
+## Validation with Custom Rules
+
+The Standard Schema validator respects all your entity's validation rules, including custom validators and entity-level validation:
+
+```ts
+import { Validators } from 'remult'
+
+@Entity('UserMail')
+class UserMail {
+  @Fields.string({ validate: [Validators.email] })
+  email!: string
+
+  @Fields.string()
+  job = ''
+}
+
+// Email validation will be enforced
+const emailSchema = std(UserMail, 'email')
+
+const result = await validateWithAnyLibrary(emailSchema, {
+  email: 'invalid-email',
+})
+// Returns: { issues: [{ message: 'Invalid Email', path: ['email'] }] }
+
+const validResult = await validateWithAnyLibrary(emailSchema, {
+  email: 'user@example.com',
+})
+// Returns: { value: { email: 'user@example.com' } }
+```
+
+## Entity-Level Validation
+
+Entity-level validation is also supported:
+
+```ts
+@Entity('Task', {
+  validation(item) {
+    if (item.userId && !item.userId.startsWith('user:')) {
+      throw new Error(
+        `Task ${item.title} must be assigned with someone starting with [user:]`,
+      )
+    }
+  },
+})
+class Task {
+  @Fields.string()
+  title = ''
+
+  @Fields.string({ required: true })
+  userId = ''
+}
+
+const taskSchema = std(Task)
+
+const result = await validateWithAnyLibrary(taskSchema, {
+  title: 'My Task',
+  userId: '123', // Invalid format
+})
+// Returns: { issues: [{ message: 'Task My Task must be assigned with someone starting with [user:]', path: [] }] }
+```
+
+## Benefits
+
+- **Interoperability**: Use Remult entities with any Standard Schema compatible library
+- **Type Safety**: Full TypeScript support with inferred types
+- **Consistency**: Same validation rules across your entire application
+- **Flexibility**: Validate entire entities or specific fields
+- **Standards Compliance**: Follows the official Standard Schema specification
+
+The Standard Schema integration makes Remult entities more versatile and easier to integrate with the broader TypeScript ecosystem while maintaining all the benefits of Remult's validation system.
 
 
 
@@ -8376,12 +8491,12 @@ inputType = 'date';
 
 # Validation
 
-Validation is a key part of any application, and you will see that it's builtin Remult ! Let's dive into it...
+Validation is a key part of any application, and you will see that it's builtin Remult !
 
 First of all, some props brings automatic validation, for example `required` and `minLength` for strings :
 
 ```ts
-@Fields.string({ minLength: 5 })
+@Fields.string({ required: true, minLength: 5 })
 title = ''
 ```
 
@@ -8467,6 +8582,10 @@ If you want to customize the error message, you can do it globally :
 ```ts
 Validators.unique.defaultMessage = 'Existe déjà!'
 ```
+
+::: tip
+Remult entities can also be used as [Standard Schema](./standard-schema.md) compatible validators, making them interoperable with other validation libraries.
+:::
 
 
 
@@ -9714,14 +9833,6 @@ remultApi({
 
 # API Reference - EntityFilter
 
----
-tags:
-  - Where
-  - Filter
-  - Entity Where
-  - Entity Filter
----
-
 # EntityFilter
 
 Used to filter the desired result set
@@ -9860,7 +9971,6 @@ where: {
   }
 }
 ```
-
 
 
 # API Reference - EntityMetadata
@@ -11193,13 +11303,7 @@ Arguments:
 
 
 
-# Remult Blog - Introducing Remult
-
----
-title: "Introducing Remult: The Backend to Frontend Framework You Always Wanted"
-sidebar: false
-editLink: false
----
+# Introducing Remult: The Backend to Frontend Framework You Always Wanted
 
 > March 14, 2023 | Noam Honig
 
@@ -11274,7 +11378,6 @@ So we open sourced the framework, to enable other lazy developers like us to be 
 Check out [Remult](https://remult.dev), and if you like it, give it a star.  Let us know what you’d like to see next, and also feel free to contribute to the project.
 
 In our next post, we’ll do a roundup of tools in the ecosystem looking to solve similar challenges though different approaches, and unpack where Remult fits in, and what it’s optimized for.
-
 
 
 # SvelteKit - Tutorial - Go further / Extra

--- a/docs/public/llms-small.txt
+++ b/docs/public/llms-small.txt
@@ -3979,7 +3979,7 @@ const logout = async () => {
 }
 ```
 
-## Remote Functions
+## Extra - Remote Functions
 
 SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
 
@@ -4004,15 +4004,17 @@ With remult library, you have both:
 So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
-import { std, repo } from 'remult'
 import { query } from '$app/server'
+import { standardSchema, repo } from 'remult'
 import { Item } from '$lib/entities'
 
-export const getLikes = query(std(Item, 'id'), async (id) => {
+export const getLikes = query(standardSchema(repo(Item), 'id'), async (id) => {
   const item = await repo(Item).findId(id)
   return item.likes
 })
 ```
+
+We are excited to see how you will use it 🚀
 
 
 
@@ -7716,7 +7718,7 @@ Beside the `remult` ORM part, you don't need to add zod, valibot, ArkType, Effec
 Import the `std` function from Remult and use it to create a Standard Schema compatible validator from any entity:
 
 ```ts
-import { std, Entity, Fields } from 'remult'
+import { standardSchema, Entity, Fields, repo } from 'remult'
 
 @Entity('User')
 class User {
@@ -7731,7 +7733,7 @@ class User {
 }
 
 // Create a Standard Schema validator for the entire entity
-const userSchema = std(User)
+const userSchema = standardSchema(repo(User))
 
 // Validate data with any Standard Schema library
 const result = await validateWithAnyLibrary(userSchema, {
@@ -7752,13 +7754,13 @@ You can create validators that only check specific fields by passing field names
 
 ```ts
 // Validate only the age field
-const ageSchema = std(User, 'age')
+const ageSchema = standardSchema(repo(User), 'age')
 
 const result = await validateWithAnyLibrary(ageSchema, { age: 30 })
 // Returns: { value: { age: 30 } }
 
 // Validate multiple specific fields
-const nameAndAgeSchema = std(User, 'name', 'age')
+const nameAndAgeSchema = standardSchema(repo(User), 'name', 'age')
 
 const result = await validateWithAnyLibrary(nameAndAgeSchema, {
   name: 'John Doe',
@@ -7785,7 +7787,7 @@ class UserMail {
 }
 
 // Email validation will be enforced
-const emailSchema = std(UserMail, 'email')
+const emailSchema = standardSchema(repo(UserMail), 'email')
 
 const result = await validateWithAnyLibrary(emailSchema, {
   email: 'invalid-email',
@@ -7820,7 +7822,7 @@ class Task {
   userId = ''
 }
 
-const taskSchema = std(Task)
+const taskSchema = standardSchema(repo(Task))
 
 const result = await validateWithAnyLibrary(taskSchema, {
   title: 'My Task',
@@ -11800,7 +11802,7 @@ const logout = async () => {
 }
 ```
 
-## Remote Functions
+## Extra - Remote Functions
 
 SvelteKit is introducing a new feature called [Remote Functions](https://github.com/sveltejs/kit/discussions/13897). It's early, but we want to see how it integrates with Remult.
 
@@ -11825,14 +11827,16 @@ With remult library, you have both:
 So you can replace the previous code with this:
 
 ```ts [src/lib/server/functions.ts]
-import { std, repo } from 'remult'
 import { query } from '$app/server'
+import { standardSchema, repo } from 'remult'
 import { Item } from '$lib/entities'
 
-export const getLikes = query(std(Item, 'id'), async (id) => {
+export const getLikes = query(standardSchema(repo(Item), 'id'), async (id) => {
   const item = await repo(Item).findId(id)
   return item.likes
 })
 ```
+
+We are excited to see how you will use it 🚀
 
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3137,6 +3137,14 @@ export interface SqlResult {
   rows: any[]
   getColumnKeyInResultForIndexInSelect(index: number): string
 }
+export declare function standardSchema<
+  entityType,
+  fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],
+>(
+  repo: Repository<entityType>,
+  ...fields: fieldsType
+): RemultEntitySchema<entityType, fieldsType>
+//[ ] RemultEntitySchema from TBD is not exported
 export interface StoredQuery {
   entityKey: string
   id: string

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -56,6 +56,7 @@ export {
   IdMetadata,
   FindFirstOptionsBase,
 } from './src/remult3/remult3.js'
+export { standardSchema } from './src/standard-schema/index.js'
 export {
   EntityBase,
   ControllerBase,

--- a/projects/core/src/standard-schema/StandardSchemaV1.ts
+++ b/projects/core/src/standard-schema/StandardSchemaV1.ts
@@ -1,0 +1,73 @@
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1
+    /** The vendor name of the schema library. */
+    readonly vendor: string
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+    ) => Result<Output> | Promise<Result<Output>>
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output
+    /** The non-existent issues. */
+    readonly issues?: undefined
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input
+    /** The output type of the schema. */
+    readonly output: Output
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['input']
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['output']
+
+  // biome-ignore lint/complexity/noUselessEmptyExport: needed for granular visibility control of TS namespace
+  export {}
+}

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -15,44 +15,34 @@ interface RemultEntitySchema<entityType, fields extends string[] = []>
 
 export function std<
   entityType,
-  fields extends Extract<keyof MembersOnly<entityType>, string>[] = [],
+  fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],
 >(
   entity: ClassType<entityType>,
-  ...fields: fields
-): RemultEntitySchema<entityType, fields> {
+  ...fields: fieldsType
+): RemultEntitySchema<entityType, fieldsType> {
   return {
     '~standard': {
       version: 1,
       vendor: 'remult',
       async validate(value) {
-        try {
-          const item = value as Partial<entityType>
-          const error = await repo(entity).validate(item, ...fields)
-          if (error) {
-            const issues: Array<StandardSchemaV1.Issue> = []
+        const item = value as Partial<entityType>
+        const error = await repo(entity).validate(item, ...fields)
+        if (error) {
+          const issues: Array<StandardSchemaV1.Issue> = []
 
-            if (error.modelState) {
-              for (const [key, message] of Object.entries(error.modelState)) {
-                issues.push({
-                  message: message as string,
-                  path: [key],
-                })
-              }
+          if (error.modelState) {
+            for (const [key, message] of Object.entries(error.modelState)) {
+              issues.push({
+                message: message as string,
+                path: [key],
+              })
             }
-
-            if (issues.length === 0 && error.message) {
-              issues.push({ message: error.message, path: [] })
-            }
-
-            return { issues }
           }
 
-          // Return the item with proper type assertion
-          return { value: item as OutputType<entityType, fields> }
-        } catch (e) {
-          let errorMessage = 'Validation error occurred'
-          return { issues: [{ message: errorMessage, path: [] }] }
+          return { issues }
         }
+
+        return { value: item as OutputType<entityType, fieldsType> }
       },
     },
   }

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -1,5 +1,4 @@
-import type { ClassType, MembersOnly } from '../../index.js'
-import { EntityError, repo } from '../../index.js'
+import type { MembersOnly, Repository } from '../../index.js'
 import type { StandardSchemaV1 } from './StandardSchemaV1.js'
 
 // Conditional type for output based on whether fields are provided
@@ -13,11 +12,11 @@ interface RemultEntitySchema<entityType, fields extends string[] = []>
     OutputType<entityType, fields>
   > {}
 
-export function std<
+export function standardSchema<
   entityType,
   fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],
 >(
-  entity: ClassType<entityType>,
+  repo: Repository<entityType>,
   ...fields: fieldsType
 ): RemultEntitySchema<entityType, fieldsType> {
   return {
@@ -27,7 +26,7 @@ export function std<
       async validate(value) {
         const item = value as Partial<entityType>
         try {
-          const error = await repo(entity).validate(item, ...fields)
+          const error = await repo.validate(item, ...fields)
           if (error && error.modelState) {
             return {
               issues: Object.entries(error.modelState).map(

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -27,21 +27,14 @@ export function std<
       async validate(value) {
         const item = value as Partial<entityType>
         const error = await repo(entity).validate(item, ...fields)
-        if (error) {
-          const issues: Array<StandardSchemaV1.Issue> = []
-
-          if (error.modelState) {
-            for (const [key, message] of Object.entries(error.modelState)) {
-              issues.push({
-                message: message as string,
-                path: [key],
-              })
-            }
+        if (error && error.modelState) {
+          return {
+            issues: Object.entries(error.modelState).map(([key, message]) => ({
+              message: message as string,
+              path: [key],
+            })),
           }
-
-          return { issues }
         }
-
         return { value: item as OutputType<entityType, fieldsType> }
       },
     },

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -43,6 +43,16 @@ export function std<
             return { issues: [{ message: err.message, path: [] }] }
           }
         }
+
+        if (fields.length > 0) {
+          const filteredItem = {}
+          for (const field of fields) {
+            if (field in item) {
+              filteredItem[field] = item[field] as any
+            }
+          }
+          return { value: filteredItem as OutputType<entityType, fieldsType> }
+        }
         return { value: item as OutputType<entityType, fieldsType> }
       },
     },

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -12,6 +12,21 @@ interface RemultEntitySchema<entityType, fields extends string[] = []>
     OutputType<entityType, fields>
   > {}
 
+/**
+ * Implementation of the [Standard Schema](https://standardschema.dev/) specification
+ *
+ * @usage
+ * ```ts
+ * // The schema for the entire entity
+ * const schema = standardSchema(repo(User))
+ *
+ * // The schema for a specific field
+ * const schema = standardSchema(repo(User), 'id')
+ *
+ * // The schema for multiple fields
+ * const schema = standardSchema(repo(User), 'name', 'age')
+ * ```
+ */
 export function standardSchema<
   entityType,
   fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -1,6 +1,7 @@
 import type { ClassType } from '../../index.js'
 import { repo } from '../../index.js'
 import type { StandardSchemaV1 } from './StandardSchemaV1.js'
+import type { EntityError } from '../../index.js'
 
 // Step 1: Define the schema interface
 interface RemultEnititySchema<entityType>
@@ -19,16 +20,57 @@ export function v<entityType>(
           const item = value as Partial<entityType>
           const error = await repo(e).validate(item)
           if (error) {
-            return { issues: [{ message: 'Invalid', path: [] }] }
+            // Extract field-specific errors from modelState
+            const issues: Array<{
+              message: string
+              path: ReadonlyArray<string | number | symbol>
+            }> = []
+
+            if (error.modelState) {
+              // Add field-specific errors with proper paths
+              for (const [fieldName, fieldError] of Object.entries(
+                error.modelState,
+              )) {
+                if (fieldError) {
+                  issues.push({
+                    message: fieldError as string,
+                    path: [fieldName],
+                  })
+                }
+              }
+            }
+
+            // If no field-specific errors but we have a general message, add it
+            if (issues.length === 0 && error.message) {
+              issues.push({
+                message: error.message,
+                path: [],
+              })
+            }
+
+            // Fallback if no specific errors are available
+            if (issues.length === 0) {
+              issues.push({
+                message: 'Validation failed',
+                path: [],
+              })
+            }
+
+            return { issues }
           }
           return { value: item }
         } catch (e) {
-          return { issues: [{ message: 'Invalid', path: [] }] }
+          let errorMessage = 'Validation error occurred'
+
+          return {
+            issues: [
+              {
+                message: errorMessage,
+                path: [],
+              },
+            ],
+          }
         }
-      },
-      types: {
-        input: {} as Partial<entityType>,
-        output: {} as Partial<entityType>,
       },
     },
   }

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -1,0 +1,35 @@
+import type { ClassType } from '../../index.js'
+import { repo } from '../../index.js'
+import type { StandardSchemaV1 } from './StandardSchemaV1.js'
+
+// Step 1: Define the schema interface
+interface RemultEnititySchema<entityType>
+  extends StandardSchemaV1<Partial<entityType>, Partial<entityType>> {}
+
+// Step 2: Implement the schema interface
+export function v<entityType>(
+  e: ClassType<entityType>,
+): RemultEnititySchema<entityType> {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'remult',
+      async validate(value) {
+        try {
+          const item = value as Partial<entityType>
+          const error = await repo(e).validate(item)
+          if (error) {
+            return { issues: [{ message: 'Invalid', path: [] }] }
+          }
+          return { value: item }
+        } catch (e) {
+          return { issues: [{ message: 'Invalid', path: [] }] }
+        }
+      },
+      types: {
+        input: {} as Partial<entityType>,
+        output: {} as Partial<entityType>,
+      },
+    },
+  }
+}

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -1,15 +1,13 @@
-import type { ClassType } from '../../index.js'
+import type { ClassType, MembersOnly } from '../../index.js'
 import { repo } from '../../index.js'
 import type { StandardSchemaV1 } from './StandardSchemaV1.js'
-import type { EntityError } from '../../index.js'
 
-// Step 1: Define the schema interface
 interface RemultEnititySchema<entityType>
   extends StandardSchemaV1<Partial<entityType>, Partial<entityType>> {}
 
-// Step 2: Implement the schema interface
-export function v<entityType>(
-  e: ClassType<entityType>,
+export function std<entityType>(
+  entity: ClassType<entityType>,
+  ...fields: Extract<keyof MembersOnly<entityType>, string>[]
 ): RemultEnititySchema<entityType> {
   return {
     '~standard': {
@@ -18,7 +16,7 @@ export function v<entityType>(
       async validate(value) {
         try {
           const item = value as Partial<entityType>
-          const error = await repo(e).validate(item)
+          const error = await repo(entity).validate(item, ...fields)
           if (error) {
             // Extract field-specific errors from modelState
             const issues: Array<{

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -61,46 +61,40 @@ describe('standard-schema', () => {
     })
   })
 
-  it('mail - not ok', async () => {
+  describe('mail', () => {
     @Entity('UserMail')
     class UserMail {
       @Fields.string({ validate: [Validators.email] })
       email!: string
-    }
-
-    const schema = std(UserMail, 'email')
-    const nok_mail = { email: 'aAa' }
-
-    const result = await schema['~standard'].validate(nok_mail)
-    expect(result).toEqual({
-      issues: [{ message: 'Invalid Email', path: ['email'] }],
-    })
-  })
-
-  it('mail - ok', async () => {
-    @Entity('UserMail')
-    class UserMail {
-      @Fields.string({ validate: [Validators.email] })
-      email!: string
-
       @Fields.string()
       job = ''
     }
+    it('not ok', async () => {
+      const schema = std(UserMail, 'email')
+      const nok_mail = { email: 'aAa' }
 
-    const schema = std(UserMail, 'email')
-    const nok_mail = { email: 'j@tt.fr' }
+      const result = await schema['~standard'].validate(nok_mail)
+      expect(result).toEqual({
+        issues: [{ message: 'Invalid Email', path: ['email'] }],
+      })
+    })
 
-    const result = await schema['~standard'].validate(nok_mail)
+    it('ok', async () => {
+      const schema = std(UserMail, 'email')
+      const nok_mail = { email: 'j@tt.fr' }
 
-    if (result.issues) {
-      // manage the issue
-      expect('to never').toBe('here')
-    } else {
-      expect(result.value.email).toEqual('j@tt.fr')
-    }
+      const result = await schema['~standard'].validate(nok_mail)
+
+      if (result.issues) {
+        // manage the issue
+        expect('to never').toBe('here')
+      } else {
+        expect(result.value.email).toEqual('j@tt.fr')
+      }
+    })
   })
 
-  it('mail - not ok', async () => {
+  it('field throw', async () => {
     @Entity('UserMail')
     class UserMail {
       @Fields.string({
@@ -160,7 +154,7 @@ describe('standard-schema', () => {
       expect(result).toEqual({ value: ok })
     })
 
-    it('should check only userId', async () => {
+    it('should check only userId (even if entity validation is NOT OK)', async () => {
       const schema = std(ETask, 'userId')
       const nok = { title: 'aAa', userId: '123' }
 

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -99,4 +99,24 @@ describe('standard-schema', () => {
       expect(result.value.email).toEqual('j@tt.fr')
     }
   })
+
+  it('mail - not ok', async () => {
+    @Entity('UserMail')
+    class UserMail {
+      @Fields.string({
+        validate: (v) => {
+          throw new Error('test')
+        },
+      })
+      email!: string
+    }
+
+    const schema = std(UserMail, 'email')
+    const nok_mail = { email: 'aAa' }
+
+    const result = await schema['~standard'].validate(nok_mail)
+    expect(result).toEqual({
+      issues: [{ message: 'test', path: ['email'] }],
+    })
+  })
 })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -91,10 +91,12 @@ describe('standard-schema', () => {
     const nok_mail = { email: 'j@tt.fr' }
 
     const result = await schema['~standard'].validate(nok_mail)
-    if ('value' in result) {
-      expect(result.value.email).toEqual('j@tt.fr')
-    } else {
+
+    if (result.issues) {
+      // manage the issue
       expect('to never').toBe('here')
+    } else {
+      expect(result.value.email).toEqual('j@tt.fr')
     }
   })
 })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { v } from '../core/src/standard-schema/index.js'
+import { Entity, Field, Fields, repo, Validators } from '../core/index.js'
+
+describe('standard-schema', () => {
+  it('should validate valid entity data', async () => {
+    @Entity('User')
+    class User {
+      @Fields.string({ required: true })
+      name!: string
+
+      @Fields.number()
+      age?: number
+    }
+
+    const schema = v(User)
+    const validUser = { name: 'John Doe', age: 30 }
+    const result = await schema['~standard'].validate(validUser)
+
+    expect(result).toEqual({
+      value: validUser,
+    })
+  })
+
+  it('should reject invalid entity data', async () => {
+    @Entity('User')
+    class User {
+      @Fields.string({ required: true })
+      name!: string
+
+      @Fields.number()
+      age?: number
+    }
+
+    const schema = v(User)
+    const invalidUser = { name: '', age: 30 } // Empty name should fail validation
+    const result = await schema['~standard'].validate(invalidUser)
+
+    expect(result).toEqual({
+      issues: [{ message: 'Invalid', path: [] }],
+    })
+  })
+
+  it('should handle missing required fields', async () => {
+    @Entity('User')
+    class User {
+      @Fields.string({ required: true })
+      name!: string
+    }
+
+    const schema = v(User)
+    const invalidUser = {} // Missing required name field
+    const result = await schema['~standard'].validate(invalidUser)
+
+    expect(result).toEqual({
+      issues: [{ message: 'Invalid', path: [] }],
+    })
+  })
+
+  it('should validate partial entity data', async () => {
+    @Entity('User')
+    class User {
+      @Fields.string({ required: true })
+      name!: string
+
+      @Fields.string()
+      email?: string
+    }
+
+    const schema = v(User)
+    const partialUser = { name: 'Jane Doe' } // Only name, email is optional
+    const result = await schema['~standard'].validate(partialUser)
+
+    expect(result).toEqual({
+      value: partialUser,
+    })
+  })
+
+  it('should demonstrate type safety with schema types', async () => {
+    @Entity('Product')
+    class Product {
+      @Fields.string({ required: true })
+      name!: string
+
+      @Fields.number()
+      price?: number
+    }
+
+    const schema = v(Product)
+
+    // TypeScript should provide proper type inference
+    type SchemaInput = NonNullable<
+      (typeof schema)['~standard']['types']
+    >['input']
+    type SchemaOutput = NonNullable<
+      (typeof schema)['~standard']['types']
+    >['output']
+
+    // These types should be Partial<Product>
+    const _input: SchemaInput = { name: 'Test Product' }
+    const _output: SchemaOutput = { name: 'Test Product', price: 100 }
+
+    // Test that the schema works with the inferred types
+    const result = await schema['~standard'].validate(_input)
+
+    if ('value' in result) {
+      // result.value should be typed as Partial<Product>
+      expect(typeof result.value.name).toBe('string')
+    }
+  })
+})

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -4,6 +4,9 @@ import { Entity, Field, Fields, repo, Validators } from '../core/index.js'
 
 @Entity('User')
 class User {
+  @Fields.id()
+  id!: string
+
   @Fields.string({ required: true })
   name!: string
 
@@ -55,6 +58,22 @@ describe('standard-schema', () => {
     const result = await schema['~standard'].validate(nok_age)
     expect(result).toEqual({
       issues: [{ message: 'Invalid value', path: ['age'] }],
+    })
+  })
+
+  it('mail', async () => {
+    @Entity('UserMail')
+    class UserMail {
+      @Fields.string({ validate: [Validators.email] })
+      email!: string
+    }
+
+    const schema = std(UserMail, 'email')
+    const nok_mail = { email: 'aAa' }
+
+    const result = await schema['~standard'].validate(nok_mail)
+    expect(result).toEqual({
+      issues: [{ message: 'Invalid Email', path: ['email'] }],
     })
   })
 })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -61,7 +61,7 @@ describe('standard-schema', () => {
     })
   })
 
-  it('mail', async () => {
+  it('mail not ok', async () => {
     @Entity('UserMail')
     class UserMail {
       @Fields.string({ validate: [Validators.email] })
@@ -75,5 +75,26 @@ describe('standard-schema', () => {
     expect(result).toEqual({
       issues: [{ message: 'Invalid Email', path: ['email'] }],
     })
+  })
+
+  it('mail ok', async () => {
+    @Entity('UserMail')
+    class UserMail {
+      @Fields.string({ validate: [Validators.email] })
+      email!: string
+
+      @Fields.string()
+      job = ''
+    }
+
+    const schema = std(UserMail, 'email')
+    const nok_mail = { email: 'j@tt.fr' }
+
+    const result = await schema['~standard'].validate(nok_mail)
+    if ('value' in result) {
+      expect(result.value.email).toEqual('j@tt.fr')
+    } else {
+      expect('to never').toBe('here')
+    }
   })
 })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -37,7 +37,7 @@ describe('standard-schema', () => {
     const result = await schema['~standard'].validate(invalidUser)
 
     expect(result).toEqual({
-      issues: [{ message: 'Invalid', path: [] }],
+      issues: [{ message: 'Should not be empty', path: ['name'] }],
     })
   })
 
@@ -53,7 +53,7 @@ describe('standard-schema', () => {
     const result = await schema['~standard'].validate(invalidUser)
 
     expect(result).toEqual({
-      issues: [{ message: 'Invalid', path: [] }],
+      issues: [{ message: 'Should not be empty', path: ['name'] }],
     })
   })
 

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -1,111 +1,60 @@
 import { describe, expect, it } from 'vitest'
-import { v } from '../core/src/standard-schema/index.js'
+import { std } from '../core/src/standard-schema/index.js'
 import { Entity, Field, Fields, repo, Validators } from '../core/index.js'
+
+@Entity('User')
+class User {
+  @Fields.string({ required: true })
+  name!: string
+
+  @Fields.number()
+  age?: number
+}
 
 describe('standard-schema', () => {
   it('should validate valid entity data', async () => {
-    @Entity('User')
-    class User {
-      @Fields.string({ required: true })
-      name!: string
+    const schema = std(User)
+    const ok = { name: 'John Doe', age: 30 }
 
-      @Fields.number()
-      age?: number
-    }
-
-    const schema = v(User)
-    const validUser = { name: 'John Doe', age: 30 }
-    const result = await schema['~standard'].validate(validUser)
-
-    expect(result).toEqual({
-      value: validUser,
-    })
+    const result = await schema['~standard'].validate(ok)
+    expect(result).toEqual({ value: ok })
   })
 
   it('should reject invalid entity data', async () => {
-    @Entity('User')
-    class User {
-      @Fields.string({ required: true })
-      name!: string
+    const schema = std(User)
+    const nok = { name: '', age: 30 }
 
-      @Fields.number()
-      age?: number
-    }
-
-    const schema = v(User)
-    const invalidUser = { name: '', age: 30 } // Empty name should fail validation
-    const result = await schema['~standard'].validate(invalidUser)
-
+    const result = await schema['~standard'].validate(nok)
     expect(result).toEqual({
       issues: [{ message: 'Should not be empty', path: ['name'] }],
     })
   })
 
   it('should handle missing required fields', async () => {
-    @Entity('User')
-    class User {
-      @Fields.string({ required: true })
-      name!: string
-    }
+    const schema = std(User)
+    const nok = {}
 
-    const schema = v(User)
-    const invalidUser = {} // Missing required name field
-    const result = await schema['~standard'].validate(invalidUser)
-
+    const result = await schema['~standard'].validate(nok)
     expect(result).toEqual({
       issues: [{ message: 'Should not be empty', path: ['name'] }],
     })
   })
 
-  it('should validate partial entity data', async () => {
-    @Entity('User')
-    class User {
-      @Fields.string({ required: true })
-      name!: string
+  it('only checking age', async () => {
+    const schema = std(User, 'age')
+    const ok_age = { age: 30 }
 
-      @Fields.string()
-      email?: string
-    }
-
-    const schema = v(User)
-    const partialUser = { name: 'Jane Doe' } // Only name, email is optional
-    const result = await schema['~standard'].validate(partialUser)
-
-    expect(result).toEqual({
-      value: partialUser,
-    })
+    const result = await schema['~standard'].validate(ok_age)
+    expect(result).toEqual({ value: ok_age })
   })
 
-  it('should demonstrate type safety with schema types', async () => {
-    @Entity('Product')
-    class Product {
-      @Fields.string({ required: true })
-      name!: string
+  it('age with wrong type', async () => {
+    const schema = std(User, 'age')
+    const nok_age = { age: 'aAa' }
 
-      @Fields.number()
-      price?: number
-    }
-
-    const schema = v(Product)
-
-    // TypeScript should provide proper type inference
-    type SchemaInput = NonNullable<
-      (typeof schema)['~standard']['types']
-    >['input']
-    type SchemaOutput = NonNullable<
-      (typeof schema)['~standard']['types']
-    >['output']
-
-    // These types should be Partial<Product>
-    const _input: SchemaInput = { name: 'Test Product' }
-    const _output: SchemaOutput = { name: 'Test Product', price: 100 }
-
-    // Test that the schema works with the inferred types
-    const result = await schema['~standard'].validate(_input)
-
-    if ('value' in result) {
-      // result.value should be typed as Partial<Product>
-      expect(typeof result.value.name).toBe('string')
-    }
+    const result = await schema['~standard'].validate(nok_age)
+    expect(result).toEqual({
+      issues: [{ message: 'Invalid value', path: ['age'] }],
+    })
   })
 })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -51,7 +51,7 @@ describe('standard-schema', () => {
     expect(result).toEqual({ value: ok_age })
   })
 
-  it('age with wrong type', async () => {
+  it('age - wrong type', async () => {
     const schema = std(User, 'age')
     const nok_age = { age: 'aAa' }
 
@@ -61,7 +61,7 @@ describe('standard-schema', () => {
     })
   })
 
-  it('mail not ok', async () => {
+  it('mail - not ok', async () => {
     @Entity('UserMail')
     class UserMail {
       @Fields.string({ validate: [Validators.email] })
@@ -77,7 +77,7 @@ describe('standard-schema', () => {
     })
   })
 
-  it('mail ok', async () => {
+  it('mail - ok', async () => {
     @Entity('UserMail')
     class UserMail {
       @Fields.string({ validate: [Validators.email] })

--- a/projects/tests/standard-schema.spec.ts
+++ b/projects/tests/standard-schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { std } from '../core/src/standard-schema/index.js'
+import { standardSchema } from '../core/src/standard-schema/index.js'
 import { Entity, Field, Fields, repo, Validators } from '../core/index.js'
 
 @Entity('User')
@@ -16,7 +16,7 @@ class User {
 
 describe('standard-schema', () => {
   it('should validate valid entity data', async () => {
-    const schema = std(User)
+    const schema = standardSchema(repo(User))
     const ok = { name: 'John Doe', age: 30 }
 
     const result = await schema['~standard'].validate(ok)
@@ -24,7 +24,7 @@ describe('standard-schema', () => {
   })
 
   it('should reject invalid entity data', async () => {
-    const schema = std(User)
+    const schema = standardSchema(repo(User))
     const nok = { name: '', age: 30 }
 
     const result = await schema['~standard'].validate(nok)
@@ -34,7 +34,7 @@ describe('standard-schema', () => {
   })
 
   it('should handle missing required fields', async () => {
-    const schema = std(User)
+    const schema = standardSchema(repo(User))
     const nok = {}
 
     const result = await schema['~standard'].validate(nok)
@@ -44,7 +44,7 @@ describe('standard-schema', () => {
   })
 
   it('only checking age', async () => {
-    const schema = std(User, 'age')
+    const schema = standardSchema(repo(User), 'age')
     const ok_age = { age: 30 }
 
     const result = await schema['~standard'].validate(ok_age)
@@ -52,7 +52,7 @@ describe('standard-schema', () => {
   })
 
   it('age - wrong type', async () => {
-    const schema = std(User, 'age')
+    const schema = standardSchema(repo(User), 'age')
     const nok_age = { age: 'aAa' }
 
     const result = await schema['~standard'].validate(nok_age)
@@ -70,7 +70,7 @@ describe('standard-schema', () => {
       job = ''
     }
     it('not ok', async () => {
-      const schema = std(UserMail, 'email')
+      const schema = standardSchema(repo(UserMail), 'email')
       const nok_mail = { email: 'aAa' }
 
       const result = await schema['~standard'].validate(nok_mail)
@@ -80,7 +80,7 @@ describe('standard-schema', () => {
     })
 
     it('ok', async () => {
-      const schema = std(UserMail, 'email')
+      const schema = standardSchema(repo(UserMail), 'email')
       const nok_mail = { email: 'j@tt.fr' }
 
       const result = await schema['~standard'].validate(nok_mail)
@@ -105,7 +105,7 @@ describe('standard-schema', () => {
       email!: string
     }
 
-    const schema = std(UserMail, 'email')
+    const schema = standardSchema(repo(UserMail), 'email')
     const nok_mail = { email: 'aAa' }
 
     const result = await schema['~standard'].validate(nok_mail)
@@ -133,7 +133,7 @@ describe('standard-schema', () => {
     }
 
     it('error wrong userId format', async () => {
-      const schema = std(ETask)
+      const schema = standardSchema(repo(ETask))
       const nok = { title: 'aAa', userId: '123' }
 
       const result = await schema['~standard'].validate(nok)
@@ -147,7 +147,7 @@ describe('standard-schema', () => {
     })
 
     it('good userId format', async () => {
-      const schema = std(ETask)
+      const schema = standardSchema(repo(ETask))
       const ok = { title: 'aAa', userId: 'user:123' }
 
       const result = await schema['~standard'].validate(ok)
@@ -155,7 +155,7 @@ describe('standard-schema', () => {
     })
 
     it('should check only userId (even if entity validation is NOT OK)', async () => {
-      const schema = std(ETask, 'userId')
+      const schema = standardSchema(repo(ETask), 'userId')
       const nok = { title: 'aAa', userId: '123' }
 
       const result = await schema['~standard'].validate(nok)


### PR DESCRIPTION
## Proposal

```ts
// Usual entity stuff
@Entity('User')
class User {
  @Fields.id()
  id!: string
  @Fields.string({ required: true })
  name!: string
  @Fields.number()
  age?: number
}

// Schema Part 🎉 new stuff 🎉
import { std } from 'remult'

const schema1 = standardSchema(repo(User))
//     ^ this is a standard-schema for all User

const schema2 = standardSchema(repo(User), 'name', 'age')
//     ^ this is a standard-schema looking for name and age (name & age are typed!)
```

## Open questions
- [x] ~~`std(User, 'name', 'age')` vs `std(User, ['name', 'age'])`~~ _update in the code example_
- [x] ~~`std` vs `Schema.standardSchemaV1` vs `INSERT_A_COOL_NAME_HERE`~~ _update in the code example_

## Checklist

- [x] export in public api
- [x] `CHANGELOG.md` updated

