### PR TITLE
Scoped dataProvider - withDataProvider + withFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added `withDataProvider` and `withFetch` - scope data access to the current async context, same `remult` (user, context); `withFetch` succeeds the deprecated `remult.useFetch` for SSR loads and enforces the api rules at the endpoint it fetches.
+- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak).
+
 ## [3.3.16] - 2026-07-14
 
 - Added support for default values without an arrow function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Added `withDataProvider` and `withFetch` - scope data access to the current async context, same `remult` (user, context); `withFetch` succeeds the deprecated `remult.useFetch` for SSR loads and enforces the api rules at the endpoint it fetches.
-- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak).
+- Added `withDataProvider` and `withFetch` - scope data access to the current async context, same `remult` (user, context); `withFetch` replaces the deprecated `remult.useFetch` for SSR loads and enforces the api rules at the endpoint it fetches.
+- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak). It now calls `initAsyncHooks()`, which enables `async_hooks` tracking for the whole process.
+- `remult.dataProvider` and `remult.apiClient` are now accessors instead of plain fields, so they are no longer own properties of the instance (`{ ...remult }` and `structuredClone` no longer copy them, a subclass redeclaring them as fields shadows the scope). Reads and writes are unchanged.
 
 ## [3.3.16] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Added `withDataProvider` and `withFetch` - scope data access to the current async context, same `remult` (user, context); `withFetch` replaces the deprecated `remult.useFetch` for SSR loads and enforces the api rules at the endpoint it fetches.
-- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak). It now calls `initAsyncHooks()`, which enables `async_hooks` tracking for the whole process.
-- `remult.dataProvider` and `remult.apiClient` are now accessors instead of plain fields, so they are no longer own properties of the instance (`{ ...remult }` and `structuredClone` no longer copy them, a subclass redeclaring them as fields shadows the scope). Reads and writes are unchanged.
+- Added `withDataProvider` and `withFetch`. Both scope data access to the current async context and keep the same `remult` (user, context). `withFetch` replaces the deprecated `remult.useFetch` for SSR loads, and the api rules run at the endpoint it fetches.
+- Fixed `TestApiDataProvider` corrupting concurrent `withRemult` contexts (crash or cross-request user leak). It now calls `initAsyncHooks()`, which turns on `async_hooks` tracking for the whole process.
+- `remult.dataProvider` and `remult.apiClient` are now accessors, not plain fields. Reads and writes behave the same, but they are no longer own properties of the instance: `{ ...remult }` and `structuredClone` skip them, and a subclass that redeclares them as fields shadows the scope.
 
 ## [3.3.16] - 2026-07-14
 

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -109,18 +109,16 @@ export const handle = sequence(
 
 To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
 
-Scope it to the read with `withRemult` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using.
+Scope it to the read with `withFetch` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using. Inside the scope, `BackendMethod` calls are dispatched over the same fetch, so api rules apply to them too.
 
 ::: code-group
 
 ```ts [src/routes/+page.ts]
-import { RestDataProvider, withRemult } from 'remult'
+import { repo, withFetch } from 'remult'
 import type { PageLoad } from './$types'
 
 export const load = (async (event) => {
-  return withRemult((remult) => remult.repo(Task).find(), {
-    dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })),
-  })
+  return withFetch(event.fetch, () => repo(Task).find())
 }) satisfies PageLoad
 ```
 

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -107,9 +107,9 @@ export const handle = sequence(
 
 ## Extra - Universal load & SSR
 
-To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
+To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch. It works on SSR and CSR with no double fetch on the client, and applies all API rules even when it runs on the server.
 
-Scope it to the read with `withFetch` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using. Inside the scope, `BackendMethod` calls are dispatched over the same fetch, so api rules apply to them too.
+Scope it to the read with `withFetch` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (what the deprecated `remult.useFetch` does) would change the provider that other load is reading through. `withFetch` also sends `BackendMethod` calls over the same fetch, so api rules apply to them too.
 
 ::: code-group
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2479,6 +2479,7 @@ export declare class Remult {
   /** The current data provider - reads honor an enclosing `withDataProvider` scope, assignment sets the instance default */
   get dataProvider(): DataProvider
   set dataProvider(provider: DataProvider)
+  private _dataProvider?
   /** Creates a new instance of the `remult` object.
    *
    * Can receive either an HttpProvider or a DataProvider as a parameter - which will be used to fetch data from.
@@ -2517,8 +2518,10 @@ export declare class Remult {
    * Check out the [extensibility section](/docs/custom-options#enhancing-field-and-entity-definitions-with-custom-options) for more custom options.
    */
   readonly context: RemultContext
-  /** The api client that will be used by `remult` to perform calls to the `api` */
-  apiClient: ApiClient
+  /** The api client that will be used by `remult` to perform calls to the `api` - reads honor an enclosing `withFetch` scope, assignment sets the instance default */
+  get apiClient(): ApiClient
+  set apiClient(client: ApiClient)
+  private _apiClient?
 }
 export interface RemultContext {
   headers?: {

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2462,9 +2462,17 @@ export declare class Remult {
     instance: any,
     allowed?: AllowedForInstance<any>,
   ): boolean
+  /**
+   * @deprecated In SvelteKit, loads run in parallel, so reassigning the shared
+   * `remult` data provider here leaks across loads. Scope the fetch to the read
+   * with `withFetch` instead, e.g.
+   * `withFetch(event.fetch, () => repo(Task).find())`.
+   * See the SvelteKit "Universal load & SSR" doc.
+   */
   useFetch(fetch: ApiClient["httpClient"]): void
-  /** The current data provider */
-  dataProvider: DataProvider
+  /** The current data provider - reads honor an enclosing `withDataProvider` scope, assignment sets the instance default */
+  get dataProvider(): DataProvider
+  set dataProvider(provider: DataProvider)
   /** Creates a new instance of the `remult` object.
    *
    * Can receive either an HttpProvider or a DataProvider as a parameter - which will be used to fetch data from.
@@ -3624,6 +3632,17 @@ export declare function valueValidator<valueType>(
   entity: any,
   e: ValidateFieldEvent<any, valueType>,
 ) => string | boolean | Promise<string | boolean>
+export declare function withDataProvider<T>(
+  dataProvider: DataProvider,
+  callback: () => Promise<T>,
+): Promise<T>
+export declare function withFetch<T>(
+  fetch: ApiClient["httpClient"],
+  callback: () => Promise<T>,
+  options?: {
+    url?: string
+  },
+): Promise<T>
 export declare function withRemult<T>(
   callback: (remult: Remult) => Promise<T>,
   options?: {

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -147,6 +147,8 @@ export {
   Allow,
   Remult,
   withRemult,
+  withDataProvider,
+  withFetch,
   RemultContext,
   ApiClient,
   isBackend,

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -6,11 +6,15 @@ import {
 import { remultStatic } from '../src/remult-static.js'
 
 export function initAsyncHooks() {
-  if (remultStatic.asyncContext?.hasStorage()) return
-  remultStatic.asyncContext = new RemultAsyncLocalStorage(
-    new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
-  )
-  remultStatic.dataScope.core =
+  const remultStorageAlreadySet = remultStatic.asyncContext?.hasStorage()
+  // the two storages are wired independently: a hand-wired asyncContext must not
+  // leave the data scope without one, or scopes degrade to save/restore
+  if (remultStorageAlreadySet && remultStatic.dataScope.core) return
+  if (!remultStorageAlreadySet)
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+  remultStatic.dataScope.core ??=
     new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore()
   let test = new AsyncLocalStorage()
   test.run(1, async () => {
@@ -19,9 +23,10 @@ export function initAsyncHooks() {
       console.log(
         "async_hooks.AsyncLocalStorage not working, using stub implementation (You're probably running on stackblitz, this will work on a normal nodejs environment)",
       )
-      remultStatic.asyncContext = new RemultAsyncLocalStorage(
-        new StubRemultAsyncLocalStorageCore(),
-      )
+      if (!remultStorageAlreadySet)
+        remultStatic.asyncContext = new RemultAsyncLocalStorage(
+          new StubRemultAsyncLocalStorageCore(),
+        )
       remultStatic.dataScope.core = undefined
     }
   })

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -7,8 +7,8 @@ import { remultStatic } from '../src/remult-static.js'
 
 export function initAsyncHooks() {
   const remultStorageAlreadySet = remultStatic.asyncContext?.hasStorage()
-  // the two storages are wired independently: a hand-wired asyncContext must not
-  // leave the data scope without one, or scopes degrade to save/restore
+  // the two storages are wired independently - a hand-wired asyncContext must
+  // still leave the data scope with a core, or scopes degrade to save/restore
   if (remultStorageAlreadySet && remultStatic.dataScope.core) return
   if (!remultStorageAlreadySet)
     remultStatic.asyncContext = new RemultAsyncLocalStorage(

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -5,11 +5,8 @@ import {
 } from '../src/context.js'
 import { remultStatic } from '../src/remult-static.js'
 
-let init = false
-
 export function initAsyncHooks() {
-  if (init) return
-  init = true
+  if (remultStatic.asyncContext?.hasStorage()) return
   remultStatic.asyncContext = new RemultAsyncLocalStorage(
     new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
   )

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -10,6 +10,8 @@ export function initAsyncHooks() {
   remultStatic.asyncContext = new RemultAsyncLocalStorage(
     new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
   )
+  remultStatic.dataScope.core =
+    new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore()
   let test = new AsyncLocalStorage()
   test.run(1, async () => {
     await Promise.resolve()
@@ -20,6 +22,7 @@ export function initAsyncHooks() {
       remultStatic.asyncContext = new RemultAsyncLocalStorage(
         new StubRemultAsyncLocalStorageCore(),
       )
+      remultStatic.dataScope.core = undefined
     }
   })
 }

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -39,19 +39,16 @@ export function TestApiDataProvider(
   ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
 
   const lock = new AsyncLock()
-  // serialized so concurrent first calls don't race ensureSchema
-  let schemaQueue: Promise<void> = Promise.resolve()
+  // separate from `lock` - the nested-storage path skips `lock` but must still
+  // serialize concurrent first calls racing ensureSchema
+  const schemaLock = new AsyncLock()
   function ensureSchemaSerialized() {
-    const run = schemaQueue
-      .catch(() => {})
-      .then(async () => {
-        if (newEntities.length > 0 && options?.ensureSchema != false) {
-          await (await dp).ensureSchema?.(newEntities)
-          newEntities = []
-        }
-      })
-    schemaQueue = run
-    return run
+    return schemaLock.runExclusive(async () => {
+      if (newEntities.length > 0 && options?.ensureSchema != false) {
+        await (await dp).ensureSchema?.(newEntities)
+        newEntities = []
+      }
+    })
   }
   async function handleOnServer(
     req: GenericRequestInfo & { body?: any; user?: unknown },
@@ -64,15 +61,12 @@ export function TestApiDataProvider(
       }
       return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
     }
-    if (
-      remultStatic.asyncContext.hasRealAsyncStorage() &&
-      remultStatic.asyncContext.tryGetStore()
-    ) {
-      // nested ALS run is concurrency-safe, no lock needed
+    if (remultStatic.asyncContext.scopedStore()) {
+      // nested storage run is concurrency-safe, no lock needed
       req.user = remult.user ? { ...remult.user } : undefined
       return remultStatic.asyncContext.run(new Remult(), call)
     }
-    // no ALS (e.g. StackBlitz): swapping globals is only safe one call at a time
+    // no real async storage: swapping globals is only safe one call at a time
     return lock.runExclusive(() =>
       MakeServerCallWithDifferentStaticRemult(call),
     )
@@ -154,7 +148,7 @@ async function MakeServerCallWithDifferentStaticRemult<T>(what: () => T) {
         return callback()
       },
       wasImplemented: 'yes',
-      isStub: true, // keep hasRealAsyncStorage() false while this fake is installed
+      isStub: true, // keep scopedStore() empty while this fake is installed
     })
     return await what()
   } finally {

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -5,7 +5,7 @@ import {
   SqlDatabase,
   type DataProvider,
   type EntityMetadata,
-  type Remult,
+  Remult,
 } from '../index.js'
 import type { RemultServerOptions } from './index.js'
 import {
@@ -39,22 +39,43 @@ export function TestApiDataProvider(
   ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
 
   const lock = new AsyncLock()
-  async function handleOnServer(req: GenericRequestInfo & { body?: any }) {
-    return lock.runExclusive(async () => {
-      return await MakeServerCallWithDifferentStaticRemult(async () => {
+  // serialized so concurrent first calls don't race ensureSchema
+  let schemaQueue: Promise<void> = Promise.resolve()
+  function ensureSchemaSerialized() {
+    const run = schemaQueue
+      .catch(() => {})
+      .then(async () => {
         if (newEntities.length > 0 && options?.ensureSchema != false) {
           await (await dp).ensureSchema?.(newEntities)
           newEntities = []
         }
-        var result = await server.handle(req)
-        if ((result?.statusCode ?? 200) >= 400) {
-          throw { ...result?.data, status: result?.statusCode ?? 500 }
-        }
-        return result?.data
-          ? JSON.parse(JSON.stringify(result.data))
-          : undefined
       })
-    })
+    schemaQueue = run
+    return run
+  }
+  async function handleOnServer(
+    req: GenericRequestInfo & { body?: any; user?: unknown },
+  ) {
+    const call = async () => {
+      await ensureSchemaSerialized()
+      var result = await server.handle(req)
+      if ((result?.statusCode ?? 200) >= 400) {
+        throw { ...result?.data, status: result?.statusCode ?? 500 }
+      }
+      return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
+    }
+    if (
+      remultStatic.asyncContext.hasRealAsyncStorage() &&
+      remultStatic.asyncContext.tryGetStore()
+    ) {
+      // nested ALS run is concurrency-safe, no lock needed
+      req.user = remult.user ? { ...remult.user } : undefined
+      return remultStatic.asyncContext.run(new Remult(), call)
+    }
+    // no ALS (e.g. StackBlitz): swapping globals is only safe one call at a time
+    return lock.runExclusive(() =>
+      MakeServerCallWithDifferentStaticRemult(call),
+    )
   }
 
   const registeredEntities = new Set<string>()
@@ -133,6 +154,7 @@ async function MakeServerCallWithDifferentStaticRemult<T>(what: () => T) {
         return callback()
       },
       wasImplemented: 'yes',
+      isStub: true, // keep hasRealAsyncStorage() false while this fake is installed
     })
     return await what()
   } finally {

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -5,7 +5,7 @@ import {
   SqlDatabase,
   type DataProvider,
   type EntityMetadata,
-  Remult,
+  type UserInfo,
 } from '../index.js'
 import type { RemultServerOptions } from './index.js'
 import {
@@ -13,21 +13,25 @@ import {
   type GenericRequestInfo,
   type RemultServerImplementation,
 } from './remult-api-server.js'
-import { remultStatic } from '../src/remult-static.js'
-import { RemultAsyncLocalStorage } from '../src/context.js'
 import { initDataProvider } from './initDataProvider.js'
+import { initAsyncHooks } from './initAsyncHooks.js'
+
+type TestApiRequest = GenericRequestInfo & { body?: any; user?: UserInfo }
 
 export function TestApiDataProvider(
   options?: Pick<RemultServerOptions<unknown>, 'ensureSchema' | 'dataProvider'>,
 ) {
   if (!options) options = {}
+  // `createRemultServerCore` skips it - without it the in-process call has no
+  // remult of its own and would corrupt the caller's context
+  initAsyncHooks()
 
   var dp = initDataProvider(options.dataProvider, false, async () => {
     return new InMemoryDataProvider()
   })
 
-  const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
-    { ...options, dataProvider: dp },
+  const server = createRemultServerCore<TestApiRequest>(
+    { ...options, dataProvider: dp, getUser: async (req) => req.user },
     {
       getRequestBody: async (req) => req.body,
       buildGenericRequestInfo: (req) => ({
@@ -36,40 +40,24 @@ export function TestApiDataProvider(
       }),
       ignoreAsyncStorage: true,
     },
-  ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
+  ) as RemultServerImplementation<TestApiRequest>
 
-  const lock = new AsyncLock()
-  // separate from `lock` - the nested-storage path skips `lock` but must still
-  // serialize concurrent first calls racing ensureSchema
+  // concurrent first calls would otherwise race on ensureSchema
   const schemaLock = new AsyncLock()
-  function ensureSchemaSerialized() {
-    return schemaLock.runExclusive(async () => {
+
+  async function handleOnServer(req: TestApiRequest) {
+    req.user = remult.user ? { ...remult.user } : undefined
+    await schemaLock.runExclusive(async () => {
       if (newEntities.length > 0 && options?.ensureSchema != false) {
         await (await dp).ensureSchema?.(newEntities)
         newEntities = []
       }
     })
-  }
-  async function handleOnServer(
-    req: GenericRequestInfo & { body?: any; user?: unknown },
-  ) {
-    const call = async () => {
-      await ensureSchemaSerialized()
-      var result = await server.handle(req)
-      if ((result?.statusCode ?? 200) >= 400) {
-        throw { ...result?.data, status: result?.statusCode ?? 500 }
-      }
-      return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
+    var result = await server.handle(req)
+    if ((result?.statusCode ?? 200) >= 400) {
+      throw { ...result?.data, status: result?.statusCode ?? 500 }
     }
-    if (remultStatic.asyncContext.scopedStore()) {
-      // nested storage run is concurrency-safe, no lock needed
-      req.user = remult.user ? { ...remult.user } : undefined
-      return remultStatic.asyncContext.run(new Remult(), call)
-    }
-    // no real async storage: swapping globals is only safe one call at a time
-    return lock.runExclusive(() =>
-      MakeServerCallWithDifferentStaticRemult(call),
-    )
+    return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
   }
 
   const registeredEntities = new Set<string>()
@@ -127,32 +115,5 @@ export class AsyncLock {
     } finally {
       resolveNext!()
     }
-  }
-}
-
-async function MakeServerCallWithDifferentStaticRemult<T>(what: () => T) {
-  var x = remultStatic.asyncContext
-  var y = remultStatic.remultFactory
-  const user = { ...remult.user! }
-  let store: {
-    remult: Remult
-    inInitRequest?: boolean
-  }
-  remultStatic.remultFactory = () => store.remult
-  try {
-    remultStatic.asyncContext = new RemultAsyncLocalStorage({
-      getStore: () => store,
-      run: (pStore, callback) => {
-        store = pStore
-        store.remult.user = user
-        return callback()
-      },
-      wasImplemented: 'yes',
-      isStub: true, // keep scopedStore() empty while this fake is installed
-    })
-    return await what()
-  } finally {
-    remultStatic.asyncContext = x
-    remultStatic.remultFactory = y
   }
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -100,10 +100,9 @@ export class RemultAsyncLocalStorage {
   hasRealAsyncStorage() {
     return !!this.remultObjectStorage && !this.remultObjectStorage.isStub
   }
+  /** callers must check hasRealAsyncStorage() first */
   runWith<T>(store: RemultAsyncStore, callback: () => Promise<T>): Promise<T> {
-    if (this.remultObjectStorage)
-      return this.remultObjectStorage.run(store, callback)
-    return callback()
+    return this.remultObjectStorage!.run(store, callback)
   }
 }
 if (!remultStatic.asyncContext)

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -44,6 +44,12 @@ import { initDataProvider } from '../server/initDataProvider.js'
 import { SubscribableImp } from './remult3/SubscribableImp.js'
 import { getEntitySettings } from './remult3/getEntityRef.js'
 
+export type RemultAsyncStore = {
+  remult: Remult
+  inInitRequest?: boolean
+  /** scoped override set by `withDataProvider` - applies to `remult` of this store only */
+  dataProvider?: DataProvider
+}
 export class RemultAsyncLocalStorage {
   static enable() {
     remultStatic.remultFactory = () => {
@@ -60,10 +66,7 @@ export class RemultAsyncLocalStorage {
   }
   constructor(
     private readonly remultObjectStorage:
-      | RemultAsyncLocalStorageCore<{
-          remult: Remult
-          inInitRequest?: boolean
-        }>
+      | RemultAsyncLocalStorageCore<RemultAsyncStore>
       | undefined,
   ) {}
   async run<T>(
@@ -90,6 +93,19 @@ export class RemultAsyncLocalStorage {
     }
     return this.remultObjectStorage.getStore()
   }
+  /** Like getStore, but returns undefined when async_hooks were never initialized. */
+  tryGetStore() {
+    return this.remultObjectStorage?.getStore()
+  }
+  /** Backed by a real AsyncLocalStorage (not the stub) - nested `run` restores the previous store. */
+  hasRealAsyncStorage() {
+    return !!this.remultObjectStorage && !this.remultObjectStorage.isStub
+  }
+  runWith<T>(store: RemultAsyncStore, callback: () => Promise<T>): Promise<T> {
+    if (this.remultObjectStorage)
+      return this.remultObjectStorage.run(store, callback)
+    return callback()
+  }
 }
 if (!remultStatic.asyncContext)
   remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
@@ -103,6 +119,9 @@ export type RemultAsyncLocalStorageCore<T> = {
 export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
 }
+
+// instance default kept off the class so RemultProxy's `implements Remult` shape is unchanged
+const instanceDataProvider = new WeakMap<Remult, DataProvider>()
 
 export class Remult {
   /**Return's a `Repository` of the specific entity type
@@ -236,8 +255,8 @@ export class Remult {
   /**
    * @deprecated In SvelteKit, loads run in parallel, so reassigning the shared
    * `remult` data provider here leaks across loads. Scope the fetch to the read
-   * with `withRemult` instead, e.g.
-   * `withRemult((r) => r.repo(X).find(), { dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) })`.
+   * with `withFetch` instead, e.g.
+   * `withFetch(event.fetch, () => repo(Task).find())`.
    * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(fetch: ApiClient['httpClient']) {
@@ -248,8 +267,20 @@ export class Remult {
       httpClient: fetch,
     }))
   }
-  /** The current data provider */
-  dataProvider: DataProvider = new RestDataProvider(() => this.apiClient)
+  /** The current data provider - reads honor an enclosing `withDataProvider` scope, assignment sets the instance default */
+  get dataProvider(): DataProvider {
+    const store = remultStatic.asyncContext?.tryGetStore()
+    if (store?.dataProvider && store.remult === this) return store.dataProvider
+    let dp = instanceDataProvider.get(this)
+    if (!dp) {
+      dp = new RestDataProvider(() => this.apiClient)
+      instanceDataProvider.set(this, dp)
+    }
+    return dp
+  }
+  set dataProvider(provider: DataProvider) {
+    instanceDataProvider.set(this, provider)
+  }
   /* @internal */
   repCache = new Map<DataProvider, Map<ClassType<any>, Repository<unknown>>>()
   /** Creates a new instance of the `remult` object.
@@ -535,18 +566,26 @@ export async function doTransaction(
 ) {
   const trans = new transactionLiveQueryPublisher(remult.liveQueryPublisher)
   let ok = true
+  // scope the tx provider when `remult` is the ambient context; mutate + restore otherwise
+  const scoped =
+    remultStatic.asyncContext.hasRealAsyncStorage() &&
+    remultStatic.asyncContext.tryGetStore()?.remult === remult
   const prev = remult.dataProvider
   try {
-    await remult.dataProvider.transaction(async (ds) => {
-      remult.dataProvider = ds
+    await prev.transaction(async (ds) => {
       remult.liveQueryPublisher = trans
-      await what(ds)
+      if (scoped) {
+        await withDataProvider(ds, () => what(ds))
+      } else {
+        remult.dataProvider = ds
+        await what(ds)
+      }
       ok = true
     })
 
     if (ok) await trans.flush()
   } finally {
-    remult.dataProvider = prev
+    if (!scoped) remult.dataProvider = prev
   }
 }
 class transactionLiveQueryPublisher implements LiveQueryChangesListener {
@@ -591,4 +630,48 @@ export async function withRemult<T>(
   )
 
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
+}
+
+/**
+ * Runs `callback` with `dataProvider` scoped to the current async context.
+ * The ambient `remult` (user, context) stays the same - only data access is
+ * rerouted - and concurrent requests are unaffected.
+ * Without AsyncLocalStorage (browser, plain scripts) it swaps the current
+ * remult's provider and restores it - single-context environments only.
+ */
+export async function withDataProvider<T>(
+  dataProvider: DataProvider,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const storage = remultStatic.asyncContext
+  const store = storage.tryGetStore()
+  if (store && storage.hasRealAsyncStorage()) {
+    return storage.runWith({ ...store, dataProvider }, callback)
+  }
+  const r = remultStatic.remultFactory()
+  const prev = r.dataProvider
+  r.dataProvider = dataProvider
+  try {
+    return await callback()
+  } finally {
+    r.dataProvider = prev
+  }
+}
+
+/**
+ * Runs `callback` with data access going through the API via `fetch` - the
+ * scoped replacement for the deprecated `remult.useFetch`.
+ * @example
+ * export const load = async (event) =>
+ *   withFetch(event.fetch, () => repo(Task).find())
+ */
+export function withFetch<T>(
+  fetch: ApiClient['httpClient'],
+  callback: () => Promise<T>,
+  options?: { url?: string },
+): Promise<T> {
+  return withDataProvider(
+    new RestDataProvider(() => ({ httpClient: fetch, url: options?.url })),
+    callback,
+  )
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -48,6 +48,7 @@ export type RemultAsyncStore = {
   remult: Remult
   inInitRequest?: boolean
   dataProvider?: DataProvider
+  apiClient?: ApiClient
 }
 export class RemultAsyncLocalStorage {
   static enable() {
@@ -656,7 +657,9 @@ export async function withDataProvider<T>(
 
 /**
  * Runs `callback` with data access going through the API via `fetch` - the
- * scoped replacement for the deprecated `remult.useFetch`.
+ * scoped replacement for the deprecated `remult.useFetch`. Inside the scope a
+ * `BackendMethod` call behaves exactly like a client call: dispatched over
+ * `fetch`, `allowed` enforced at the endpoint, body runs privileged there.
  * @example
  * export const load = async (event) =>
  *   withFetch(event.fetch, () => repo(Task).find())
@@ -666,8 +669,24 @@ export function withFetch<T>(
   callback: () => Promise<T>,
   options?: { url?: string },
 ): Promise<T> {
-  return withDataProvider(
-    new RestDataProvider(() => ({ httpClient: fetch, url: options?.url })),
-    callback,
-  )
+  const apiClient: ApiClient = { httpClient: fetch, url: options?.url }
+  const dataProvider = new RestDataProvider(() => apiClient)
+  const storage = remultStatic.asyncContext
+  const store = storage.tryGetStore()
+  if (store && storage.hasRealAsyncStorage()) {
+    return storage.runWith({ ...store, dataProvider, apiClient }, callback)
+  }
+  return (async () => {
+    const r = remultStatic.remultFactory()
+    const prevDp = r.dataProvider
+    const prevApi = r.apiClient
+    r.dataProvider = dataProvider
+    r.apiClient = apiClient
+    try {
+      return await callback()
+    } finally {
+      r.dataProvider = prevDp
+      r.apiClient = prevApi
+    }
+  })()
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -96,11 +96,15 @@ export class RemultAsyncLocalStorage {
   tryGetStore() {
     return this.remultObjectStorage?.getStore()
   }
-  /** the stub's `run` never restores the previous store on exit */
-  hasRealAsyncStorage() {
-    return !!this.remultObjectStorage && !this.remultObjectStorage.isStub
+  /** store only when backed by real async storage - the stub's `run` never restores the previous store on exit */
+  scopedStore() {
+    const storage = this.remultObjectStorage
+    return storage && !storage.isStub ? storage.getStore() : undefined
   }
-  /** callers must check hasRealAsyncStorage() first */
+  hasStorage() {
+    return !!this.remultObjectStorage
+  }
+  /** callers must check scopedStore() first */
   runWith<T>(store: RemultAsyncStore, callback: () => Promise<T>): Promise<T> {
     return this.remultObjectStorage!.run(store, callback)
   }
@@ -117,9 +121,6 @@ export type RemultAsyncLocalStorageCore<T> = {
 export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
 }
-
-// instance default kept off the class so RemultProxy's `implements Remult` shape is unchanged
-const instanceDataProvider = new WeakMap<Remult, DataProvider>()
 
 export class Remult {
   /**Return's a `Repository` of the specific entity type
@@ -267,18 +268,14 @@ export class Remult {
   }
   /** The current data provider - reads honor an enclosing `withDataProvider` scope, assignment sets the instance default */
   get dataProvider(): DataProvider {
-    const store = remultStatic.asyncContext?.tryGetStore()
+    const store = remultStatic.asyncContext?.scopedStore()
     if (store?.dataProvider && store.remult === this) return store.dataProvider
-    let dp = instanceDataProvider.get(this)
-    if (!dp) {
-      dp = new RestDataProvider(() => this.apiClient)
-      instanceDataProvider.set(this, dp)
-    }
-    return dp
+    return (this._dataProvider ??= new RestDataProvider(() => this.apiClient))
   }
   set dataProvider(provider: DataProvider) {
-    instanceDataProvider.set(this, provider)
+    this._dataProvider = provider
   }
+  private _dataProvider?: DataProvider
   /* @internal */
   repCache = new Map<DataProvider, Map<ClassType<any>, Repository<unknown>>>()
   /** Creates a new instance of the `remult` object.
@@ -367,11 +364,19 @@ export class Remult {
    * Check out the [extensibility section](/docs/custom-options#enhancing-field-and-entity-definitions-with-custom-options) for more custom options.
    */
   readonly context: RemultContext = {} as RemultContext
-  /** The api client that will be used by `remult` to perform calls to the `api` */
-  apiClient: ApiClient = {
-    url: '/api',
-    subscriptionClient: new SseSubscriptionClient(),
+  /** The api client that will be used by `remult` to perform calls to the `api` - reads honor an enclosing `withFetch` scope, assignment sets the instance default */
+  get apiClient(): ApiClient {
+    const store = remultStatic.asyncContext?.scopedStore()
+    if (store?.apiClient && store.remult === this) return store.apiClient
+    return (this._apiClient ??= {
+      url: '/api',
+      subscriptionClient: new SseSubscriptionClient(),
+    })
   }
+  set apiClient(client: ApiClient) {
+    this._apiClient = client
+  }
+  private _apiClient?: ApiClient
 }
 
 remultStatic.defaultRemultFactory = () => new Remult()
@@ -562,12 +567,13 @@ export async function doTransaction(
   remult: Remult,
   what: (dp: DataProvider) => Promise<void>,
 ) {
+  // callers may pass the global proxy - its setter targets the instance while an
+  // active scope shadows the reads, so resolve it to the actual instance first
+  if (!(remult instanceof Remult)) remult = remultStatic.remultFactory()
   const trans = new transactionLiveQueryPublisher(remult.liveQueryPublisher)
   let ok = true
   // mutate+restore inside a scope would clobber the enclosing override
-  const scoped =
-    remultStatic.asyncContext.hasRealAsyncStorage() &&
-    remultStatic.asyncContext.tryGetStore()?.remult === remult
+  const scoped = remultStatic.asyncContext.scopedStore()?.remult === remult
   const prev = remult.dataProvider
   try {
     await prev.transaction(async (ds) => {
@@ -630,6 +636,74 @@ export async function withRemult<T>(
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
 }
 
+type ScopedStorePatch = {
+  dataProvider: DataProvider
+  apiClient?: ApiClient
+}
+// tracks overlapping no-storage scopes so only the last exit restores the originals
+const swapState = new WeakMap<
+  Remult,
+  { depth: number; dataProvider: DataProvider; apiClient: ApiClient }
+>()
+
+async function withScopedStore<T>(
+  buildPatch: (remult: Remult) => ScopedStorePatch,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const storage = remultStatic.asyncContext
+  const store = storage.scopedStore()
+  if (store) {
+    // inInitRequest must not leak into the scope - an in-process api request
+    // issued inside it would be served with the scoped provider and recurse
+    return storage.runWith(
+      {
+        ...store,
+        inInitRequest: undefined,
+        apiClient: undefined,
+        ...buildPatch(store.remult),
+      },
+      callback,
+    )
+  }
+  if (storage.hasStorage() && !storage.tryGetStore()) {
+    // outside a request the enabled factory throws - open a scope like withRemult
+    return withRemult((r) => {
+      const patch = buildPatch(r)
+      r.dataProvider = patch.dataProvider
+      if (patch.apiClient) r.apiClient = patch.apiClient
+      return callback()
+    })
+  }
+  // no async storage (browser): swap and restore the shared instance
+  const r = remultStatic.remultFactory()
+  const patch = buildPatch(r)
+  let state = swapState.get(r)
+  if (!state) {
+    swapState.set(
+      r,
+      (state = {
+        depth: 0,
+        dataProvider: r.dataProvider,
+        apiClient: r.apiClient,
+      }),
+    )
+  }
+  state.depth++
+  r.dataProvider = patch.dataProvider
+  if (patch.apiClient) r.apiClient = patch.apiClient
+  try {
+    return await callback()
+  } finally {
+    // the scope-private provider must not outlive the scope in the repo cache
+    r.repCache.delete(patch.dataProvider)
+    if (--state.depth === 0) {
+      swapState.delete(r)
+      r.dataProvider = state.dataProvider
+      r.apiClient = state.apiClient
+    }
+  }
+}
+
 /**
  * Runs `callback` with `dataProvider` scoped to the current async context - same
  * `remult` (user, context), only data access is rerouted; concurrent requests are
@@ -639,19 +713,7 @@ export async function withDataProvider<T>(
   dataProvider: DataProvider,
   callback: () => Promise<T>,
 ): Promise<T> {
-  const storage = remultStatic.asyncContext
-  const store = storage.tryGetStore()
-  if (store && storage.hasRealAsyncStorage()) {
-    return storage.runWith({ ...store, dataProvider }, callback)
-  }
-  const r = remultStatic.remultFactory()
-  const prev = r.dataProvider
-  r.dataProvider = dataProvider
-  try {
-    return await callback()
-  } finally {
-    r.dataProvider = prev
-  }
+  return withScopedStore(() => ({ dataProvider }), callback)
 }
 
 /**
@@ -668,24 +730,9 @@ export function withFetch<T>(
   callback: () => Promise<T>,
   options?: { url?: string },
 ): Promise<T> {
-  const apiClient: ApiClient = { httpClient: fetch, url: options?.url }
-  const dataProvider = new RestDataProvider(() => apiClient)
-  const storage = remultStatic.asyncContext
-  const store = storage.tryGetStore()
-  if (store && storage.hasRealAsyncStorage()) {
-    return storage.runWith({ ...store, dataProvider, apiClient }, callback)
-  }
-  return (async () => {
-    const r = remultStatic.remultFactory()
-    const prevDp = r.dataProvider
-    const prevApi = r.apiClient
-    r.dataProvider = dataProvider
-    r.apiClient = apiClient
-    try {
-      return await callback()
-    } finally {
-      r.dataProvider = prevDp
-      r.apiClient = prevApi
-    }
-  })()
+  return withScopedStore((r) => {
+    const apiClient: ApiClient = { ...r.apiClient, httpClient: fetch }
+    if (options?.url) apiClient.url = options.url
+    return { dataProvider: new RestDataProvider(() => apiClient), apiClient }
+  }, callback)
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -47,7 +47,6 @@ import { getEntitySettings } from './remult3/getEntityRef.js'
 export type RemultAsyncStore = {
   remult: Remult
   inInitRequest?: boolean
-  /** scoped override set by `withDataProvider` - applies to `remult` of this store only */
   dataProvider?: DataProvider
 }
 export class RemultAsyncLocalStorage {
@@ -93,11 +92,10 @@ export class RemultAsyncLocalStorage {
     }
     return this.remultObjectStorage.getStore()
   }
-  /** Like getStore, but returns undefined when async_hooks were never initialized. */
   tryGetStore() {
     return this.remultObjectStorage?.getStore()
   }
-  /** Backed by a real AsyncLocalStorage (not the stub) - nested `run` restores the previous store. */
+  /** the stub's `run` never restores the previous store on exit */
   hasRealAsyncStorage() {
     return !!this.remultObjectStorage && !this.remultObjectStorage.isStub
   }
@@ -566,7 +564,7 @@ export async function doTransaction(
 ) {
   const trans = new transactionLiveQueryPublisher(remult.liveQueryPublisher)
   let ok = true
-  // scope the tx provider when `remult` is the ambient context; mutate + restore otherwise
+  // mutate+restore inside a scope would clobber the enclosing override
   const scoped =
     remultStatic.asyncContext.hasRealAsyncStorage() &&
     remultStatic.asyncContext.tryGetStore()?.remult === remult
@@ -633,11 +631,9 @@ export async function withRemult<T>(
 }
 
 /**
- * Runs `callback` with `dataProvider` scoped to the current async context.
- * The ambient `remult` (user, context) stays the same - only data access is
- * rerouted - and concurrent requests are unaffected.
- * Without AsyncLocalStorage (browser, plain scripts) it swaps the current
- * remult's provider and restores it - single-context environments only.
+ * Runs `callback` with `dataProvider` scoped to the current async context - same
+ * `remult` (user, context), only data access is rerouted; concurrent requests are
+ * unaffected. Without AsyncLocalStorage it swaps and restores the current provider.
  */
 export async function withDataProvider<T>(
   dataProvider: DataProvider,

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -47,8 +47,6 @@ import { getEntitySettings } from './remult3/getEntityRef.js'
 export type RemultAsyncStore = {
   remult: Remult
   inInitRequest?: boolean
-  dataProvider?: DataProvider
-  apiClient?: ApiClient
 }
 export class RemultAsyncLocalStorage {
   static enable() {
@@ -78,7 +76,11 @@ export class RemultAsyncLocalStorage {
     } else return callback(remult)
   }
   isInInitRequest() {
-    return this.remultObjectStorage?.getStore()?.inInitRequest
+    const store = this.remultObjectStorage?.getStore()
+    if (!store?.inInitRequest) return false
+    // inside a scope an in-process api request must get its own remult - reusing
+    // this one would serve it with the scoped provider and recurse
+    return remultStatic.dataScope?.get()?.remult !== store.remult
   }
   setInInitRequest(val: boolean) {
     const store = this.remultObjectStorage?.getStore()
@@ -96,17 +98,8 @@ export class RemultAsyncLocalStorage {
   tryGetStore() {
     return this.remultObjectStorage?.getStore()
   }
-  /** store only when backed by real async storage - the stub's `run` never restores the previous store on exit */
-  scopedStore() {
-    const storage = this.remultObjectStorage
-    return storage && !storage.isStub ? storage.getStore() : undefined
-  }
   hasStorage() {
     return !!this.remultObjectStorage
-  }
-  /** callers must check scopedStore() first */
-  runWith<T>(store: RemultAsyncStore, callback: () => Promise<T>): Promise<T> {
-    return this.remultObjectStorage!.run(store, callback)
   }
 }
 if (!remultStatic.asyncContext)
@@ -117,6 +110,33 @@ export type RemultAsyncLocalStorageCore<T> = {
   wasImplemented: 'yes'
   isStub?: boolean
 }
+
+/** A `withDataProvider`/`withFetch` scope, pinned to the remult that was ambient when it opened */
+export type RemultDataScope = {
+  remult: Remult
+  dataProvider: DataProvider
+  apiClient?: ApiClient
+}
+export class RemultDataScopeStorage {
+  /** set by `initAsyncHooks` - without it the scope degrades to save/restore */
+  core?: RemultAsyncLocalStorageCore<RemultDataScope>
+  private current?: RemultDataScope
+  get() {
+    return this.core ? this.core.getStore() : this.current
+  }
+  async run<T>(scope: RemultDataScope, callback: () => Promise<T>): Promise<T> {
+    if (this.core) return this.core.run(scope, callback)
+    const prev = this.current
+    this.current = scope
+    try {
+      return await callback()
+    } finally {
+      this.current = prev
+    }
+  }
+}
+if (!remultStatic.dataScope)
+  remultStatic.dataScope = new RemultDataScopeStorage()
 
 export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
@@ -268,8 +288,8 @@ export class Remult {
   }
   /** The current data provider - reads honor an enclosing `withDataProvider` scope, assignment sets the instance default */
   get dataProvider(): DataProvider {
-    const store = remultStatic.asyncContext?.scopedStore()
-    if (store?.dataProvider && store.remult === this) return store.dataProvider
+    const scope = remultStatic.dataScope?.get()
+    if (scope?.remult === this) return scope.dataProvider
     return (this._dataProvider ??= new RestDataProvider(() => this.apiClient))
   }
   set dataProvider(provider: DataProvider) {
@@ -366,8 +386,8 @@ export class Remult {
   readonly context: RemultContext = {} as RemultContext
   /** The api client that will be used by `remult` to perform calls to the `api` - reads honor an enclosing `withFetch` scope, assignment sets the instance default */
   get apiClient(): ApiClient {
-    const store = remultStatic.asyncContext?.scopedStore()
-    if (store?.apiClient && store.remult === this) return store.apiClient
+    const scope = remultStatic.dataScope?.get()
+    if (scope?.apiClient && scope.remult === this) return scope.apiClient
     return (this._apiClient ??= {
       url: '/api',
       subscriptionClient: new SseSubscriptionClient(),
@@ -515,10 +535,16 @@ export interface UserInfo {
 }
 
 export declare type Allowed =
-  boolean | string | string[] | ((c?: Remult) => boolean)
+  | boolean
+  | string
+  | string[]
+  | ((c?: Remult) => boolean)
 
 export declare type AllowedForInstance<T> =
-  boolean | string | string[] | ((entity?: T, c?: Remult) => boolean)
+  | boolean
+  | string
+  | string[]
+  | ((entity?: T, c?: Remult) => boolean)
 export class Allow {
   static everyone = () => true
   static authenticated = (...args: any[]) => {
@@ -567,30 +593,12 @@ export async function doTransaction(
   remult: Remult,
   what: (dp: DataProvider) => Promise<void>,
 ) {
-  // callers may pass the global proxy - its setter targets the instance while an
-  // active scope shadows the reads, so resolve it to the actual instance first
-  if (!(remult instanceof Remult)) remult = remultStatic.remultFactory()
   const trans = new transactionLiveQueryPublisher(remult.liveQueryPublisher)
-  let ok = true
-  // mutate+restore inside a scope would clobber the enclosing override
-  const scoped = remultStatic.asyncContext.scopedStore()?.remult === remult
-  const prev = remult.dataProvider
-  try {
-    await prev.transaction(async (ds) => {
-      remult.liveQueryPublisher = trans
-      if (scoped) {
-        await withDataProvider(ds, () => what(ds))
-      } else {
-        remult.dataProvider = ds
-        await what(ds)
-      }
-      ok = true
-    })
-
-    if (ok) await trans.flush()
-  } finally {
-    if (!scoped) remult.dataProvider = prev
-  }
+  await remult.dataProvider.transaction(async (ds) => {
+    remult.liveQueryPublisher = trans
+    await withDataProvider(ds, () => what(ds))
+  })
+  await trans.flush()
 }
 class transactionLiveQueryPublisher implements LiveQueryChangesListener {
   constructor(private orig: LiveQueryChangesListener) {}
@@ -636,71 +644,27 @@ export async function withRemult<T>(
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
 }
 
-type ScopedStorePatch = {
-  dataProvider: DataProvider
-  apiClient?: ApiClient
+/** the remult a scope attaches to, or undefined when there is no request cycle to attach to */
+function ambientRemult(): Remult | undefined {
+  try {
+    return remultStatic.remultFactory()
+  } catch {
+    return undefined
+  }
 }
-// tracks overlapping no-storage scopes so only the last exit restores the originals
-const swapState = new WeakMap<
-  Remult,
-  { depth: number; dataProvider: DataProvider; apiClient: ApiClient }
->()
 
-async function withScopedStore<T>(
-  buildPatch: (remult: Remult) => ScopedStorePatch,
+async function withScope<T>(
+  build: (remult: Remult) => Omit<RemultDataScope, 'remult'>,
   callback: () => Promise<T>,
 ): Promise<T> {
-  const storage = remultStatic.asyncContext
-  const store = storage.scopedStore()
-  if (store) {
-    // inInitRequest must not leak into the scope - an in-process api request
-    // issued inside it would be served with the scoped provider and recurse
-    return storage.runWith(
-      {
-        ...store,
-        inInitRequest: undefined,
-        apiClient: undefined,
-        ...buildPatch(store.remult),
-      },
-      callback,
-    )
-  }
-  if (storage.hasStorage() && !storage.tryGetStore()) {
-    // outside a request the enabled factory throws - open a scope like withRemult
-    return withRemult((r) => {
-      const patch = buildPatch(r)
-      r.dataProvider = patch.dataProvider
-      if (patch.apiClient) r.apiClient = patch.apiClient
-      return callback()
-    })
-  }
-  // no async storage (browser): swap and restore the shared instance
-  const r = remultStatic.remultFactory()
-  const patch = buildPatch(r)
-  let state = swapState.get(r)
-  if (!state) {
-    swapState.set(
-      r,
-      (state = {
-        depth: 0,
-        dataProvider: r.dataProvider,
-        apiClient: r.apiClient,
-      }),
-    )
-  }
-  state.depth++
-  r.dataProvider = patch.dataProvider
-  if (patch.apiClient) r.apiClient = patch.apiClient
+  const remult = ambientRemult()
+  if (!remult) return withRemult(() => withScope(build, callback))
+  const scope: RemultDataScope = { remult, ...build(remult) }
   try {
-    return await callback()
+    return await remultStatic.dataScope.run(scope, callback)
   } finally {
     // the scope-private provider must not outlive the scope in the repo cache
-    r.repCache.delete(patch.dataProvider)
-    if (--state.depth === 0) {
-      swapState.delete(r)
-      r.dataProvider = state.dataProvider
-      r.apiClient = state.apiClient
-    }
+    remult.repCache.delete(scope.dataProvider)
   }
 }
 
@@ -709,11 +673,11 @@ async function withScopedStore<T>(
  * `remult` (user, context), only data access is rerouted; concurrent requests are
  * unaffected. Without AsyncLocalStorage it swaps and restores the current provider.
  */
-export async function withDataProvider<T>(
+export function withDataProvider<T>(
   dataProvider: DataProvider,
   callback: () => Promise<T>,
 ): Promise<T> {
-  return withScopedStore(() => ({ dataProvider }), callback)
+  return withScope(() => ({ dataProvider }), callback)
 }
 
 /**
@@ -730,7 +694,7 @@ export function withFetch<T>(
   callback: () => Promise<T>,
   options?: { url?: string },
 ): Promise<T> {
-  return withScopedStore((r) => {
+  return withScope((r) => {
     const apiClient: ApiClient = { ...r.apiClient, httpClient: fetch }
     if (options?.url) apiClient.url = options.url
     return { dataProvider: new RestDataProvider(() => apiClient), apiClient }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -120,8 +120,8 @@ export type RemultDataScope = {
 export class RemultDataScopeStorage {
   /** set by `initAsyncHooks` - without it the scope is process wide */
   core?: RemultAsyncLocalStorageCore<RemultDataScope>
-  // a stack rather than save/restore: scopes that close out of order (parallel
-  // client loads) then leave the still open ones with their own provider
+  // a stack rather than save/restore, so scopes closing out of order (parallel
+  // client loads) leave the still open ones with their own provider
   private stack: RemultDataScope[] = []
   get() {
     if (this.core) return this.core.getStore()
@@ -687,10 +687,10 @@ async function withScope<T>(
 }
 
 /**
- * Runs `callback` with `dataProvider` scoped to the current async context - same
- * `remult` (user, context), only data access is rerouted; concurrent requests are
- * unaffected. Without AsyncLocalStorage the innermost open scope wins, so
- * overlapping scopes in the same process can read each other's provider.
+ * Runs `callback` with `dataProvider` scoped to the current async context. Same
+ * `remult` (user, context), only data access changes, and concurrent requests
+ * keep their own provider. Without AsyncLocalStorage the innermost open scope
+ * wins, so overlapping scopes in the same process can read each other's provider.
  */
 export function withDataProvider<T>(
   dataProvider: DataProvider,
@@ -702,8 +702,8 @@ export function withDataProvider<T>(
 /**
  * Runs `callback` with data access going through the API via `fetch` - the
  * scoped replacement for the deprecated `remult.useFetch`. Inside the scope a
- * `BackendMethod` call behaves exactly like a client call: dispatched over
- * `fetch`, `allowed` enforced at the endpoint, body runs privileged there.
+ * `BackendMethod` call behaves like a client call: it goes over `fetch`, the
+ * endpoint checks `allowed`, and the body runs privileged there.
  * @example
  * export const load = async (event) =>
  *   withFetch(event.fetch, () => repo(Task).find())

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -118,20 +118,23 @@ export type RemultDataScope = {
   apiClient?: ApiClient
 }
 export class RemultDataScopeStorage {
-  /** set by `initAsyncHooks` - without it the scope degrades to save/restore */
+  /** set by `initAsyncHooks` - without it the scope is process wide */
   core?: RemultAsyncLocalStorageCore<RemultDataScope>
-  private current?: RemultDataScope
+  // a stack rather than save/restore: scopes that close out of order (parallel
+  // client loads) then leave the still open ones with their own provider
+  private stack: RemultDataScope[] = []
   get() {
-    return this.core ? this.core.getStore() : this.current
+    if (this.core) return this.core.getStore()
+    return this.stack[this.stack.length - 1]
   }
   async run<T>(scope: RemultDataScope, callback: () => Promise<T>): Promise<T> {
     if (this.core) return this.core.run(scope, callback)
-    const prev = this.current
-    this.current = scope
+    this.stack.push(scope)
     try {
       return await callback()
     } finally {
-      this.current = prev
+      const i = this.stack.lastIndexOf(scope)
+      if (i > -1) this.stack.splice(i, 1)
     }
   }
 }
@@ -593,12 +596,23 @@ export async function doTransaction(
   remult: Remult,
   what: (dp: DataProvider) => Promise<void>,
 ) {
-  const trans = new transactionLiveQueryPublisher(remult.liveQueryPublisher)
-  await remult.dataProvider.transaction(async (ds) => {
-    remult.liveQueryPublisher = trans
-    await withDataProvider(ds, () => what(ds))
-  })
-  await trans.flush()
+  const prevPublisher = remult.liveQueryPublisher
+  const trans = new transactionLiveQueryPublisher(prevPublisher)
+  // the proxy has no identity to pin a scope to, so it falls back to the ambient remult
+  const target = remult instanceof Remult ? remult : undefined
+  try {
+    await remult.dataProvider.transaction(async (ds) => {
+      remult.liveQueryPublisher = trans
+      await withScope(
+        target,
+        () => ({ dataProvider: ds }),
+        () => what(ds),
+      )
+    })
+    await trans.flush()
+  } finally {
+    remult.liveQueryPublisher = prevPublisher
+  }
 }
 class transactionLiveQueryPublisher implements LiveQueryChangesListener {
   constructor(private orig: LiveQueryChangesListener) {}
@@ -644,21 +658,25 @@ export async function withRemult<T>(
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
 }
 
-/** the remult a scope attaches to, or undefined when there is no request cycle to attach to */
-function ambientRemult(): Remult | undefined {
-  try {
-    return remultStatic.remultFactory()
-  } catch {
-    return undefined
-  }
+/**
+ * The remult a scope attaches to, or undefined when there is no request cycle to
+ * attach to. Checks the store instead of catching, so a `remultFactory` that
+ * throws for its own reasons still surfaces its error.
+ */
+/* @internal */
+export function tryGetAmbientRemult(): Remult | undefined {
+  const context = remultStatic.asyncContext
+  if (context.hasStorage() && !context.tryGetStore()) return undefined
+  return remultStatic.remultFactory()
 }
 
 async function withScope<T>(
+  target: Remult | undefined,
   build: (remult: Remult) => Omit<RemultDataScope, 'remult'>,
   callback: () => Promise<T>,
 ): Promise<T> {
-  const remult = ambientRemult()
-  if (!remult) return withRemult(() => withScope(build, callback))
+  const remult = target ?? tryGetAmbientRemult()
+  if (!remult) return withRemult(() => withScope(undefined, build, callback))
   const scope: RemultDataScope = { remult, ...build(remult) }
   try {
     return await remultStatic.dataScope.run(scope, callback)
@@ -671,13 +689,14 @@ async function withScope<T>(
 /**
  * Runs `callback` with `dataProvider` scoped to the current async context - same
  * `remult` (user, context), only data access is rerouted; concurrent requests are
- * unaffected. Without AsyncLocalStorage it swaps and restores the current provider.
+ * unaffected. Without AsyncLocalStorage the innermost open scope wins, so
+ * overlapping scopes in the same process can read each other's provider.
  */
 export function withDataProvider<T>(
   dataProvider: DataProvider,
   callback: () => Promise<T>,
 ): Promise<T> {
-  return withScope(() => ({ dataProvider }), callback)
+  return withScope(undefined, () => ({ dataProvider }), callback)
 }
 
 /**
@@ -694,9 +713,13 @@ export function withFetch<T>(
   callback: () => Promise<T>,
   options?: { url?: string },
 ): Promise<T> {
-  return withScope((r) => {
-    const apiClient: ApiClient = { ...r.apiClient, httpClient: fetch }
-    if (options?.url) apiClient.url = options.url
-    return { dataProvider: new RestDataProvider(() => apiClient), apiClient }
-  }, callback)
+  return withScope(
+    undefined,
+    (r) => {
+      const apiClient: ApiClient = { ...r.apiClient, httpClient: fetch }
+      if (options?.url) apiClient.url = options.url
+      return { dataProvider: new RestDataProvider(() => apiClient), apiClient }
+    },
+    callback,
+  )
 }

--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -96,8 +96,10 @@ export class RemultProxy implements Remult {
   }
   /**
    * @deprecated Mutating the shared request `remult` is unsafe (it can affect a
-   * concurrent `+page.server.ts` on the server). Scope the rest fetch to the read
-   * with `withRemult` instead - see the SvelteKit "Universal load & SSR" doc.
+   * concurrent `+page.server.ts` on the server). Scope the fetch to the read
+   * with `withFetch` instead, e.g.
+   * `withFetch(event.fetch, () => repo(Task).find())`.
+   * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(args: typeof fetch) {
     return remultStatic.remultFactory().useFetch(args)

--- a/projects/core/src/remult-static.ts
+++ b/projects/core/src/remult-static.ts
@@ -44,6 +44,8 @@ if (
 export const remultStatic = x
 
 export function defaultFactory() {
+  const store = remultStatic.asyncContext?.tryGetStore()
+  if (store) return store.remult
   if (!remultStatic.defaultRemult) {
     remultStatic.defaultRemult = remultStatic.defaultRemultFactory()
   }

--- a/projects/core/src/remult-static.ts
+++ b/projects/core/src/remult-static.ts
@@ -1,5 +1,10 @@
 import type { ClassType } from '../classType.js'
-import type { ClassHelper, Remult, RemultAsyncLocalStorage } from './context.js'
+import type {
+  ClassHelper,
+  Remult,
+  RemultAsyncLocalStorage,
+  RemultDataScopeStorage,
+} from './context.js'
 import type { DataProvider } from './data-interfaces.js'
 import type { columnInfo } from './remult3/columnInfo.js'
 
@@ -10,6 +15,7 @@ let x = {
   remultFactory: undefined as unknown as () => Remult,
   defaultRemult: undefined as unknown as Remult,
   asyncContext: undefined as unknown as RemultAsyncLocalStorage,
+  dataScope: undefined as unknown as RemultDataScopeStorage,
   columnsOfType: new Map<any, columnInfo[]>(),
   allEntities: [] as ClassType<any>[],
   classHelpers: new Map<any, ClassHelper>(),

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -35,6 +35,11 @@ interface inArgs {
 interface result {
   data: any
 }
+// a `withFetch` scope makes server-side BackendMethod calls behave like client calls
+function scopedApiClient() {
+  const scoped = remultStatic.asyncContext?.tryGetStore?.()?.apiClient
+  return scoped?.httpClient ? scoped : undefined
+}
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(
     private actionUrl: string,
@@ -282,12 +287,21 @@ export function BackendMethod<type = unknown>(
       result = async function (...args: any[]) {
         if (!isBackend()) {
           return await serverAction.doWork(args, undefined)
-        } else
-          return await originalMethod.apply(
-            //@ts-ignore
-            this as any,
+        }
+        const scoped = scopedApiClient()
+        if (scoped) {
+          return await serverAction.doWork(
             args,
+            undefined,
+            scoped.url,
+            buildRestDataProvider(scoped.httpClient!),
           )
+        }
+        return await originalMethod.apply(
+          //@ts-ignore
+          this as any,
+          args,
+        )
       }
       registerAction(target, result)
       result[serverActionField] = serverAction
@@ -512,7 +526,17 @@ export function BackendMethod<type = unknown>(
       let self: any = this
       if (!isBackend()) {
         return serverAction.doWork(args, self)
-      } else return await originalMethod.apply(self, args)
+      }
+      const scoped = scopedApiClient()
+      if (scoped) {
+        return serverAction.doWork(
+          args,
+          self,
+          scoped.url,
+          buildRestDataProvider(scoped.httpClient!),
+        )
+      }
+      return await originalMethod.apply(self, args)
     }
     registerAction(target.constructor, result)
     result[serverActionField] = serverAction

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -35,10 +35,10 @@ interface inArgs {
 interface result {
   data: any
 }
-// a `withFetch` scope makes server-side BackendMethod calls behave like client calls
-function scopedApiClient() {
-  const scoped = remultStatic.asyncContext?.tryGetStore?.()?.apiClient
-  return scoped?.httpClient ? scoped : undefined
+// a `withFetch` scope makes server-side BackendMethod calls behave like client
+// calls - doWork's url/http defaults resolve through the scope-aware apiClient
+function inFetchScope() {
+  return !!remultStatic.asyncContext?.scopedStore?.()?.apiClient
 }
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(
@@ -285,17 +285,8 @@ export function BackendMethod<type = unknown>(
       }
 
       result = async function (...args: any[]) {
-        if (!isBackend()) {
+        if (!isBackend() || inFetchScope()) {
           return await serverAction.doWork(args, undefined)
-        }
-        const scoped = scopedApiClient()
-        if (scoped) {
-          return await serverAction.doWork(
-            args,
-            undefined,
-            scoped.url,
-            buildRestDataProvider(scoped.httpClient!),
-          )
         }
         return await originalMethod.apply(
           //@ts-ignore
@@ -524,17 +515,8 @@ export function BackendMethod<type = unknown>(
     result = async function (...args: any[]) {
       //@ts-ignore I specifically referred to the this of the original function - so it'll be sent inside
       let self: any = this
-      if (!isBackend()) {
+      if (!isBackend() || inFetchScope()) {
         return serverAction.doWork(args, self)
-      }
-      const scoped = scopedApiClient()
-      if (scoped) {
-        return serverAction.doWork(
-          args,
-          self,
-          scoped.url,
-          buildRestDataProvider(scoped.httpClient!),
-        )
       }
       return await originalMethod.apply(self, args)
     }

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -36,9 +36,12 @@ interface result {
   data: any
 }
 // a `withFetch` scope makes server-side BackendMethod calls behave like client
-// calls - doWork's url/http defaults resolve through the scope-aware apiClient
+// calls - doWork's url/http defaults resolve through the scope-aware apiClient.
+// The scope must not reach the in-process request it dispatches to, hence the
+// check that it belongs to the current remult.
 function inFetchScope() {
-  return !!remultStatic.asyncContext?.scopedStore?.()?.apiClient
+  const scope = remultStatic.dataScope?.get()
+  return !!scope?.apiClient && scope.remult === remultStatic.remultFactory()
 }
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -36,10 +36,9 @@ interface inArgs {
 interface result {
   data: any
 }
-// a `withFetch` scope makes server-side BackendMethod calls behave like client
-// calls - doWork's url/http defaults resolve through the scope-aware apiClient.
-// The scope must not reach the in-process request it dispatches to, hence the
-// check that it belongs to the current remult.
+// in a `withFetch` scope a server-side BackendMethod goes over the wire like a
+// client call - doWork's url/http defaults resolve through the scoped apiClient.
+// The remult check keeps the scope out of the in-process request it dispatches to.
 function inFetchScope() {
   const scope = remultStatic.dataScope?.get()
   return !!scope?.apiClient && scope.remult === tryGetAmbientRemult()

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -8,6 +8,7 @@ import {
   doTransaction,
   isBackend,
   setControllerSettings,
+  tryGetAmbientRemult,
 } from './context.js'
 import type { DataApiResponse } from './data-api.js'
 import type {
@@ -41,7 +42,7 @@ interface result {
 // check that it belongs to the current remult.
 function inFetchScope() {
   const scope = remultStatic.dataScope?.get()
-  return !!scope?.apiClient && scope.remult === remultStatic.remultFactory()
+  return !!scope?.apiClient && scope.remult === tryGetAmbientRemult()
 }
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(

--- a/projects/tests/async-hooks.spec.ts
+++ b/projects/tests/async-hooks.spec.ts
@@ -6,6 +6,7 @@ import { remult } from '../core/src/remult-proxy.js'
 import { remultStatic } from '../core/src/remult-static.js'
 import {
   AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore,
+  initAsyncHooks,
   StubRemultAsyncLocalStorageCore,
 } from '../core/server/initAsyncHooks.js'
 import { remultApi } from '../core/remult-express'
@@ -121,6 +122,41 @@ describe('test stub async hooks', () => {
     expect(result?.id).toBe('1')
     await api.withRemultAsync({} as any, () => repo(t).findFirst())
     expect(count).toBe(2)
+  })
+})
+describe('initAsyncHooks wires the data scope storage', () => {
+  let savedContext: typeof remultStatic.asyncContext
+  let savedCore: typeof remultStatic.dataScope.core
+  beforeEach(() => {
+    savedContext = remultStatic.asyncContext
+    savedCore = remultStatic.dataScope.core
+  })
+  afterEach(() => {
+    remultStatic.asyncContext = savedContext
+    remultStatic.dataScope.core = savedCore
+  })
+  it('gives the data scope a storage even when the remult storage is already set', () => {
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    remultStatic.dataScope.core = undefined
+    const context = remultStatic.asyncContext
+
+    initAsyncHooks()
+
+    expect(remultStatic.dataScope.core).toBeDefined()
+    expect(remultStatic.asyncContext).toBe(context)
+  })
+  it('keeps an existing data scope storage', () => {
+    const core = new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore<any>()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    remultStatic.dataScope.core = core
+
+    initAsyncHooks()
+
+    expect(remultStatic.dataScope.core).toBe(core)
   })
 })
 describe('test with remult within get user & init request', () => {

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -28,7 +28,7 @@ class Task {
   title = ''
 }
 
-@Entity('gatedTasks', {
+@Entity<GatedTask>('gatedTasks', {
   allowApiCrud: true,
   allowApiDelete: false,
   apiPrefilter: { pub: true },

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -46,7 +46,11 @@ class GatedTask {
 
 class GatedMethods {
   @BackendMethod({ allowed: false })
-  static async visibleCount() {
+  static async forbiddenCount() {
+    return await repo(GatedTask).count()
+  }
+  @BackendMethod({ allowed: true })
+  static async totalCount() {
     return await repo(GatedTask).count()
   }
 }
@@ -54,7 +58,7 @@ class GatedMethods {
 // http client backed by a full in-process api pipeline
 function apiHttpClient(dataProvider: DataProvider) {
   const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
-    { entities: [GatedTask], dataProvider },
+    { entities: [GatedTask], controllers: [GatedMethods], dataProvider },
     {
       getRequestBody: async (req) => req.body,
       buildGenericRequestInfo: (req) => ({
@@ -344,10 +348,7 @@ describe('withDataProvider with real async storage', () => {
     )
   })
 
-  // current semantics, locked for the RFC discussion: a server-side BackendMethod
-  // call is a plain function call - `allowed` is NOT checked - but its body's
-  // repo() ops resolve through the scope, so they hit the api rules
-  it('a BackendMethod called inside withFetch runs its body through the api', async () => {
+  it('a BackendMethod inside withFetch is dispatched like a client call - allowed enforced at the endpoint', async () => {
     const db = new InMemoryDataProvider()
     await withRemult(
       async () => {
@@ -362,9 +363,32 @@ describe('withDataProvider with real async storage', () => {
     const http = apiHttpClient(db)
     await withRemult(
       async () => {
-        expect(await GatedMethods.visibleCount()).toBe(2) // privileged outside the scope
-        const gated = await withFetch(http, () => GatedMethods.visibleCount())
-        expect(gated).toBe(1)
+        expect(await GatedMethods.forbiddenCount()).toBe(2) // direct server call, no gate
+        await expect(
+          withFetch(http, () => GatedMethods.forbiddenCount()),
+        ).rejects.toMatchObject({ httpStatusCode: 403 })
+      },
+      { dataProvider: db },
+    )
+  })
+
+  it('a BackendMethod inside withFetch runs its body privileged at the endpoint', async () => {
+    const db = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await repo(GatedTask).insert([
+          { id: 1, title: 'public', pub: true },
+          { id: 2, title: 'private', pub: false },
+        ])
+      },
+      { dataProvider: db },
+    )
+
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        const total = await withFetch(http, () => GatedMethods.totalCount())
+        expect(total).toBe(2) // not gated: the body is server code at the endpoint
       },
       { dataProvider: db },
     )

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -102,6 +102,26 @@ function apiHttpClient(dataProvider: DataProvider) {
   }
 }
 
+// records calls ('GET' urls plain, others prefixed); `get` resolves via onGet
+function mockHttp(onGet: (url: string) => any = () => []) {
+  const calls: string[] = []
+  return {
+    calls,
+    http: {
+      get: async (url: string) => {
+        calls.push(url)
+        return onGet(url)
+      },
+      post: async (url: string) => {
+        calls.push('POST ' + url)
+        return {}
+      },
+      put: async () => ({}),
+      delete: async () => {},
+    },
+  }
+}
+
 function deferred() {
   let resolve!: () => void
   const promise = new Promise<void>((res) => (resolve = res))
@@ -321,16 +341,7 @@ describe('withDataProvider with real async storage', () => {
 
   it('withFetch routes reads through the http client, same user', async () => {
     const dbA = new InMemoryDataProvider()
-    const calls: string[] = []
-    const http = {
-      get: async (url: string) => {
-        calls.push(url)
-        return [{ id: 7, title: 'from api' }]
-      },
-      post: async () => ({}),
-      put: async () => ({}),
-      delete: async () => {},
-    }
+    const { calls, http } = mockHttp(() => [{ id: 7, title: 'from api' }])
     await withRemult(
       async () => {
         remult.user = { id: 'u1' }
@@ -347,16 +358,7 @@ describe('withDataProvider with real async storage', () => {
   })
 
   it('withFetch url option overrides the default api root', async () => {
-    const calls: string[] = []
-    const http = {
-      get: async (url: string) => {
-        calls.push(url)
-        return []
-      },
-      post: async () => ({}),
-      put: async () => ({}),
-      delete: async () => {},
-    }
+    const { calls, http } = mockHttp()
     await withRemult(
       async () => {
         await withFetch(http, () => repo(Task).find(), { url: '/custom' })
@@ -488,16 +490,7 @@ describe('TestApiDataProvider with concurrent server requests', () => {
 
 describe('withDataProvider without async storage (fallback)', () => {
   it('withFetch swaps and restores dataProvider and apiClient', async () => {
-    const calls: string[] = []
-    const http = {
-      get: async (url: string) => {
-        calls.push(url)
-        return []
-      },
-      post: async () => ({}),
-      put: async () => ({}),
-      delete: async () => {},
-    }
+    const { calls, http } = mockHttp()
     const prevDp = remult.dataProvider
     const prevApi = remult.apiClient
     try {
@@ -533,6 +526,169 @@ describe('withDataProvider without async storage (fallback)', () => {
       expect(remult.dataProvider).toBe(dbA)
     } finally {
       remult.dataProvider = prev
+    }
+  })
+})
+
+describe('scoped store fixes', () => {
+  useRealAsyncStorage()
+
+  it('does not carry inInitRequest into the scope', async () => {
+    // a carried flag would make an in-process api request reuse the caller's
+    // remult and serve itself with the scoped provider - infinite recursion
+    await withRemult(async () => {
+      remultStatic.asyncContext.setInInitRequest(true)
+      expect(remultStatic.asyncContext.isInInitRequest()).toBe(true)
+      await withDataProvider(new InMemoryDataProvider(), async () => {
+        expect(remultStatic.asyncContext.isInInitRequest()).toBeFalsy()
+      })
+      await withFetch(mockHttp().http, async () => {
+        expect(remultStatic.asyncContext.isInInitRequest()).toBeFalsy()
+      })
+      expect(remultStatic.asyncContext.isInInitRequest()).toBe(true)
+    })
+  })
+
+  it('doTransaction accepts the global remult proxy inside a scope', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await withDataProvider(dbB, async () => {
+          await expect(
+            doTransaction(remult, async () => {
+              await repo(Task).insert({ id: 1 })
+              throw new Error('rollback')
+            }),
+          ).rejects.toThrow('rollback')
+        })
+        expect(remult.dataProvider).toBe(dbA) // instance default not clobbered
+      },
+      { dataProvider: dbA },
+    )
+    await withRemult(async () => expect(await repo(Task).count()).toBe(0), {
+      dataProvider: dbB,
+    })
+  })
+
+  it('BackendMethods use the scoped fetch also when runningOnServer is false', async () => {
+    const db = new InMemoryDataProvider()
+    await seedGated(db)
+    const http = apiHttpClient(db)
+    const prev = remultStatic.actionInfo.runningOnServer
+    remultStatic.actionInfo.runningOnServer = false
+    try {
+      await withRemult(
+        async () => {
+          expect(await withFetch(http, () => GatedMethods.totalCount())).toBe(2)
+        },
+        { dataProvider: db },
+      )
+    } finally {
+      remultStatic.actionInfo.runningOnServer = prev
+    }
+  })
+
+  it('CRUD and BackendMethods share the base url inside withFetch', async () => {
+    const { calls, http } = mockHttp()
+    await withRemult(
+      async (r) => {
+        r.apiClient.url = '/backend'
+        await withFetch(http, async () => {
+          await repo(Task).find()
+          await GatedMethods.totalCount()
+        })
+        expect(calls).toEqual([
+          '/backend/scopedDpTasks',
+          'POST /backend/totalCount',
+        ])
+      },
+      { dataProvider: new InMemoryDataProvider() },
+    )
+  })
+
+  it('withDataProvider inside withFetch runs BackendMethods directly', async () => {
+    const db = new InMemoryDataProvider()
+    await seedGated(db)
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        await withFetch(http, async () => {
+          await expect(GatedMethods.forbiddenCount()).rejects.toMatchObject({
+            httpStatusCode: 403,
+          })
+          await withDataProvider(db, async () => {
+            expect(await GatedMethods.forbiddenCount()).toBe(2) // privileged again
+          })
+        })
+      },
+      { dataProvider: db },
+    )
+  })
+
+  it('works with async storage enabled but no ambient store', async () => {
+    const db = new InMemoryDataProvider()
+    await seedGated(db)
+    const http = apiHttpClient(db)
+    const rows = await withFetch(http, () => repo(GatedTask).find())
+    expect(rows.map((r) => r.id)).toEqual([1])
+  })
+})
+
+describe('withFetch fallback fixes (no async storage)', () => {
+  it('BackendMethods keep the default api root and the subscriptionClient', async () => {
+    const { calls, http } = mockHttp()
+    const prevDp = remult.dataProvider
+    const prevRunning = remultStatic.actionInfo.runningOnServer
+    remultStatic.actionInfo.runningOnServer = false
+    const subscriptionClient = remult.apiClient.subscriptionClient
+    try {
+      remult.dataProvider = new InMemoryDataProvider()
+      await withFetch(http, async () => {
+        expect(remult.apiClient.subscriptionClient).toBe(subscriptionClient)
+        await GatedMethods.totalCount()
+      })
+      expect(calls).toEqual(['POST /api/totalCount'])
+    } finally {
+      remult.dataProvider = prevDp
+      remultStatic.actionInfo.runningOnServer = prevRunning
+    }
+  })
+
+  it('overlapping scopes restore the original state on last exit', async () => {
+    const a = mockHttp()
+    const b = mockHttp()
+    const prevDp = remult.dataProvider
+    const prevApi = remult.apiClient
+    const origDp = new InMemoryDataProvider()
+    try {
+      remult.dataProvider = origDp
+      const release = deferred()
+      const first = withFetch(a.http, async () => {
+        await release.promise
+      })
+      const second = withFetch(b.http, async () => {})
+      await second
+      release.resolve()
+      await first
+      expect(remult.dataProvider).toBe(origDp)
+      expect(remult.apiClient).toBe(prevApi)
+    } finally {
+      remult.dataProvider = prevDp
+    }
+  })
+
+  it('does not retain the scoped provider in the repo cache', async () => {
+    const { http } = mockHttp()
+    const prevDp = remult.dataProvider
+    try {
+      remult.dataProvider = new InMemoryDataProvider()
+      const r = remultStatic.remultFactory()
+      const before = r.repCache.size
+      await withFetch(http, () => repo(Task).find())
+      expect(r.repCache.size).toBe(before)
+    } finally {
+      remult.dataProvider = prevDp
     }
   })
 })

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, afterEach, describe, expect, it } from 'vitest'
 import {
   BackendMethod,
+  Controller,
   Entity,
   Fields,
   InMemoryDataProvider,
@@ -14,6 +15,7 @@ import {
 import { RemultAsyncLocalStorage, doTransaction } from '../core/src/context.js'
 import { remultStatic } from '../core/src/remult-static.js'
 import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+import { TestApiDataProvider } from '../core/server/test-api-data-provider.js'
 import {
   createRemultServerCore,
   type GenericRequestInfo,
@@ -55,10 +57,28 @@ class GatedMethods {
   }
 }
 
+@Controller('gatedCtrl')
+class GatedController {
+  @Fields.string()
+  note = ''
+  @BackendMethod({ allowed: false })
+  async forbiddenNote() {
+    return this.note
+  }
+  @BackendMethod({ allowed: true })
+  async echo() {
+    return this.note + '!'
+  }
+}
+
 // http client backed by a full in-process api pipeline
 function apiHttpClient(dataProvider: DataProvider) {
   const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
-    { entities: [GatedTask], controllers: [GatedMethods], dataProvider },
+    {
+      entities: [GatedTask],
+      controllers: [GatedMethods, GatedController],
+      dataProvider,
+    },
     {
       getRequestBody: async (req) => req.body,
       buildGenericRequestInfo: (req) => ({
@@ -88,7 +108,34 @@ function deferred() {
   return { promise, resolve }
 }
 
-describe('withDataProvider with real async storage', () => {
+// `find` signals when it starts and blocks until released - holds the call open
+function gated(
+  inner: DataProvider,
+  started: () => void,
+  gate: Promise<void>,
+): DataProvider {
+  return {
+    getEntityDataProvider: (entity) => {
+      const rows = inner.getEntityDataProvider(entity)
+      return {
+        ...rows,
+        count: rows.count.bind(rows),
+        groupBy: rows.groupBy?.bind(rows),
+        update: rows.update.bind(rows),
+        delete: rows.delete.bind(rows),
+        insert: rows.insert.bind(rows),
+        find: async (options) => {
+          started()
+          await gate
+          return rows.find(options)
+        },
+      }
+    },
+    transaction: (action) => inner.transaction(action),
+  }
+}
+
+function useRealAsyncStorage() {
   beforeEach(() => {
     remultStatic.asyncContext = new RemultAsyncLocalStorage(
       new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
@@ -99,6 +146,22 @@ describe('withDataProvider with real async storage', () => {
     RemultAsyncLocalStorage.disable()
     remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
   })
+}
+
+async function seedGated(db: DataProvider) {
+  await withRemult(
+    async () => {
+      await repo(GatedTask).insert([
+        { id: 1, title: 'public', pub: true, secret: 's1' },
+        { id: 2, title: 'private', pub: false, secret: 's2' },
+      ])
+    },
+    { dataProvider: db },
+  )
+}
+
+describe('withDataProvider with real async storage', () => {
+  useRealAsyncStorage()
 
   it('scopes data access, keeps the ambient remult identity', async () => {
     const dbA = new InMemoryDataProvider()
@@ -221,33 +284,17 @@ describe('withDataProvider with real async storage', () => {
     const dbShared = new InMemoryDataProvider()
     const aStarted = deferred()
     const releaseA = deferred()
-    const gatedB: DataProvider = {
-      getEntityDataProvider: (e) => {
-        const inner = dbB.getEntityDataProvider(e)
-        return {
-          ...inner,
-          count: inner.count.bind(inner),
-          groupBy: inner.groupBy?.bind(inner),
-          update: inner.update.bind(inner),
-          delete: inner.delete.bind(inner),
-          insert: inner.insert.bind(inner),
-          find: async (options) => {
-            aStarted.resolve()
-            await releaseA.promise
-            return inner.find(options)
-          },
-        }
-      },
-      transaction: (action) => dbB.transaction(action),
-    }
 
     const requestA = withRemult(
       async () => {
         remult.user = { id: 'A' }
-        return withDataProvider(gatedB, async () => {
-          const rows = await repo(Task).find()
-          return { user: remult.user?.id, rows: rows.length }
-        })
+        return withDataProvider(
+          gated(dbB, aStarted.resolve, releaseA.promise),
+          async () => {
+            const rows = await repo(Task).find()
+            return { user: remult.user?.id, rows: rows.length }
+          },
+        )
       },
       { dataProvider: dbShared },
     )
@@ -321,16 +368,7 @@ describe('withDataProvider with real async storage', () => {
 
   it('withFetch applies the api rules of the endpoint', async () => {
     const db = new InMemoryDataProvider()
-    await withRemult(
-      async () => {
-        await repo(GatedTask).insert([
-          { id: 1, title: 'public', pub: true, secret: 's1' },
-          { id: 2, title: 'private', pub: false, secret: 's2' },
-        ])
-      },
-      { dataProvider: db },
-    )
-
+    await seedGated(db)
     const http = apiHttpClient(db)
     await withRemult(
       async () => {
@@ -348,55 +386,133 @@ describe('withDataProvider with real async storage', () => {
     )
   })
 
-  it('a BackendMethod inside withFetch is dispatched like a client call - allowed enforced at the endpoint', async () => {
+  it('a BackendMethod inside withFetch is dispatched like a client call', async () => {
     const db = new InMemoryDataProvider()
-    await withRemult(
-      async () => {
-        await repo(GatedTask).insert([
-          { id: 1, title: 'public', pub: true },
-          { id: 2, title: 'private', pub: false },
-        ])
-      },
-      { dataProvider: db },
-    )
-
+    await seedGated(db)
     const http = apiHttpClient(db)
     await withRemult(
       async () => {
         expect(await GatedMethods.forbiddenCount()).toBe(2) // direct server call, no gate
         await expect(
           withFetch(http, () => GatedMethods.forbiddenCount()),
-        ).rejects.toMatchObject({ httpStatusCode: 403 })
+        ).rejects.toMatchObject({ httpStatusCode: 403 }) // allowed enforced at the endpoint
+        expect(await withFetch(http, () => GatedMethods.totalCount())).toBe(2) // body runs privileged there
       },
       { dataProvider: db },
     )
   })
 
-  it('a BackendMethod inside withFetch runs its body privileged at the endpoint', async () => {
+  it('an instance BackendMethod inside withFetch is dispatched like a client call', async () => {
     const db = new InMemoryDataProvider()
-    await withRemult(
-      async () => {
-        await repo(GatedTask).insert([
-          { id: 1, title: 'public', pub: true },
-          { id: 2, title: 'private', pub: false },
-        ])
-      },
-      { dataProvider: db },
-    )
-
     const http = apiHttpClient(db)
     await withRemult(
       async () => {
-        const total = await withFetch(http, () => GatedMethods.totalCount())
-        expect(total).toBe(2) // not gated: the body is server code at the endpoint
+        const c = new GatedController()
+        c.note = 'hi'
+        expect(await c.echo()).toBe('hi!') // direct server call
+        await expect(
+          withFetch(http, () => c.forbiddenNote()),
+        ).rejects.toMatchObject({ httpStatusCode: 403 })
+        expect(await withFetch(http, () => c.echo())).toBe('hi!')
       },
       { dataProvider: db },
     )
   })
 })
 
+let userSeenByApiPipeline: string | undefined
+
+@Entity('apiRulesTasks', {
+  allowApiCrud: true,
+  apiPrefilter: () => {
+    userSeenByApiPipeline = remult.user?.id
+    return undefined
+  },
+})
+class ApiRulesTask {
+  @Fields.integer()
+  id = 0
+}
+
+// A withRemult starting while the in-process api call swaps the process-global statics
+// registers in the throwaway context and loses its remult once they are restored.
+describe('TestApiDataProvider with concurrent server requests', () => {
+  useRealAsyncStorage()
+
+  it('a concurrent withRemult keeps its own context and user', async () => {
+    const aCallStarted = deferred()
+    const releaseA = deferred()
+    const bEntered = deferred()
+    const aFinished = deferred()
+
+    const apiDb = TestApiDataProvider({
+      dataProvider: gated(
+        new InMemoryDataProvider(),
+        aCallStarted.resolve,
+        releaseA.promise,
+      ),
+      ensureSchema: false,
+    })
+
+    // Request A: a server load reading through the api pipeline in-process.
+    const requestA = withRemult(
+      async () => {
+        remult.user = { id: 'A' }
+        await repo(ApiRulesTask).find()
+      },
+      { dataProvider: apiDb },
+    ).then(aFinished.resolve)
+
+    // Request B: enters withRemult while A's in-process api call is in flight.
+    const requestB = (async () => {
+      await aCallStarted.promise
+      return withRemult(async () => {
+        const userSeenOnEntry = remult.user?.id
+        remult.user = { id: 'B' }
+        bEntered.resolve()
+        await aFinished.promise // A completes, statics restored
+        return { userSeenOnEntry, userAfterA: remult.user?.id }
+      })
+    })()
+
+    await bEntered.promise
+    releaseA.resolve()
+    await requestA
+
+    const b = await requestB
+    expect(userSeenByApiPipeline).toBe('A') // caller's user reaches the api pipeline
+    expect(b.userSeenOnEntry).toBeUndefined() // leaked 'A' = cross-request user bleed
+    expect(b.userAfterA).toBe('B') // without nesting: 'outside of a valid request cycle'
+  })
+})
+
 describe('withDataProvider without async storage (fallback)', () => {
-  it('swaps and restores on the current remult', async () => {
+  it('withFetch swaps and restores dataProvider and apiClient', async () => {
+    const calls: string[] = []
+    const http = {
+      get: async (url: string) => {
+        calls.push(url)
+        return []
+      },
+      post: async () => ({}),
+      put: async () => ({}),
+      delete: async () => {},
+    }
+    const prevDp = remult.dataProvider
+    const prevApi = remult.apiClient
+    try {
+      remult.dataProvider = new InMemoryDataProvider()
+      const dpBefore = remult.dataProvider
+      await withFetch(http, () => repo(Task).find())
+      expect(calls).toEqual(['/api/scopedDpTasks'])
+      expect(remult.dataProvider).toBe(dpBefore)
+      expect(remult.apiClient).toBe(prevApi)
+    } finally {
+      remult.dataProvider = prevDp
+    }
+  })
+
+  it('swaps and restores, also when the callback throws', async () => {
     const dbA = new InMemoryDataProvider()
     const dbB = new InMemoryDataProvider()
     const prev = remult.dataProvider
@@ -409,17 +525,6 @@ describe('withDataProvider without async storage (fallback)', () => {
       })
       expect(await repo(Task).count()).toBe(1)
       expect(remult.dataProvider).toBe(dbA)
-    } finally {
-      remult.dataProvider = prev
-    }
-  })
-
-  it('restores even when the callback throws', async () => {
-    const dbA = new InMemoryDataProvider()
-    const dbB = new InMemoryDataProvider()
-    const prev = remult.dataProvider
-    try {
-      remult.dataProvider = dbA
       await expect(
         withDataProvider(dbB, async () => {
           throw new Error('boom')

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -1,9 +1,9 @@
 import { beforeEach, afterEach, describe, expect, it } from 'vitest'
 import {
+  BackendMethod,
   Entity,
   Fields,
   InMemoryDataProvider,
-  Remult,
   remult,
   repo,
   withRemult,
@@ -14,6 +14,11 @@ import {
 import { RemultAsyncLocalStorage, doTransaction } from '../core/src/context.js'
 import { remultStatic } from '../core/src/remult-static.js'
 import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+import {
+  createRemultServerCore,
+  type GenericRequestInfo,
+  type RemultServerImplementation,
+} from '../core/server/remult-api-server.js'
 
 @Entity('scopedDpTasks', { allowApiCrud: true })
 class Task {
@@ -21,6 +26,56 @@ class Task {
   id = 0
   @Fields.string()
   title = ''
+}
+
+@Entity('gatedTasks', {
+  allowApiCrud: true,
+  allowApiDelete: false,
+  apiPrefilter: { pub: true },
+})
+class GatedTask {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
+  @Fields.boolean()
+  pub = false
+  @Fields.string({ includeInApi: false })
+  secret = ''
+}
+
+class GatedMethods {
+  @BackendMethod({ allowed: false })
+  static async visibleCount() {
+    return await repo(GatedTask).count()
+  }
+}
+
+// http client backed by a full in-process api pipeline
+function apiHttpClient(dataProvider: DataProvider) {
+  const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
+    { entities: [GatedTask], dataProvider },
+    {
+      getRequestBody: async (req) => req.body,
+      buildGenericRequestInfo: (req) => ({
+        internal: req,
+        public: { headers: new Headers() },
+      }),
+      ignoreAsyncStorage: true,
+    },
+  ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
+  const call = async (method: string, url: string, body?: any) => {
+    const r = await server.handle({ url, method, body })
+    if ((r?.statusCode ?? 200) >= 400)
+      throw { ...r?.data, status: r?.statusCode ?? 500 }
+    return r?.data
+  }
+  return {
+    get: (url: string) => call('GET', url),
+    post: (url: string, body: any) => call('POST', url, body),
+    put: (url: string, body: any) => call('PUT', url, body),
+    delete: (url: string) => call('DELETE', url),
+  }
 }
 
 function deferred() {
@@ -50,12 +105,12 @@ describe('withDataProvider with real async storage', () => {
         await repo(Task).insert({ id: 1, title: 'in A' })
 
         await withDataProvider(dbB, async () => {
-          expect(remult.user?.id).toBe('u1') // same remult, same user
-          expect(await repo(Task).count()).toBe(0) // reads B, not A
+          expect(remult.user?.id).toBe('u1')
+          expect(await repo(Task).count()).toBe(0)
           await repo(Task).insert({ id: 2, title: 'in B' })
         })
 
-        expect(await repo(Task).count()).toBe(1) // back to A
+        expect(await repo(Task).count()).toBe(1)
       },
       { dataProvider: dbA },
     )
@@ -74,14 +129,14 @@ describe('withDataProvider with real async storage', () => {
           await repo(Task).insert({ id: 1 })
           await withRemult(
             async () => {
-              expect(await repo(Task).count()).toBe(0) // sees C, not B
+              expect(await repo(Task).count()).toBe(0)
               await repo(Task).insert({ id: 2 })
             },
             { dataProvider: dbC },
           )
-          expect(await repo(Task).count()).toBe(1) // back to B
+          expect(await repo(Task).count()).toBe(1)
         })
-        expect(await repo(Task).count()).toBe(0) // back to A
+        expect(await repo(Task).count()).toBe(0)
       },
       { dataProvider: dbA },
     )
@@ -95,8 +150,8 @@ describe('withDataProvider with real async storage', () => {
       async () => {
         await withDataProvider(dbB, async () => {
           expect(remult.dataProvider).toBe(dbB)
-          remult.dataProvider = dbC // writes the instance default
-          expect(remult.dataProvider).toBe(dbB) // scope still wins for reads
+          remult.dataProvider = dbC
+          expect(remult.dataProvider).toBe(dbB) // scope wins over the assignment above
         })
         expect(remult.dataProvider).toBe(dbC)
       },
@@ -119,13 +174,13 @@ describe('withDataProvider with real async storage', () => {
       async (r) => {
         await withDataProvider(trackedB, async () => {
           await doTransaction(r, async () => {
-            expect(remult.dataProvider).toBe(dbB) // tx provider, innermost scope
+            expect(remult.dataProvider).toBe(dbB)
             await repo(Task).insert({ id: 1 })
             await repo(Task).insert({ id: 2 })
           })
-          expect(remult.dataProvider).toBe(trackedB) // outer scope restored
+          expect(remult.dataProvider).toBe(trackedB)
         })
-        expect(await repo(Task).count()).toBe(0) // nothing landed in A
+        expect(await repo(Task).count()).toBe(0)
       },
       { dataProvider: dbA },
     )
@@ -194,7 +249,7 @@ describe('withDataProvider with real async storage', () => {
     )
 
     const requestB = (async () => {
-      await aStarted.promise // enter while A's scoped find is in flight
+      await aStarted.promise
       return withRemult(
         async () => {
           remult.user = { id: 'B' }
@@ -209,8 +264,8 @@ describe('withDataProvider with real async storage', () => {
     releaseA.resolve()
     const a = await requestA
 
-    expect(a).toEqual({ user: 'A', rows: 0 }) // A saw gated dbB, kept its user
-    expect(b).toEqual({ user: 'B', count: 1 }) // B unaffected by A's scope
+    expect(a).toEqual({ user: 'A', rows: 0 })
+    expect(b).toEqual({ user: 'B', count: 1 })
   })
 
   it('withFetch routes reads through the http client, same user', async () => {
@@ -234,7 +289,7 @@ describe('withDataProvider with real async storage', () => {
         })
         expect(rows.map((r) => r.id)).toEqual([7])
         expect(calls).toEqual(['/api/scopedDpTasks'])
-        expect(await repo(Task).count()).toBe(0) // back to A
+        expect(await repo(Task).count()).toBe(0)
       },
       { dataProvider: dbA },
     )
@@ -257,6 +312,61 @@ describe('withDataProvider with real async storage', () => {
         expect(calls).toEqual(['/custom/scopedDpTasks'])
       },
       { dataProvider: new InMemoryDataProvider() },
+    )
+  })
+
+  it('withFetch applies the api rules of the endpoint', async () => {
+    const db = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await repo(GatedTask).insert([
+          { id: 1, title: 'public', pub: true, secret: 's1' },
+          { id: 2, title: 'private', pub: false, secret: 's2' },
+        ])
+      },
+      { dataProvider: db },
+    )
+
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        await withFetch(http, async () => {
+          const rows = await repo(GatedTask).find()
+          expect(rows.map((r) => r.id)).toEqual([1]) // apiPrefilter
+          expect(rows[0].secret).toBeFalsy() // includeInApi: false
+          await expect(repo(GatedTask).delete(1)).rejects.toMatchObject({
+            httpStatusCode: 403, // allowApiDelete: false, same error shape a browser gets
+          })
+        })
+        expect(await repo(GatedTask).count()).toBe(2) // privileged again outside
+      },
+      { dataProvider: db },
+    )
+  })
+
+  // current semantics, locked for the RFC discussion: a server-side BackendMethod
+  // call is a plain function call - `allowed` is NOT checked - but its body's
+  // repo() ops resolve through the scope, so they hit the api rules
+  it('a BackendMethod called inside withFetch runs its body through the api', async () => {
+    const db = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await repo(GatedTask).insert([
+          { id: 1, title: 'public', pub: true },
+          { id: 2, title: 'private', pub: false },
+        ])
+      },
+      { dataProvider: db },
+    )
+
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        expect(await GatedMethods.visibleCount()).toBe(2) // privileged outside the scope
+        const gated = await withFetch(http, () => GatedMethods.visibleCount())
+        expect(gated).toBe(1)
+      },
+      { dataProvider: db },
     )
   })
 })

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -1,0 +1,299 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest'
+import {
+  Entity,
+  Fields,
+  InMemoryDataProvider,
+  Remult,
+  remult,
+  repo,
+  withRemult,
+  withDataProvider,
+  withFetch,
+  type DataProvider,
+} from '../core/index.js'
+import { RemultAsyncLocalStorage, doTransaction } from '../core/src/context.js'
+import { remultStatic } from '../core/src/remult-static.js'
+import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+
+@Entity('scopedDpTasks', { allowApiCrud: true })
+class Task {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => (resolve = res))
+  return { promise, resolve }
+}
+
+describe('withDataProvider with real async storage', () => {
+  beforeEach(() => {
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    RemultAsyncLocalStorage.enable()
+  })
+  afterEach(() => {
+    RemultAsyncLocalStorage.disable()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
+  })
+
+  it('scopes data access, keeps the ambient remult identity', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        remult.user = { id: 'u1' }
+        await repo(Task).insert({ id: 1, title: 'in A' })
+
+        await withDataProvider(dbB, async () => {
+          expect(remult.user?.id).toBe('u1') // same remult, same user
+          expect(await repo(Task).count()).toBe(0) // reads B, not A
+          await repo(Task).insert({ id: 2, title: 'in B' })
+        })
+
+        expect(await repo(Task).count()).toBe(1) // back to A
+      },
+      { dataProvider: dbA },
+    )
+    await withRemult(async () => expect(await repo(Task).count()).toBe(1), {
+      dataProvider: dbB,
+    })
+  })
+
+  it('an inner withRemult dataProvider wins over an outer scope', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const dbC = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await withDataProvider(dbB, async () => {
+          await repo(Task).insert({ id: 1 })
+          await withRemult(
+            async () => {
+              expect(await repo(Task).count()).toBe(0) // sees C, not B
+              await repo(Task).insert({ id: 2 })
+            },
+            { dataProvider: dbC },
+          )
+          expect(await repo(Task).count()).toBe(1) // back to B
+        })
+        expect(await repo(Task).count()).toBe(0) // back to A
+      },
+      { dataProvider: dbA },
+    )
+  })
+
+  it('remult.dataProvider reads honor the scope, assignment sets the instance', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const dbC = new InMemoryDataProvider()
+    await withRemult(
+      async () => {
+        await withDataProvider(dbB, async () => {
+          expect(remult.dataProvider).toBe(dbB)
+          remult.dataProvider = dbC // writes the instance default
+          expect(remult.dataProvider).toBe(dbB) // scope still wins for reads
+        })
+        expect(remult.dataProvider).toBe(dbC)
+      },
+      { dataProvider: dbA },
+    )
+  })
+
+  it('doTransaction inside a scope runs on the scoped provider', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    let txOnB = 0
+    const trackedB: DataProvider = {
+      getEntityDataProvider: (e) => dbB.getEntityDataProvider(e),
+      transaction: (action) => {
+        txOnB++
+        return dbB.transaction(action)
+      },
+    }
+    await withRemult(
+      async (r) => {
+        await withDataProvider(trackedB, async () => {
+          await doTransaction(r, async () => {
+            expect(remult.dataProvider).toBe(dbB) // tx provider, innermost scope
+            await repo(Task).insert({ id: 1 })
+            await repo(Task).insert({ id: 2 })
+          })
+          expect(remult.dataProvider).toBe(trackedB) // outer scope restored
+        })
+        expect(await repo(Task).count()).toBe(0) // nothing landed in A
+      },
+      { dataProvider: dbA },
+    )
+    expect(txOnB).toBe(1)
+    await withRemult(async () => expect(await repo(Task).count()).toBe(2), {
+      dataProvider: dbB,
+    })
+  })
+
+  it('a failed doTransaction inside a scope rolls back on the scoped provider', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    await withRemult(
+      async (r) => {
+        await withDataProvider(dbB, async () => {
+          await expect(
+            doTransaction(r, async () => {
+              await repo(Task).insert({ id: 1 })
+              throw new Error('rollback')
+            }),
+          ).rejects.toThrow('rollback')
+        })
+      },
+      { dataProvider: dbA },
+    )
+    await withRemult(async () => expect(await repo(Task).count()).toBe(0), {
+      dataProvider: dbB,
+    })
+  })
+
+  it('concurrent requests each keep their own scope', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const dbShared = new InMemoryDataProvider()
+    const aStarted = deferred()
+    const releaseA = deferred()
+    const gatedB: DataProvider = {
+      getEntityDataProvider: (e) => {
+        const inner = dbB.getEntityDataProvider(e)
+        return {
+          ...inner,
+          count: inner.count.bind(inner),
+          groupBy: inner.groupBy?.bind(inner),
+          update: inner.update.bind(inner),
+          delete: inner.delete.bind(inner),
+          insert: inner.insert.bind(inner),
+          find: async (options) => {
+            aStarted.resolve()
+            await releaseA.promise
+            return inner.find(options)
+          },
+        }
+      },
+      transaction: (action) => dbB.transaction(action),
+    }
+
+    const requestA = withRemult(
+      async () => {
+        remult.user = { id: 'A' }
+        return withDataProvider(gatedB, async () => {
+          const rows = await repo(Task).find()
+          return { user: remult.user?.id, rows: rows.length }
+        })
+      },
+      { dataProvider: dbShared },
+    )
+
+    const requestB = (async () => {
+      await aStarted.promise // enter while A's scoped find is in flight
+      return withRemult(
+        async () => {
+          remult.user = { id: 'B' }
+          await repo(Task).insert({ id: 9 })
+          return { user: remult.user?.id, count: await repo(Task).count() }
+        },
+        { dataProvider: dbA },
+      )
+    })()
+
+    const b = await requestB
+    releaseA.resolve()
+    const a = await requestA
+
+    expect(a).toEqual({ user: 'A', rows: 0 }) // A saw gated dbB, kept its user
+    expect(b).toEqual({ user: 'B', count: 1 }) // B unaffected by A's scope
+  })
+
+  it('withFetch routes reads through the http client, same user', async () => {
+    const dbA = new InMemoryDataProvider()
+    const calls: string[] = []
+    const http = {
+      get: async (url: string) => {
+        calls.push(url)
+        return [{ id: 7, title: 'from api' }]
+      },
+      post: async () => ({}),
+      put: async () => ({}),
+      delete: async () => {},
+    }
+    await withRemult(
+      async () => {
+        remult.user = { id: 'u1' }
+        const rows = await withFetch(http, async () => {
+          expect(remult.user?.id).toBe('u1')
+          return repo(Task).find()
+        })
+        expect(rows.map((r) => r.id)).toEqual([7])
+        expect(calls).toEqual(['/api/scopedDpTasks'])
+        expect(await repo(Task).count()).toBe(0) // back to A
+      },
+      { dataProvider: dbA },
+    )
+  })
+
+  it('withFetch url option overrides the default api root', async () => {
+    const calls: string[] = []
+    const http = {
+      get: async (url: string) => {
+        calls.push(url)
+        return []
+      },
+      post: async () => ({}),
+      put: async () => ({}),
+      delete: async () => {},
+    }
+    await withRemult(
+      async () => {
+        await withFetch(http, () => repo(Task).find(), { url: '/custom' })
+        expect(calls).toEqual(['/custom/scopedDpTasks'])
+      },
+      { dataProvider: new InMemoryDataProvider() },
+    )
+  })
+})
+
+describe('withDataProvider without async storage (fallback)', () => {
+  it('swaps and restores on the current remult', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const prev = remult.dataProvider
+    try {
+      remult.dataProvider = dbA
+      await repo(Task).insert({ id: 1 })
+      await withDataProvider(dbB, async () => {
+        expect(await repo(Task).count()).toBe(0)
+        await repo(Task).insert({ id: 2 })
+      })
+      expect(await repo(Task).count()).toBe(1)
+      expect(remult.dataProvider).toBe(dbA)
+    } finally {
+      remult.dataProvider = prev
+    }
+  })
+
+  it('restores even when the callback throws', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const prev = remult.dataProvider
+    try {
+      remult.dataProvider = dbA
+      await expect(
+        withDataProvider(dbB, async () => {
+          throw new Error('boom')
+        }),
+      ).rejects.toThrow('boom')
+      expect(remult.dataProvider).toBe(dbA)
+    } finally {
+      remult.dataProvider = prev
+    }
+  })
+})

--- a/projects/tests/scoped-data-provider.spec.ts
+++ b/projects/tests/scoped-data-provider.spec.ts
@@ -6,6 +6,7 @@ import {
   Fields,
   InMemoryDataProvider,
   remult,
+  Remult,
   repo,
   withRemult,
   withDataProvider,
@@ -277,6 +278,31 @@ describe('withDataProvider with real async storage', () => {
     })
   })
 
+  it('doTransaction scopes the remult it was given, not the ambient one', async () => {
+    const dbA = new InMemoryDataProvider()
+    const committed = new InMemoryDataProvider()
+    const inTransaction = new InMemoryDataProvider()
+    const dbB: DataProvider = {
+      getEntityDataProvider: (e) => committed.getEntityDataProvider(e),
+      transaction: (action) => inTransaction.transaction(action),
+    }
+    await withRemult(
+      async () => {
+        // a remult of its own, not the one the request cycle put in the store
+        const other = new Remult(dbB)
+        await doTransaction(other, async (ds) => {
+          expect(other.dataProvider).toBe(ds)
+          await other.repo(Task).insert({ id: 1 })
+        })
+        expect(await other.repo(Task).count()).toBe(0) // the write went to the transaction
+        await withRemult(async () => expect(await repo(Task).count()).toBe(1), {
+          dataProvider: inTransaction,
+        })
+      },
+      { dataProvider: dbA },
+    )
+  })
+
   it('a failed doTransaction inside a scope rolls back on the scoped provider', async () => {
     const dbA = new InMemoryDataProvider()
     const dbB = new InMemoryDataProvider()
@@ -502,6 +528,30 @@ describe('withDataProvider without async storage (fallback)', () => {
       expect(remult.apiClient).toBe(prevApi)
     } finally {
       remult.dataProvider = prevDp
+    }
+  })
+
+  it('a scope closing out of order leaves an open sibling with its own provider', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    const dbC = new InMemoryDataProvider()
+    const prev = remult.dataProvider
+    const releaseFirst = deferred()
+    const releaseSecond = deferred()
+    try {
+      remult.dataProvider = dbA
+      const first = withDataProvider(dbB, () => releaseFirst.promise)
+      const second = withDataProvider(dbC, async () => {
+        await releaseSecond.promise
+        return remult.dataProvider
+      })
+      releaseFirst.resolve()
+      await first
+      releaseSecond.resolve()
+      expect(await second).toBe(dbC)
+      expect(remult.dataProvider).toBe(dbA)
+    } finally {
+      remult.dataProvider = prev
     }
   })
 


### PR DESCRIPTION
- `withDataProvider(dp, fn)` scopes data access via the async-context store: same `remult` (user, context), only data access is rerouted, concurrent requests unaffected. `remult.dataProvider` reads honor the innermost scope; assignment still sets the instance default.
- `withFetch(event.fetch, () => repo(Task).find())` is the scoped successor of the deprecated `useFetch` (#1026) for SSR loads. `doTransaction` now nests through the same mechanism instead of mutate-and-restore, which also makes parallel transactions on one request safe.
- Inside `withFetch`, a `BackendMethod` call behaves exactly like a client call: dispatched over the scoped fetch, `allowed` enforced at the endpoint (403 otherwise), body runs privileged there, `transactional` honored. Verified against a full in-process api pipeline, along with `apiPrefilter` / `includeInApi` / `allowApiDelete` applying through `withFetch` with the same error shape a browser gets.
- Draft to discuss the direction: groundwork for an in-process `enforceApiRules` (server reads/writes behaving exactly like client API calls) and a slimmer `TestApiDataProvider`. Relates to #1030 (which stays worthwhile for the current harness).