### PR TITLE
ci: run on node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 🧑‍💻 Setup env
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: 📦 install things
         run: npm i
@@ -46,7 +46,7 @@ jobs:
       - name: 🧑‍💻 Setup env
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: 📦 Install dependencies
         run: cd projects/create-remult && npm i
@@ -110,7 +110,7 @@ jobs:
       - name: 🧑‍💻 Setup env
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: 🛠️ Build create-remult
         run: cd projects/create-remult && npm i && npm run build


### PR DESCRIPTION
The nuxt template resolves `nuxt: ^4.0.1` to 4.5.x, whose dependency tree crashes npm 10 with `Cannot read properties of null (reading 'edgesOut')`. Node 24 ships npm 11, which resolves it.

Verified on node 24.19.0 / npm 11.17.0: all three jobs pass, including `Verify Create` for nuxt, react and sveltekit templates.