### PR TITLE
Deprecate remult.useFetch; document withRemult for SSR loads + import.meta.env.SSR shape

### DIFF
--- a/.claude/skills/remult/SKILL.md
+++ b/.claude/skills/remult/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remult
-description: Remult patterns - entities, fields, repo() usage, lifecycle hooks, permissions (allowApi + apiPrefilter), upsert, customFilter, sqlExpression, ValueList enums, relations. Use whenever writing or modifying Remult entities, configuring API permissions, working with `repo()`, or building CRUD flows in any Remult-powered app (React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt).
+description: Remult patterns - entities, fields, repo() usage, lifecycle hooks, permissions (allowApi + apiPrefilter), upsert, customFilter, sqlExpression, ValueList enums, relations, BackendMethod, and keeping server-only / Node-only code (fs, sharp, ...) out of the client bundle with `import.meta.env.SSR`. Use whenever writing or modifying Remult entities, configuring API permissions, working with `repo()`, writing a BackendMethod, guarding server-only code, or building CRUD flows in any Remult-powered app (React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt).
 ---
 
 # Remult
@@ -88,7 +88,12 @@ static async log(msg: string) {
   if (import.meta.env.SSR) {
     const { appendFileSync } = await import('fs')
     appendFileSync('./logs/log.txt', `${new Date().toISOString()} ${msg}\n`)
+    return { status: 'ok' }
   }
+  // Unreachable on the server (SSR is build-time true). When the method returns a
+  // value, `return` inside the block and `throw` here to keep the return type clean
+  // (no `| undefined`).
+  throw new Error('server-only')
 }
 ```
 

--- a/.claude/skills/remult/SKILL.md
+++ b/.claude/skills/remult/SKILL.md
@@ -110,7 +110,7 @@ Same pattern in hooks:
 })
 ```
 
