### PR TITLE
fix(interactive): allow llm frontmatter key in tutorial schema

### DIFF
--- a/docs/interactive/src/content/config.ts
+++ b/docs/interactive/src/content/config.ts
@@ -1,9 +1,17 @@
 import { contentSchema } from '@tutorialkit/types';
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
+
+const schema = z.preprocess((val) => {
+  if (val && typeof val === 'object' && 'llm' in val) {
+    const { llm, ...rest } = val as Record<string, unknown>;
+    return rest;
+  }
+  return val;
+}, contentSchema);
 
 const tutorial = defineCollection({
   type: 'content',
-  schema: contentSchema,
+  schema,
 });
 
 export const collections = { tutorial };


### PR DESCRIPTION
The tutorial content schema from `@tutorialkit/types` is `.strict()`, so the `llm:` metadata key added to 47 tutorial markdown files in 9ff5cdf broke the Astro build on deploy.

Preprocesses frontmatter to strip `llm` before strict validation.