### PR TITLE
fix: TestApiDataProvider corrupts concurrent withRemult contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak): when a real `AsyncLocalStorage` is available, calls now nest in it instead of swapping process-global statics.
+
 ## [3.3.13] - 2026-06-09
 
 - Fixed `groupBy`/`aggregate` with `limit`/`page` but no `orderBy` emitting `OFFSET/FETCH` without an `ORDER BY`, which is invalid on SQL Server. A grouped query now falls back to ordering by the group columns, and a pure aggregate skips paging entirely.

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -2,10 +2,8 @@ import {
   InMemoryDataProvider,
   remult,
   RestDataProvider,
-  SqlDatabase,
-  type DataProvider,
   type EntityMetadata,
-  type Remult,
+  Remult,
 } from '../index.js'
 import type { RemultServerOptions } from './index.js'
 import {
@@ -39,21 +37,28 @@ export function TestApiDataProvider(
   ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
 
   const lock = new AsyncLock()
-  async function handleOnServer(req: GenericRequestInfo & { body?: any }) {
+  async function handleOnServer(
+    req: GenericRequestInfo & { body?: any; user?: unknown },
+  ) {
+    const call = async () => {
+      if (newEntities.length > 0 && options?.ensureSchema != false) {
+        await (await dp).ensureSchema?.(newEntities)
+        newEntities = []
+      }
+      var result = await server.handle(req)
+      if ((result?.statusCode ?? 200) >= 400) {
+        throw { ...result?.data, status: result?.statusCode ?? 500 }
+      }
+      return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
+    }
     return lock.runExclusive(async () => {
-      return await MakeServerCallWithDifferentStaticRemult(async () => {
-        if (newEntities.length > 0 && options?.ensureSchema != false) {
-          await (await dp).ensureSchema?.(newEntities)
-          newEntities = []
-        }
-        var result = await server.handle(req)
-        if ((result?.statusCode ?? 200) >= 400) {
-          throw { ...result?.data, status: result?.statusCode ?? 500 }
-        }
-        return result?.data
-          ? JSON.parse(JSON.stringify(result.data))
-          : undefined
-      })
+      if (remultStatic.asyncContext.hasRealAsyncStorage()) {
+        // Nest in the real AsyncLocalStorage instead of swapping process-global
+        // statics, which corrupts concurrent requests' remult contexts.
+        req.user = { ...remult.user! }
+        return remultStatic.asyncContext.run(new Remult(), call)
+      }
+      return MakeServerCallWithDifferentStaticRemult(call)
     })
   }
 
@@ -133,6 +138,7 @@ async function MakeServerCallWithDifferentStaticRemult<T>(what: () => T) {
         return callback()
       },
       wasImplemented: 'yes',
+      isStub: true, // keep hasRealAsyncStorage() false while this fake is installed
     })
     return await what()
   } finally {

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -37,29 +37,38 @@ export function TestApiDataProvider(
   ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
 
   const lock = new AsyncLock()
+  // serialized so concurrent first calls don't race ensureSchema
+  let schemaQueue: Promise<void> = Promise.resolve()
+  function ensureSchemaSerialized() {
+    const run = schemaQueue
+      .catch(() => {})
+      .then(async () => {
+        if (newEntities.length > 0 && options?.ensureSchema != false) {
+          await (await dp).ensureSchema?.(newEntities)
+          newEntities = []
+        }
+      })
+    schemaQueue = run
+    return run
+  }
   async function handleOnServer(
     req: GenericRequestInfo & { body?: any; user?: unknown },
   ) {
     const call = async () => {
-      if (newEntities.length > 0 && options?.ensureSchema != false) {
-        await (await dp).ensureSchema?.(newEntities)
-        newEntities = []
-      }
+      await ensureSchemaSerialized()
       var result = await server.handle(req)
       if ((result?.statusCode ?? 200) >= 400) {
         throw { ...result?.data, status: result?.statusCode ?? 500 }
       }
       return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
     }
-    return lock.runExclusive(async () => {
-      if (remultStatic.asyncContext.hasRealAsyncStorage()) {
-        // Nest in the real AsyncLocalStorage instead of swapping process-global
-        // statics, which corrupts concurrent requests' remult contexts.
-        req.user = { ...remult.user! }
-        return remultStatic.asyncContext.run(new Remult(), call)
-      }
-      return MakeServerCallWithDifferentStaticRemult(call)
-    })
+    if (remultStatic.asyncContext.hasRealAsyncStorage()) {
+      // nested ALS run is concurrency-safe, no lock needed
+      req.user = { ...remult.user! }
+      return remultStatic.asyncContext.run(new Remult(), call)
+    }
+    // no ALS (e.g. StackBlitz): swapping globals is only safe one call at a time
+    return lock.runExclusive(() => MakeServerCallWithDifferentStaticRemult(call))
   }
 
   const registeredEntities = new Set<string>()

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -77,6 +77,13 @@ export class RemultAsyncLocalStorage {
   isInInitRequest() {
     return this.remultObjectStorage?.getStore()?.inInitRequest
   }
+  /** Backed by a real AsyncLocalStorage (not a stub) - nested `run` is concurrency-safe. */
+  hasRealAsyncStorage() {
+    return (
+      this.remultObjectStorage?.wasImplemented === 'yes' &&
+      !this.remultObjectStorage.isStub
+    )
+  }
   setInInitRequest(val: boolean) {
     const store = this.remultObjectStorage?.getStore()
     if (!store) return

--- a/projects/tests/test-api-data-provider-concurrency.spec.ts
+++ b/projects/tests/test-api-data-provider-concurrency.spec.ts
@@ -1,0 +1,124 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest'
+import {
+  Entity,
+  Fields,
+  InMemoryDataProvider,
+  withRemult,
+  remult,
+  repo,
+  type DataProvider,
+} from '../core/index.js'
+import { TestApiDataProvider } from '../core/server/test-api-data-provider.js'
+import { RemultAsyncLocalStorage } from '../core/src/context.js'
+import { remultStatic } from '../core/src/remult-static.js'
+import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+
+let userSeenByApiPipeline: string | undefined
+
+@Entity('tasks', {
+  allowApiCrud: true,
+  apiPrefilter: () => {
+    userSeenByApiPipeline = remult.user?.id
+    return undefined
+  },
+})
+class Task {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => (resolve = res))
+  return { promise, resolve }
+}
+
+// `find` signals when it starts and blocks until released - holds the in-process call open.
+function gatedDataProvider(
+  inner: DataProvider,
+  started: () => void,
+  gate: Promise<void>,
+): DataProvider {
+  return {
+    getEntityDataProvider: (entity) => {
+      const rows = inner.getEntityDataProvider(entity)
+      return {
+        ...rows,
+        count: rows.count.bind(rows),
+        groupBy: rows.groupBy?.bind(rows),
+        find: async (options) => {
+          started()
+          await gate
+          return rows.find(options)
+        },
+        update: rows.update.bind(rows),
+        delete: rows.delete.bind(rows),
+        insert: rows.insert.bind(rows),
+      }
+    },
+    transaction: (action) => inner.transaction(action),
+  }
+}
+
+// A withRemult starting while TestApiDataProvider swaps the process-global statics
+// registers in the throwaway context and loses its remult once they are restored.
+describe('TestApiDataProvider with concurrent server requests', () => {
+  beforeEach(() => {
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    RemultAsyncLocalStorage.enable()
+  })
+  afterEach(() => {
+    RemultAsyncLocalStorage.disable()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined)
+  })
+
+  it("a concurrent withRemult keeps its own context and user", async () => {
+    const aCallStarted = deferred()
+    const releaseA = deferred()
+    const bEntered = deferred()
+    const aFinished = deferred()
+
+    const testApi = TestApiDataProvider({
+      ensureSchema: false,
+      dataProvider: gatedDataProvider(
+        new InMemoryDataProvider(),
+        aCallStarted.resolve,
+        releaseA.promise,
+      ),
+    })
+
+    // Request A: a server load reading through the api pipeline in-process.
+    const requestA = withRemult(
+      async () => {
+        remult.user = { id: 'A' }
+        await repo(Task).find()
+      },
+      { dataProvider: testApi },
+    ).then(aFinished.resolve)
+
+    // Request B: enters withRemult while A's in-process api call is in flight.
+    const requestB = (async () => {
+      await aCallStarted.promise
+      return withRemult(async () => {
+        const userSeenOnEntry = remult.user?.id
+        remult.user = { id: 'B' }
+        bEntered.resolve()
+        await aFinished.promise // A completes, statics restored
+        return { userSeenOnEntry, userAfterA: remult.user?.id }
+      })
+    })()
+
+    await bEntered.promise
+    releaseA.resolve()
+    await requestA
+
+    const b = await requestB
+    expect(userSeenByApiPipeline).toBe('A') // caller's user reaches the api pipeline
+    expect(b.userSeenOnEntry).toBeUndefined() // leaked 'A' = cross-request user bleed
+    expect(b.userAfterA).toBe('B') // throws 'outside of a valid request cycle' today
+  })
+})


### PR DESCRIPTION
Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak): when a real `AsyncLocalStorage` is available, calls now nest in it instead of swapping process-global statics.