-**Do not use `if (!import.meta.env.SSR) return` as an early-return** - it does NOT strip the Node-only deps from the client bundle. Always wrap the server-only section in `if (import.meta.env.SSR) { ... }`.
+**The shape is mandatory (this is THE thing people get wrong):** `import.meta.env.SSR` is a build-time constant Vite replaces + tree-shakes, so it can only drop a **wrapped block**. The server-only `import()` MUST be inside `if (import.meta.env.SSR) { ... }` (return inside; `throw` after for a returning method). An early `if (!import.meta.env.SSR) return` leaves the import statically reachable -> it stays in the client bundle -> `Module not found`.
 
 For more (abstract-the-call, bundler exclusion), see <https://remult.dev/docs/using-server-only-packages>.
 

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -107,27 +107,27 @@ export const handle = sequence(
 
 ## Extra - Universal load & SSR
 
-To Use remult in ssr `PageLoad` - this will leverage the `event`'s fetch to load data on the server
-without reloading it on the frontend, and abiding to all api rules even when it runs on the server
+To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
+
+Scope it to the read with `withRemult` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using.
 
 ::: code-group
 
 ```ts [src/routes/+page.ts]
-import { remult } from 'remult'
+import { RestDataProvider, withRemult } from 'remult'
 import type { PageLoad } from './$types'
 
 export const load = (async (event) => {
-  // Instruct remult to use the special svelte fetch
-  // Like this univeral load will work in SSR & CSR
-  remult.useFetch(event.fetch)
-  return repo(Task).find()
+  return withRemult((remult) => remult.repo(Task).find(), {
+    dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })),
+  })
 }) satisfies PageLoad
 ```
 
 :::
 
 ::: tip
-You can add this in `+layout.ts` as well and all routes **under** will have the correct fetch out of the box.
+firstly ships a ready-made wrapper (`remultApiUniversalLoad`) that also handles CSR/hydration reuse - see [remultApiLoad.ts](https://github.com/jycouet/firstly/blob/main/packages/firstly/src/lib/svelte/remultApiLoad.ts).
 :::
 
 ## Extra - Server load

--- a/docs/docs/using-server-only-packages.md
+++ b/docs/docs/using-server-only-packages.md
@@ -53,7 +53,12 @@ static async log(msg: string) {
   if (import.meta.env.SSR) {
     const { appendFileSync } = await import('fs')
     appendFileSync('./logs/log.txt', `${new Date().toISOString()} ${msg}\n`)
+    return { status: 'ok' }
   }
+  // `import.meta.env.SSR` is build-time `true` on the server, so this line is never
+  // reached. When the method returns a value, `return` inside the block and `throw`
+  // here - it keeps the inferred return type clean (no `| undefined`).
+  throw new Error('server-only')
 }
 ```
 

--- a/docs/docs/using-server-only-packages.md
+++ b/docs/docs/using-server-only-packages.md
@@ -75,8 +75,23 @@ Same pattern in an entity `saved` hook:
 })
 ```
 
-::: warning Early-return does NOT work
-`if (!import.meta.env.SSR) return` at the top of a `BackendMethod` does **not** strip the Node-only deps from the client bundle - you'll still get `Module not found`. Always wrap the server-only section in `if (import.meta.env.SSR) { ... }`.
+::: danger The shape is mandatory: wrap the block, never early-return
+`import.meta.env.SSR` is a **build-time constant** - Vite replaces it with `true`/`false` and tree-shakes. It can therefore only drop a **wrapped block**, so the server-only `import()` must live _inside_ `if (import.meta.env.SSR) { ... }`. An early `if (!import.meta.env.SSR) return` leaves the import statically reachable, so it stays in the client bundle and you get `Module not found`.
+
+```ts
+// ✅ the whole block (and its import) is stripped from the client bundle
+if (import.meta.env.SSR) {
+  const { appendFileSync } = await import('fs')
+  // ...
+  return result
+}
+throw new Error('server-only') // unreachable on the server; required for a clean return type
+
+// ❌ NOT stripped -> `Module not found` in the client build
+if (!import.meta.env.SSR) return
+const { appendFileSync } = await import('fs') // still statically reachable
+```
+
 :::
 
 ## Solution 2 - abstract the call

--- a/examples/sveltekit-todo/src/routes/+layout.ts
+++ b/examples/sveltekit-todo/src/routes/+layout.ts
@@ -1,7 +1,5 @@
-import { remult } from 'remult'
 import type { LayoutLoad } from './$types'
 
 export const load = (async (event) => {
-  remult.useFetch(event.fetch)
   return { ...event.data }
 }) satisfies LayoutLoad

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -104,8 +104,6 @@ export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
 }
 
-let warnedUseFetchDeprecated = false
-
 export class Remult {
   /**Return's a `Repository` of the specific entity type
    * @example
@@ -236,20 +234,16 @@ export class Remult {
     return undefined!
   }
   /**
-   * @deprecated Mutating the shared request `remult` is unsafe: on the server a
-   * universal `load` runs concurrently with a `+page.server.ts`, and reassigning
-   * the data provider here affects that other load. Instead, scope the rest fetch to
-   * the read with `withRemult`, e.g.
+   * @deprecated In SvelteKit, loads run in parallel, so reassigning the shared
+   * `remult` data provider here leaks across loads. Scope the fetch to the read
+   * with `withRemult` instead, e.g.
    * `withRemult((r) => r.repo(X).find(), { dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) })`.
-   * See the SvelteKit "Universal load & SSR" doc and firstly's `remultApiUniversalLoad`.
+   * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(fetch: ApiClient['httpClient']) {
-    if (!warnedUseFetchDeprecated) {
-      warnedUseFetchDeprecated = true
-      console.warn(
-        '[remult] `useFetch` is deprecated, see https://remult.dev/docs/installation/framework/sveltekit#extra-universal-load-ssr',
-      )
-    }
+    console.warn(
+      '[remult] `useFetch` is deprecated, see https://remult.dev/docs/installation/framework/sveltekit#extra-universal-load-ssr',
+    )
     this.dataProvider = new RestDataProvider(() => ({
       httpClient: fetch,
     }))

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -104,6 +104,8 @@ export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
 }
 
+let warnedUseFetchDeprecated = false
+
 export class Remult {
   /**Return's a `Repository` of the specific entity type
    * @example
@@ -233,7 +235,21 @@ export class Remult {
     } else return this.isAllowed(allowed as Allowed)
     return undefined!
   }
+  /**
+   * @deprecated Mutating the shared request `remult` is unsafe: on the server a
+   * universal `load` runs concurrently with a `+page.server.ts`, and reassigning
+   * the data provider here affects that other load. Instead, scope the rest fetch to
+   * the read with `withRemult`, e.g.
+   * `withRemult((r) => r.repo(X).find(), { dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) })`.
+   * See the SvelteKit "Universal load & SSR" doc and firstly's `remultApiUniversalLoad`.
+   */
   useFetch(fetch: ApiClient['httpClient']) {
+    if (!warnedUseFetchDeprecated) {
+      warnedUseFetchDeprecated = true
+      console.warn(
+        '[remult] `useFetch` is deprecated, see https://remult.dev/docs/installation/framework/sveltekit#extra-universal-load-ssr',
+      )
+    }
     this.dataProvider = new RestDataProvider(() => ({
       httpClient: fetch,
     }))

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -487,16 +487,10 @@ export interface UserInfo {
 }
 
 export declare type Allowed =
-  | boolean
-  | string
-  | string[]
-  | ((c?: Remult) => boolean)
+  boolean | string | string[] | ((c?: Remult) => boolean)
 
 export declare type AllowedForInstance<T> =
-  | boolean
-  | string
-  | string[]
-  | ((entity?: T, c?: Remult) => boolean)
+  boolean | string | string[] | ((entity?: T, c?: Remult) => boolean)
 export class Allow {
   static everyone = () => true
   static authenticated = (...args: any[]) => {

--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -94,6 +94,11 @@ export class RemultProxy implements Remult {
   clearAllCache() {
     return remultStatic.remultFactory().clearAllCache()
   }
+  /**
+   * @deprecated Mutating the shared request `remult` is unsafe (it can affect a
+   * concurrent `+page.server.ts` on the server). Scope the rest fetch to the read
+   * with `withRemult` instead - see the SvelteKit "Universal load & SSR" doc.
+   */
   useFetch(args: typeof fetch) {
     return remultStatic.remultFactory().useFetch(args)
   }

--- a/projects/create-remult/templates/sveltekit/src/routes/+layout.ts
+++ b/projects/create-remult/templates/sveltekit/src/routes/+layout.ts
@@ -1,7 +1,5 @@
-import { remult } from "remult";
 import type { LayoutLoad } from "./$types";
 
 export const load = (async (event) => {
-  remult.useFetch(event.fetch);
   return { user: event.data.user };
 }) satisfies LayoutLoad;


### PR DESCRIPTION
Two related changes for SvelteKit + server-only code.

**Deprecate `remult.useFetch`** (minor; JSDoc `@deprecated` + a warn-once at runtime). It reassigns the shared request `remult`'s data provider, which on the server can affect a `+page.server.ts` running concurrently with a universal `load`. The "Universal load & SSR" doc now scopes the rest fetch to the read with `withRemult` (and links firstly's ready-made `remultApiUniversalLoad`). Dropped `useFetch` from the create-remult SvelteKit template and the sveltekit-todo example.

**Server-only packages doc + remult skill**: for a returning `BackendMethod`, show `return` inside `if (import.meta.env.SSR) { ... }` and `throw` after it, and make the key point loud - `import.meta.env.SSR` is a build-time constant, so it only strips a wrapped block; `if (!import.meta.env.SSR) return` leaves the import reachable and breaks the client build. Widened the skill's description so it triggers on "server-only" / "BackendMethod".
