### PR TITLE
feat: withFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added `withFetch(fetch, (remult) => ...)`: runs the callback with a `remult` that reads through the api via `fetch`, keeping the current user and context. Replaces the deprecated `remult.useFetch` in a SvelteKit universal `load`; `BackendMethod` calls inside go over the same fetch.
+- `withRemult` accepts `from: remult` to copy `user`, `context` and `apiClient` from another remult.
+
 ## [3.3.17] - 2026-08-24
 
 - Fixed `TypeError: Cannot delete property` on client save when a field has `includeInApi: false` and the entity was subscribed (e.g. grid dirty tracking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Added `withFetch(fetch, (remult) => ...)`: runs the callback with a `remult` that reads through the api via `fetch`, keeping the current user and context. Replaces the deprecated `remult.useFetch` in a SvelteKit universal `load`; `BackendMethod` calls inside go over the same fetch.
-- `withRemult` accepts `from: remult` to copy `user`, `context` and `apiClient` from another remult.
 
 ## [3.3.17] - 2026-08-24
 

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -107,20 +107,21 @@ export const handle = sequence(
 
 ## Extra - Universal load & SSR
 
-To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
+To use remult in an SSR `PageLoad`, route the read through the API with `withFetch` and the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
 
-Scope it to the read with `withRemult` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using.
+`withFetch` hands the callback its own `remult` (same user and context, data access through `event.fetch`) instead of mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (what the deprecated `remult.useFetch` does) would change the provider that other load is using. `BackendMethod` calls inside the callback go over `event.fetch` too, so their `allowed` rule is enforced at the endpoint.
+
+Use the `remult` the callback receives: in the browser there is no async context, so the global `remult` is not scoped there.
 
 ::: code-group
 
 ```ts [src/routes/+page.ts]
-import { RestDataProvider, withRemult } from 'remult'
+import { withFetch } from 'remult'
 import type { PageLoad } from './$types'
 
 export const load = (async (event) => {
-  return withRemult((remult) => remult.repo(Task).find(), {
-    dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })),
-  })
+  const tasks = await withFetch(event.fetch, (remult) => remult.repo(Task).find())
+  return { tasks }
 }) satisfies PageLoad
 ```
 

--- a/examples/sveltekit-todo/src/routes/+page.server.ts
+++ b/examples/sveltekit-todo/src/routes/+page.server.ts
@@ -8,7 +8,8 @@ export const load = (async (event) => {
   // api level: through the api as the current user, so includeInApi,
   // allowApi* and apiPrefilter apply. Same global repo(), scoped by withFetch.
   const fromApi = await withFetch(event.fetch, () => repo(Task).find())
-  // plain objects: toJson would apply includeInApi again for the current user
-  const pick = (t: Task) => ({ id: t.id, title: t.title, ownerId: t.ownerId })
-  return { fromDb: fromDb.map(pick), fromApi: fromApi.map(pick) }
+
+  const names = (tasks: Task[]) => tasks.map((t) => t.createdBy ?? '(hidden)')
+  console.log('createdBy from db:', names(fromDb), 'via api:', names(fromApi))
+  return { fromDb: names(fromDb), fromApi: names(fromApi) }
 }) satisfies PageServerLoad

--- a/examples/sveltekit-todo/src/routes/+page.server.ts
+++ b/examples/sveltekit-todo/src/routes/+page.server.ts
@@ -1,15 +1,22 @@
 import { repo, withFetch } from 'remult'
 import { Task } from '../shared/Task'
+import { TasksController } from '../shared/TasksController'
 import type { PageServerLoad } from './$types'
 
 export const load = (async (event) => {
-  // privileged: straight to the database, every field, no api rule
+  // privileged: straight to the database, every field, allowed is not checked
   const fromDb = await repo(Task).find()
-  // api level: through the api as the current user, so includeInApi,
-  // allowApi* and apiPrefilter apply. Same global repo(), scoped by withFetch.
-  const fromApi = await withFetch(event.fetch, () => repo(Task).find())
+  const directCount = await TasksController.countAll()
+
+  // api level: through the api as the current user, so includeInApi, allowApi*
+  // and allowed apply. Same global repo() and BackendMethod, scoped by withFetch.
+  const { fromApi, apiCount } = await withFetch(event.fetch, async () => ({
+    fromApi: await repo(Task).find(),
+    apiCount: await TasksController.countAll().catch(() => '(forbidden)'),
+  }))
 
   const names = (tasks: Task[]) => tasks.map((t) => t.createdBy ?? '(hidden)')
-  console.log('createdBy from db:', names(fromDb), 'via api:', names(fromApi))
-  return { fromDb: names(fromDb), fromApi: names(fromApi) }
+  console.log('[+page.server.ts] createdBy from db:', names(fromDb), 'via api:', names(fromApi))
+  console.log('[+page.server.ts] countAll direct:', directCount, 'via api:', apiCount)
+  return { fromDb: names(fromDb), fromApi: names(fromApi), directCount, apiCount }
 }) satisfies PageServerLoad

--- a/examples/sveltekit-todo/src/routes/+page.server.ts
+++ b/examples/sveltekit-todo/src/routes/+page.server.ts
@@ -5,15 +5,19 @@ import type { PageServerLoad } from './$types'
 
 export const load = (async (event) => {
   // privileged: straight to the database, every field, allowed is not checked
-  const fromDb = await repo(Task).find()
-  const directCount = await TasksController.countAll()
+  const [fromDb, directCount] = await Promise.all([
+    repo(Task).find(),
+    TasksController.countAll(),
+  ])
 
   // api level: through the api as the current user, so includeInApi, allowApi*
   // and allowed apply. Same global repo() and BackendMethod, scoped by withFetch.
-  const { fromApi, apiCount } = await withFetch(event.fetch, async () => ({
-    fromApi: await repo(Task).find(),
-    apiCount: await TasksController.countAll().catch(() => '(forbidden)'),
-  }))
+  const [fromApi, apiCount] = await withFetch(event.fetch, () =>
+    Promise.all([
+      repo(Task).find(),
+      TasksController.countAll().catch(() => '(forbidden)'),
+    ]),
+  )
 
   const names = (tasks: Task[]) => tasks.map((t) => t.createdBy ?? '(hidden)')
   console.log('[+page.server.ts] createdBy from db:', names(fromDb), 'via api:', names(fromApi))

--- a/examples/sveltekit-todo/src/routes/+page.server.ts
+++ b/examples/sveltekit-todo/src/routes/+page.server.ts
@@ -1,0 +1,14 @@
+import { repo, withFetch } from 'remult'
+import { Task } from '../shared/Task'
+import type { PageServerLoad } from './$types'
+
+export const load = (async (event) => {
+  // privileged: straight to the database, every field, no api rule
+  const fromDb = await repo(Task).find()
+  // api level: through the api as the current user, so includeInApi,
+  // allowApi* and apiPrefilter apply. Same global repo(), scoped by withFetch.
+  const fromApi = await withFetch(event.fetch, () => repo(Task).find())
+  // plain objects: toJson would apply includeInApi again for the current user
+  const pick = (t: Task) => ({ id: t.id, title: t.title, ownerId: t.ownerId })
+  return { fromDb: fromDb.map(pick), fromApi: fromApi.map(pick) }
+}) satisfies PageServerLoad

--- a/examples/sveltekit-todo/src/routes/+page.svelte
+++ b/examples/sveltekit-todo/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import { Task } from '../shared/Task'
   import { TasksController } from '../shared/TasksController'
   import { signOut } from '@auth/sveltekit/client'
+  import { invalidateAll } from '$app/navigation'
 
   let { data } = $props()
 
@@ -109,6 +110,15 @@
     </div>
 
     <section>
+      <h2>+page.ts: universal load (SSR & CSR)</h2>
+      <p>
+        <code>withFetch(event.fetch, (remult) => remult.repo(Task).find())</code>
+        last ran on: <b>{data.ranOn}</b>, {data.tasks.length} tasks.
+        <button onclick={() => invalidateAll()}>re-run loads (CSR)</button>
+      </p>
+    </section>
+
+    <section>
       <h2>+page.server.ts: privileged vs api level</h2>
       <p>
         Same <code>repo(Task).find()</code>, once straight on the database,
@@ -118,6 +128,10 @@
       </p>
       <p>createdBy from db: {data.fromDb.join(', ')}</p>
       <p>createdBy via api: {data.fromApi.join(', ')}</p>
+      <p>
+        <code>TasksController.countAll()</code> (<code>allowed: 'admin'</code>)
+        direct: {data.directCount}, via api: {data.apiCount}
+      </p>
     </section>
   </main>
 </div>

--- a/examples/sveltekit-todo/src/routes/+page.svelte
+++ b/examples/sveltekit-todo/src/routes/+page.svelte
@@ -107,5 +107,31 @@
       <button onclick={() => setAllCompleted(false)}>Mark All Incomplete</button
       >
     </div>
+
+    <section>
+      <h2>+page.server.ts: privileged vs api level</h2>
+      <p>
+        Same <code>repo(Task).find()</code>, once straight on the database,
+        once through <code>withFetch(event.fetch)</code> as {remult.user?.name}.
+        <code>ownerId</code> is <code>includeInApi: 'admin'</code>, so log in as
+        Steve to see the api side hide it.
+      </p>
+      <table>
+        <thead>
+          <tr><th>title</th><th>ownerId from db</th><th>ownerId via api</th></tr>
+        </thead>
+        <tbody>
+          {#each data.fromDb as t (t.id)}
+            <tr>
+              <td>{t.title}</td>
+              <td>{t.ownerId}</td>
+              <td>
+                {data.fromApi.find((a) => a.id === t.id)?.ownerId ?? '(hidden)'}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
   </main>
 </div>

--- a/examples/sveltekit-todo/src/routes/+page.svelte
+++ b/examples/sveltekit-todo/src/routes/+page.svelte
@@ -113,25 +113,11 @@
       <p>
         Same <code>repo(Task).find()</code>, once straight on the database,
         once through <code>withFetch(event.fetch)</code> as {remult.user?.name}.
-        <code>ownerId</code> is <code>includeInApi: 'admin'</code>, so log in as
-        Steve to see the api side hide it.
+        <code>createdBy</code> is <code>includeInApi: 'admin'</code>, so log in
+        as Steve to see the api side hide it.
       </p>
-      <table>
-        <thead>
-          <tr><th>title</th><th>ownerId from db</th><th>ownerId via api</th></tr>
-        </thead>
-        <tbody>
-          {#each data.fromDb as t (t.id)}
-            <tr>
-              <td>{t.title}</td>
-              <td>{t.ownerId}</td>
-              <td>
-                {data.fromApi.find((a) => a.id === t.id)?.ownerId ?? '(hidden)'}
-              </td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+      <p>createdBy from db: {data.fromDb.join(', ')}</p>
+      <p>createdBy via api: {data.fromApi.join(', ')}</p>
     </section>
   </main>
 </div>

--- a/examples/sveltekit-todo/src/routes/+page.svelte
+++ b/examples/sveltekit-todo/src/routes/+page.svelte
@@ -4,12 +4,13 @@
   import { TasksController } from '../shared/TasksController'
   import { signOut } from '@auth/sveltekit/client'
 
-  let tasks = $state<Task[]>([])
+  let { data } = $props()
+
+  // loaded in +page.ts, so the list is already there on SSR; the live query keeps it fresh
+  // svelte-ignore state_referenced_locally
+  let tasks = $state<Task[]>(data.tasks)
 
   $effect(() => {
-    // repo(Task)
-    //   .find()
-    //   .then((t) => (tasks = t));
     return repo(Task)
       .liveQuery()
       .subscribe((info) => {

--- a/examples/sveltekit-todo/src/routes/+page.ts
+++ b/examples/sveltekit-todo/src/routes/+page.ts
@@ -1,0 +1,11 @@
+import { withFetch } from 'remult'
+import { Task } from '../shared/Task'
+import type { PageLoad } from './$types'
+
+// Runs on the server (SSR) and in the browser. `event.fetch` carries the auth
+// cookie, so the api rules of Task apply on both sides, and the browser reuses
+// the SSR response instead of fetching again.
+export const load = (async (event) => {
+  const tasks = await withFetch(event.fetch, (remult) => remult.repo(Task).find())
+  return { tasks }
+}) satisfies PageLoad

--- a/examples/sveltekit-todo/src/routes/+page.ts
+++ b/examples/sveltekit-todo/src/routes/+page.ts
@@ -7,5 +7,5 @@ import type { PageLoad } from './$types'
 // the SSR response instead of fetching again.
 export const load = (async (event) => {
   const tasks = await withFetch(event.fetch, (remult) => remult.repo(Task).find())
-  return { tasks }
+  return { ...event.data, tasks }
 }) satisfies PageLoad

--- a/examples/sveltekit-todo/src/routes/+page.ts
+++ b/examples/sveltekit-todo/src/routes/+page.ts
@@ -3,10 +3,8 @@ import { withFetch } from 'remult'
 import { Task } from '../shared/Task'
 import type { PageLoad } from './$types'
 
-// Universal load: runs on the server for SSR, again in the browser on hydration
-// (event.fetch replays the SSR response, no second request) and on client-side
-// navigation. Use the remult the callback hands you: in the browser there is no
-// async context, so the global remult is not scoped.
+// use the callback's remult: in the browser there is no async context, so the
+// global remult is not scoped there
 export const load = (async (event) => {
   const tasks = await withFetch(event.fetch, (remult) => remult.repo(Task).find())
   const ranOn = browser ? 'csr' : 'ssr'

--- a/examples/sveltekit-todo/src/routes/+page.ts
+++ b/examples/sveltekit-todo/src/routes/+page.ts
@@ -1,11 +1,15 @@
+import { browser } from '$app/environment'
 import { withFetch } from 'remult'
 import { Task } from '../shared/Task'
 import type { PageLoad } from './$types'
 
-// Runs on the server (SSR) and in the browser. `event.fetch` carries the auth
-// cookie, so the api rules of Task apply on both sides, and the browser reuses
-// the SSR response instead of fetching again.
+// Universal load: runs on the server for SSR, again in the browser on hydration
+// (event.fetch replays the SSR response, no second request) and on client-side
+// navigation. Use the remult the callback hands you: in the browser there is no
+// async context, so the global remult is not scoped.
 export const load = (async (event) => {
   const tasks = await withFetch(event.fetch, (remult) => remult.repo(Task).find())
-  return { ...event.data, tasks }
+  const ranOn = browser ? 'csr' : 'ssr'
+  console.log(`[+page.ts] ${ranOn}: ${tasks.length} tasks via event.fetch`)
+  return { ...event.data, tasks, ranOn }
 }) satisfies PageLoad

--- a/examples/sveltekit-todo/src/shared/Task.ts
+++ b/examples/sveltekit-todo/src/shared/Task.ts
@@ -1,9 +1,12 @@
-import { Allow, Entity, Fields } from 'remult'
+import { Allow, Entity, Fields, remult } from 'remult'
 
 @Entity<Task>('tasks', {
   allowApiCrud: Allow.authenticated,
   allowApiInsert: 'admin',
   allowApiDelete: 'admin',
+  saving: (task, e) => {
+    if (e.isNew) task.ownerId = remult.user?.id ?? ''
+  },
 })
 export class Task {
   @Fields.id()
@@ -23,4 +26,8 @@ export class Task {
 
   @Fields.createdAt()
   completedAt: Date = new Date()
+
+  // only admins get it through the api, a privileged server read always does
+  @Fields.string({ includeInApi: 'admin', allowApiUpdate: false })
+  ownerId = ''
 }

--- a/examples/sveltekit-todo/src/shared/Task.ts
+++ b/examples/sveltekit-todo/src/shared/Task.ts
@@ -4,9 +4,6 @@ import { Allow, Entity, Fields, remult } from 'remult'
   allowApiCrud: Allow.authenticated,
   allowApiInsert: 'admin',
   allowApiDelete: 'admin',
-  saving: (task, e) => {
-    if (e.isNew) task.createdBy = remult.user?.name ?? ''
-  },
 })
 export class Task {
   @Fields.id()
@@ -29,5 +26,5 @@ export class Task {
 
   // only admins get it through the api, a privileged server read always does
   @Fields.string({ includeInApi: 'admin', allowApiUpdate: false })
-  createdBy = ''
+  createdBy = remult.user?.name ?? ''
 }

--- a/examples/sveltekit-todo/src/shared/Task.ts
+++ b/examples/sveltekit-todo/src/shared/Task.ts
@@ -5,7 +5,7 @@ import { Allow, Entity, Fields, remult } from 'remult'
   allowApiInsert: 'admin',
   allowApiDelete: 'admin',
   saving: (task, e) => {
-    if (e.isNew) task.ownerId = remult.user?.id ?? ''
+    if (e.isNew) task.createdBy = remult.user?.name ?? ''
   },
 })
 export class Task {
@@ -29,5 +29,5 @@ export class Task {
 
   // only admins get it through the api, a privileged server read always does
   @Fields.string({ includeInApi: 'admin', allowApiUpdate: false })
-  ownerId = ''
+  createdBy = ''
 }

--- a/examples/sveltekit-todo/src/shared/TasksController.ts
+++ b/examples/sveltekit-todo/src/shared/TasksController.ts
@@ -2,6 +2,11 @@ import { BackendMethod, remult } from 'remult'
 import { Task } from './Task'
 
 export class TasksController {
+  @BackendMethod({ allowed: 'admin' })
+  static async countAll() {
+    return remult.repo(Task).count()
+  }
+
   @BackendMethod({ allowed: true })
   static async setAllCompleted(completed: boolean) {
     const taskRepo = remult.repo(Task)

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2471,8 +2471,8 @@ export declare class Remult {
   /**
    * @deprecated In SvelteKit, loads run in parallel, so reassigning the shared
    * `remult` data provider here leaks across loads. Scope the fetch to the read
-   * with `withRemult` instead, e.g.
-   * `withRemult((r) => r.repo(X).find(), { dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) })`.
+   * with `withFetch` instead, e.g.
+   * `withFetch(event.fetch, (r) => r.repo(Task).find())`.
    * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(fetch: ApiClient["httpClient"]): void
@@ -3637,6 +3637,13 @@ export declare function valueValidator<valueType>(
   entity: any,
   e: ValidateFieldEvent<any, valueType>,
 ) => string | boolean | Promise<string | boolean>
+export declare function withFetch<T>(
+  fetch: NonNullable<ApiClient["httpClient"]>,
+  callback: (remult: Remult) => Promise<T>,
+  options?: {
+    url?: string
+  },
+): Promise<T>
 export declare function withRemult<T>(
   callback: (remult: Remult) => Promise<T>,
   options?: {
@@ -3644,6 +3651,8 @@ export declare function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
+    /** Copies `user`, `context` and `apiClient` from this remult - same request, different data access */
+    from?: Remult
   },
 ): Promise<T>
 ````

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3651,7 +3651,7 @@ export declare function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
-    /** Copies `user`, `context` and `apiClient` from this remult - same request, different data access */
+    /** Copies the request state (`user`, `context`, `apiClient`, live query wiring) from this remult, only data access changes */
     from?: Remult
   },
 ): Promise<T>

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3651,8 +3651,6 @@ export declare function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
-    /** Copies the request state (`user`, `context`, `apiClient`, live query wiring) from this remult, only data access changes */
-    from?: Remult
   },
 ): Promise<T>
 ````

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -147,6 +147,7 @@ export {
   Allow,
   Remult,
   withRemult,
+  withFetch,
   RemultContext,
   ApiClient,
   isBackend,

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -236,8 +236,8 @@ export class Remult {
   /**
    * @deprecated In SvelteKit, loads run in parallel, so reassigning the shared
    * `remult` data provider here leaks across loads. Scope the fetch to the read
-   * with `withRemult` instead, e.g.
-   * `withRemult((r) => r.repo(X).find(), { dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) })`.
+   * with `withFetch` instead, e.g.
+   * `withFetch(event.fetch, (r) => r.repo(Task).find())`.
    * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(fetch: ApiClient['httpClient']) {
@@ -343,6 +343,8 @@ export class Remult {
     url: '/api',
     subscriptionClient: new SseSubscriptionClient(),
   }
+  /* @internal */
+  backendMethodsThroughApi = false
 }
 
 remultStatic.defaultRemultFactory = () => new Remult()
@@ -580,9 +582,12 @@ export async function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
+    /** Copies `user`, `context` and `apiClient` from this remult - same request, different data access */
+    from?: Remult
   },
 ) {
   const remult = new Remult()
+  if (options?.from) inherit(remult, options.from)
 
   remult.dataProvider = await initDataProvider(
     options?.dataProvider,
@@ -591,4 +596,45 @@ export async function withRemult<T>(
   )
 
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
+}
+
+/**
+ * Runs `callback` with a `remult` that reads through the api via `fetch`, keeping
+ * the current user and context. Replaces the deprecated `remult.useFetch` in a
+ * universal SvelteKit `load`, which runs concurrently with the server load.
+ * `BackendMethod` calls inside go over `fetch` too, so `allowed` is enforced at the endpoint.
+ * @example
+ * export const load = (event) => withFetch(event.fetch, (r) => r.repo(Task).find())
+ */
+export function withFetch<T>(
+  fetch: NonNullable<ApiClient['httpClient']>,
+  callback: (remult: Remult) => Promise<T>,
+  options?: { url?: string },
+): Promise<T> {
+  const remult = new Remult()
+  inherit(remult, ambientRemult())
+  remult.apiClient.httpClient = fetch
+  if (options?.url) remult.apiClient.url = options.url
+  remult.backendMethodsThroughApi = true
+  return remultStatic.asyncContext.run(remult, callback)
+}
+
+function inherit(remult: Remult, from: Remult | undefined) {
+  if (!from) return
+  remult.user = from.user
+  Object.assign(remult.context, from.context)
+  remult.apiClient = { ...from.apiClient }
+  remult.liveQueryStorage = from.liveQueryStorage
+  remult.subscriptionServer = from.subscriptionServer
+  remult.liveQueryPublisher = from.liveQueryPublisher
+}
+
+// undefined outside a request cycle, where the factory throws
+/* @internal */
+export function ambientRemult() {
+  try {
+    return remultStatic.remultFactory()
+  } catch {
+    return undefined
+  }
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -580,12 +580,9 @@ export async function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
-    /** Copies the request state (`user`, `context`, `apiClient`, live query wiring) from this remult, only data access changes */
-    from?: Remult
   },
 ) {
   const remult = new Remult()
-  if (options?.from) inherit(remult, options.from)
 
   remult.dataProvider = await initDataProvider(
     options?.dataProvider,
@@ -624,6 +621,7 @@ export function inFetchScope() {
   return !!remult && fetchScoped.has(remult)
 }
 
+// the request state travels, the data provider does not
 function inherit(remult: Remult, from: Remult | undefined) {
   if (!from) return
   remult.user = from.user

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -343,8 +343,6 @@ export class Remult {
     url: '/api',
     subscriptionClient: new SseSubscriptionClient(),
   }
-  /* @internal */
-  backendMethodsThroughApi = false
 }
 
 remultStatic.defaultRemultFactory = () => new Remult()
@@ -582,7 +580,7 @@ export async function withRemult<T>(
       | DataProvider
       | Promise<DataProvider>
       | (() => Promise<DataProvider | undefined>)
-    /** Copies `user`, `context` and `apiClient` from this remult - same request, different data access */
+    /** Copies the request state (`user`, `context`, `apiClient`, live query wiring) from this remult, only data access changes */
     from?: Remult
   },
 ) {
@@ -600,9 +598,8 @@ export async function withRemult<T>(
 
 /**
  * Runs `callback` with a `remult` that reads through the api via `fetch`, keeping
- * the current user and context. Replaces the deprecated `remult.useFetch` in a
- * universal SvelteKit `load`, which runs concurrently with the server load.
- * `BackendMethod` calls inside go over `fetch` too, so `allowed` is enforced at the endpoint.
+ * the current user and context. `BackendMethod` calls inside go over `fetch` too,
+ * so `allowed` is enforced at the endpoint.
  * @example
  * export const load = (event) => withFetch(event.fetch, (r) => r.repo(Task).find())
  */
@@ -615,8 +612,16 @@ export function withFetch<T>(
   inherit(remult, ambientRemult())
   remult.apiClient.httpClient = fetch
   if (options?.url) remult.apiClient.url = options.url
-  remult.backendMethodsThroughApi = true
+  fetchScoped.add(remult)
   return remultStatic.asyncContext.run(remult, callback)
+}
+
+// kept off the Remult shape: only BackendMethod dispatch reads it
+const fetchScoped = new WeakSet<Remult>()
+/* @internal */
+export function inFetchScope() {
+  const remult = ambientRemult()
+  return !!remult && fetchScoped.has(remult)
 }
 
 function inherit(remult: Remult, from: Remult | undefined) {
@@ -630,8 +635,7 @@ function inherit(remult: Remult, from: Remult | undefined) {
 }
 
 // undefined outside a request cycle, where the factory throws
-/* @internal */
-export function ambientRemult() {
+function ambientRemult() {
   try {
     return remultStatic.remultFactory()
   } catch {

--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -96,8 +96,9 @@ export class RemultProxy implements Remult {
   }
   /**
    * @deprecated Mutating the shared request `remult` is unsafe (it can affect a
-   * concurrent `+page.server.ts` on the server). Scope the rest fetch to the read
-   * with `withRemult` instead - see the SvelteKit "Universal load & SSR" doc.
+   * concurrent `+page.server.ts` on the server). Scope the fetch to the read
+   * with `withFetch` instead, e.g. `withFetch(event.fetch, (r) => r.repo(Task).find())`.
+   * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(args: typeof fetch) {
     return remultStatic.remultFactory().useFetch(args)
@@ -280,6 +281,14 @@ export class RemultProxy implements Remult {
   }
   set subscriptionServer(value: SubscriptionServer) {
     remultStatic.remultFactory().subscriptionServer = value
+  }
+  /* @internal */
+  get backendMethodsThroughApi() {
+    return remultStatic.remultFactory().backendMethodsThroughApi
+  }
+  /* @internal */
+  set backendMethodsThroughApi(value: boolean) {
+    remultStatic.remultFactory().backendMethodsThroughApi = value
   }
 }
 

--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -282,14 +282,6 @@ export class RemultProxy implements Remult {
   set subscriptionServer(value: SubscriptionServer) {
     remultStatic.remultFactory().subscriptionServer = value
   }
-  /* @internal */
-  get backendMethodsThroughApi() {
-    return remultStatic.remultFactory().backendMethodsThroughApi
-  }
-  /* @internal */
-  set backendMethodsThroughApi(value: boolean) {
-    remultStatic.remultFactory().backendMethodsThroughApi = value
-  }
 }
 
 export const remult: Remult = new RemultProxy()

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -8,7 +8,7 @@ import {
   doTransaction,
   isBackend,
   setControllerSettings,
-  ambientRemult,
+  inFetchScope,
 } from './context.js'
 import type { DataApiResponse } from './data-api.js'
 import type {
@@ -36,6 +36,7 @@ interface inArgs {
 interface result {
   data: any
 }
+const dispatchOverApi = () => !isBackend() || inFetchScope()
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(
     private actionUrl: string,
@@ -281,7 +282,7 @@ export function BackendMethod<type = unknown>(
       }
 
       result = async function (...args: any[]) {
-        if (!isBackend() || ambientRemult()?.backendMethodsThroughApi) {
+        if (dispatchOverApi()) {
           return await serverAction.doWork(args, undefined)
         } else
           return await originalMethod.apply(
@@ -511,7 +512,7 @@ export function BackendMethod<type = unknown>(
     result = async function (...args: any[]) {
       //@ts-ignore I specifically referred to the this of the original function - so it'll be sent inside
       let self: any = this
-      if (!isBackend() || ambientRemult()?.backendMethodsThroughApi) {
+      if (dispatchOverApi()) {
         return serverAction.doWork(args, self)
       } else return await originalMethod.apply(self, args)
     }

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -8,6 +8,7 @@ import {
   doTransaction,
   isBackend,
   setControllerSettings,
+  ambientRemult,
 } from './context.js'
 import type { DataApiResponse } from './data-api.js'
 import type {
@@ -280,7 +281,7 @@ export function BackendMethod<type = unknown>(
       }
 
       result = async function (...args: any[]) {
-        if (!isBackend()) {
+        if (!isBackend() || ambientRemult()?.backendMethodsThroughApi) {
           return await serverAction.doWork(args, undefined)
         } else
           return await originalMethod.apply(
@@ -510,7 +511,7 @@ export function BackendMethod<type = unknown>(
     result = async function (...args: any[]) {
       //@ts-ignore I specifically referred to the this of the original function - so it'll be sent inside
       let self: any = this
-      if (!isBackend()) {
+      if (!isBackend() || ambientRemult()?.backendMethodsThroughApi) {
         return serverAction.doWork(args, self)
       } else return await originalMethod.apply(self, args)
     }

--- a/projects/test-servers/sveltekit-server/src/hooks.server.ts
+++ b/projects/test-servers/sveltekit-server/src/hooks.server.ts
@@ -1,0 +1,9 @@
+import type { Handle } from '@sveltejs/kit'
+import { _api } from './routes/api/[...remult]/+server'
+
+// api routes run their own request cycle: an initRequest crash there is the 400
+// the shared server tests expect, through the hook it would surface as a 500
+export const handle: Handle = ({ event, resolve }) =>
+  event.url.pathname.startsWith('/api/')
+    ? resolve(event)
+    : _api({ event, resolve })

--- a/projects/test-servers/sveltekit-server/src/hooks.server.ts
+++ b/projects/test-servers/sveltekit-server/src/hooks.server.ts
@@ -1,9 +1,3 @@
-import type { Handle } from '@sveltejs/kit'
 import { _api } from './routes/api/[...remult]/+server'
 
-// api routes run their own request cycle: an initRequest crash there is the 400
-// the shared server tests expect, through the hook it would surface as a 500
-export const handle: Handle = ({ event, resolve }) =>
-  event.url.pathname.startsWith('/api/')
-    ? resolve(event)
-    : _api({ event, resolve })
+export const handle = _api

--- a/projects/test-servers/sveltekit-server/src/routes/api/[...remult]/+server.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/api/[...remult]/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestEvent } from '@sveltejs/kit'
 
 import { Task } from '../../../shared/Task'
+import { Gated } from '../../../shared/Gated'
 import { TasksController } from '../../../shared/TasksController'
 import { remult } from 'remult'
 import { remultApi } from 'remult/remult-sveltekit'
@@ -16,9 +17,15 @@ const initRequestModule = new Module({
 })
 
 export const _api = remultApi({
-  entities: [Task],
+  entities: [Task, Gated],
   controllers: [TasksController],
   admin: true,
+  getUser: async (event) => {
+    const auth = event.request.headers.get('authorization')
+    if (auth === 'Bearer admin') return { id: 'admin', roles: ['admin'] }
+    if (auth === 'Bearer user') return { id: 'user' }
+    return undefined
+  },
   initRequest: async (event) => {
     remult.context.setHeaders = (headers) => {
       event.setHeaders(headers)

--- a/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.server.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.server.ts
@@ -1,33 +1,31 @@
 import { repo, withFetch } from 'remult'
 import { Gated } from '../../shared/Gated'
 import { Task } from '../../shared/Task'
-import { _api } from '../api/[...remult]/+server'
 import type { PageServerLoad } from './$types'
 
 const show = (rows: Gated[]) => rows.map((r) => `${r.id}:${r.secret ?? ''}`)
 
-export const load = (async (event) =>
-  _api.withRemult(event, async () => {
-    if ((await repo(Gated).count()) === 0)
-      await repo(Gated).insert([
-        { id: 1, pub: true, secret: 's1' },
-        { id: 2, pub: false, secret: 's2' },
-      ])
+export const load = (async (event) => {
+  if ((await repo(Gated).count()) === 0)
+    await repo(Gated).insert([
+      { id: 1, pub: true, secret: 's1' },
+      { id: 2, pub: false, secret: 's2' },
+    ])
 
-    // privileged: the database, every row and field, allowed not checked
-    const fromDb = show(await repo(Gated).find())
-    await Task.testForbidden()
+  // privileged: the database, every row and field, allowed not checked
+  const fromDb = show(await repo(Gated).find())
+  await Task.testForbidden()
 
-    // api level: through event.fetch as the caller, so apiPrefilter,
-    // includeInApi and allowed apply. Same global repo() and BackendMethod.
-    const fromApi = await withFetch(event.fetch, async () =>
-      show(await repo(Gated).find()),
-    )
-    const forbidden = await withFetch(event.fetch, async () =>
-      Task.testForbidden(),
-    ).then(
-      () => 'ran',
-      (e) => e.status,
-    )
-    return { fromDb, fromApi, forbidden }
-  })) satisfies PageServerLoad
+  // api level: through event.fetch as the caller, so apiPrefilter,
+  // includeInApi and allowed apply. Same global repo() and BackendMethod.
+  const fromApi = await withFetch(event.fetch, async () =>
+    show(await repo(Gated).find()),
+  )
+  const forbidden = await withFetch(event.fetch, async () =>
+    Task.testForbidden(),
+  ).then(
+    () => 'ran',
+    (e) => e.status,
+  )
+  return { fromDb, fromApi, forbidden }
+}) satisfies PageServerLoad

--- a/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.server.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.server.ts
@@ -1,0 +1,33 @@
+import { repo, withFetch } from 'remult'
+import { Gated } from '../../shared/Gated'
+import { Task } from '../../shared/Task'
+import { _api } from '../api/[...remult]/+server'
+import type { PageServerLoad } from './$types'
+
+const show = (rows: Gated[]) => rows.map((r) => `${r.id}:${r.secret ?? ''}`)
+
+export const load = (async (event) =>
+  _api.withRemult(event, async () => {
+    if ((await repo(Gated).count()) === 0)
+      await repo(Gated).insert([
+        { id: 1, pub: true, secret: 's1' },
+        { id: 2, pub: false, secret: 's2' },
+      ])
+
+    // privileged: the database, every row and field, allowed not checked
+    const fromDb = show(await repo(Gated).find())
+    await Task.testForbidden()
+
+    // api level: through event.fetch as the caller, so apiPrefilter,
+    // includeInApi and allowed apply. Same global repo() and BackendMethod.
+    const fromApi = await withFetch(event.fetch, async () =>
+      show(await repo(Gated).find()),
+    )
+    const forbidden = await withFetch(event.fetch, async () =>
+      Task.testForbidden(),
+    ).then(
+      () => 'ran',
+      (e) => e.status,
+    )
+    return { fromDb, fromApi, forbidden }
+  })) satisfies PageServerLoad

--- a/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.svelte
+++ b/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { PageData } from './$types'
+  export let data: PageData
+</script>
+
+<h2>withFetch</h2>
+<pre id="result">{@html JSON.stringify(data)}</pre>

--- a/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/with-fetch/+page.ts
@@ -1,0 +1,17 @@
+import { browser } from '$app/environment'
+import { withFetch } from 'remult'
+import { Gated } from '../../shared/Gated'
+import type { PageLoad } from './$types'
+
+// use the callback's remult: in the browser there is no async context, so the
+// global remult is not scoped there
+export const load = (async (event) => {
+  const rows = await withFetch(event.fetch, (remult) =>
+    remult.repo(Gated).find(),
+  )
+  return {
+    ...event.data,
+    universal: rows.map((r) => `${r.id}:${r.secret ?? ''}`),
+    ranOn: browser ? 'csr' : 'ssr',
+  }
+}) satisfies PageLoad

--- a/projects/test-servers/sveltekit-server/src/shared/Gated.ts
+++ b/projects/test-servers/sveltekit-server/src/shared/Gated.ts
@@ -1,0 +1,14 @@
+import { Entity, Fields, remult } from 'remult'
+
+@Entity<Gated>('gated', {
+  allowApiCrud: true,
+  apiPrefilter: () => (remult.isAllowed('admin') ? {} : { pub: true }),
+})
+export class Gated {
+  @Fields.integer()
+  id = 0
+  @Fields.boolean()
+  pub = false
+  @Fields.string({ includeInApi: 'admin' })
+  secret = ''
+}

--- a/projects/tests/backend-tests/all-server-tests.ts
+++ b/projects/tests/backend-tests/all-server-tests.ts
@@ -20,6 +20,7 @@ export function testAsExpressMW(
   additionalTests?: (
     withRemultForTest: (what: () => Promise<void>) => () => Promise<void>,
   ) => void,
+  options?: ServerTestOptions,
 ) {
   let destroy: () => Promise<void>
 
@@ -33,19 +34,22 @@ export function testAsExpressMW(
       }
     })
   })
-  allServerTests(port, {}, additionalTests)
+  allServerTests(port, options, additionalTests)
   afterAll(async () => {
     RemultAsyncLocalStorage.disable()
     return destroy()
   })
 }
 
+export type ServerTestOptions = {
+  skipAsyncHooks?: boolean
+  skipLiveQuery?: boolean
+  /** an initRequest throw is a 400 from the api handler, but a 500 when it happens in a framework hook */
+  initRequestCrashStatus?: number
+}
 export function allServerTests(
   port: number,
-  options?: {
-    skipAsyncHooks?: boolean
-    skipLiveQuery?: boolean
-  },
+  options?: ServerTestOptions,
   additionalTests?: (
     withRemultForTest: (what: () => Promise<void>) => () => Promise<void>,
   ) => void,
@@ -587,11 +591,9 @@ export function allServerTests(
             })
             expect('to never').toBe('be here')
           } catch (error) {
-            if (error instanceof Error) {
-              expect(error.message).toMatchInlineSnapshot(
-                `"Request failed with status code 400"`,
-              )
-            }
+            expect(axios.isAxiosError(error) && error.response?.status).toBe(
+              options?.initRequestCrashStatus ?? 400,
+            )
           }
         }),
       )

--- a/projects/tests/backend-tests/test-sveltekit-server.spec.ts
+++ b/projects/tests/backend-tests/test-sveltekit-server.spec.ts
@@ -55,5 +55,7 @@ describe('test sveltekit server', async () => {
         }),
       )
     },
+    // hooks.server.ts runs initRequest, so its crash surfaces as SvelteKit's 500
+    { initRequestCrashStatus: 500 },
   )
 })

--- a/projects/tests/backend-tests/test-sveltekit-server.spec.ts
+++ b/projects/tests/backend-tests/test-sveltekit-server.spec.ts
@@ -5,11 +5,39 @@ import { handler } from '../../test-servers/sveltekit-server/build/handler.js'
 import axios from 'axios'
 import { remult } from '../../core/index.js'
 
+const REGEX_RESULT = /<pre id="result">([\s\S]*?)<\/pre>/
+const REGEX_HTML_COMMENT = /<!--[\s\S]*?-->/g
+
 describe('test sveltekit server', async () => {
   testAsExpressMW(
     3014,
     (req, res, next) => handler(req, res, next),
     (withRemultForTest) => {
+      const withFetchPage = async (auth?: string) => {
+        const html: string = (
+          await axios.get('http://127.0.0.1:3014/with-fetch', {
+            headers: auth ? { authorization: `Bearer ${auth}` } : {},
+          })
+        ).data
+        const inner = html.match(REGEX_RESULT)![1]
+        return JSON.parse(inner.replace(REGEX_HTML_COMMENT, ''))
+      }
+      it('withFetch in +page.server.ts and +page.ts goes through the api rules', async () => {
+        expect(await withFetchPage()).toEqual({
+          fromDb: ['1:s1', '2:s2'],
+          fromApi: ['1:'],
+          forbidden: 403,
+          universal: ['1:'],
+          ranOn: 'ssr',
+        })
+        expect(await withFetchPage('admin')).toEqual({
+          fromDb: ['1:s1', '2:s2'],
+          fromApi: ['1:s1', '2:s2'],
+          forbidden: 403,
+          universal: ['1:s1', '2:s2'],
+          ranOn: 'ssr',
+        })
+      })
       it(
         'test headers in response',
         withRemultForTest(async () => {

--- a/projects/tests/with-fetch.spec.ts
+++ b/projects/tests/with-fetch.spec.ts
@@ -1,0 +1,362 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  BackendMethod,
+  Controller,
+  Entity,
+  Fields,
+  InMemoryDataProvider,
+  remult,
+  repo,
+  withFetch,
+  withRemult,
+  type DataProvider,
+} from '../core/index.js'
+import { RemultAsyncLocalStorage } from '../core/src/context.js'
+import { remultStatic } from '../core/src/remult-static.js'
+import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+import {
+  createRemultServerCore,
+  type GenericRequestInfo,
+  type RemultServerImplementation,
+} from '../core/server/remult-api-server.js'
+
+@Entity('withFetchTasks', { allowApiCrud: true })
+class Task {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
+}
+
+@Entity<GatedTask>('withFetchGated', {
+  allowApiCrud: true,
+  allowApiDelete: false,
+  apiPrefilter: { pub: true },
+})
+class GatedTask {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
+  @Fields.boolean()
+  pub = false
+  @Fields.string({ includeInApi: false })
+  secret = ''
+}
+
+class GatedMethods {
+  @BackendMethod({ allowed: false })
+  static async forbiddenCount() {
+    return await repo(GatedTask).count()
+  }
+  @BackendMethod({ allowed: true })
+  static async totalCount() {
+    return await repo(GatedTask).count()
+  }
+  @BackendMethod({ allowed: true })
+  static async ping() {
+    return 'pong'
+  }
+}
+
+@Controller('withFetchCtrl')
+class GatedController {
+  @Fields.string()
+  note = ''
+  @BackendMethod({ allowed: false })
+  async forbiddenNote() {
+    return this.note
+  }
+  @BackendMethod({ allowed: true })
+  async echo() {
+    return this.note + '!'
+  }
+}
+
+// http client backed by a full in-process api pipeline
+function apiHttpClient(dataProvider: DataProvider) {
+  const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
+    {
+      entities: [GatedTask],
+      controllers: [GatedMethods, GatedController],
+      dataProvider,
+    },
+    {
+      getRequestBody: async (req) => req.body,
+      buildGenericRequestInfo: (req) => ({
+        internal: req,
+        public: { headers: new Headers() },
+      }),
+      ignoreAsyncStorage: true,
+    },
+  ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
+  const call = async (method: string, url: string, body?: any) => {
+    const r = await server.handle({ url, method, body })
+    if ((r?.statusCode ?? 200) >= 400)
+      throw { ...r?.data, status: r?.statusCode ?? 500 }
+    return r?.data
+  }
+  return {
+    get: (url: string) => call('GET', url),
+    post: (url: string, body: any) => call('POST', url, body),
+    put: (url: string, body: any) => call('PUT', url, body),
+    delete: (url: string) => call('DELETE', url),
+  }
+}
+
+// records the urls it was asked for, `get` answers with `rows`
+function mockHttp(rows: any[] = []) {
+  const calls: string[] = []
+  return {
+    calls,
+    http: {
+      get: async (url: string) => {
+        calls.push(url)
+        return rows
+      },
+      post: async (url: string) => {
+        calls.push('POST ' + url)
+        return {}
+      },
+      put: async () => ({}),
+      delete: async () => {},
+    },
+  }
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => (resolve = res))
+  return { promise, resolve }
+}
+
+function useRealAsyncStorage() {
+  beforeEach(() => {
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    RemultAsyncLocalStorage.enable()
+  })
+  afterEach(() => {
+    RemultAsyncLocalStorage.disable()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
+  })
+}
+
+async function seedGated(db: DataProvider) {
+  await withRemult(
+    async () => {
+      await repo(GatedTask).insert([
+        { id: 1, title: 'public', pub: true, secret: 's1' },
+        { id: 2, title: 'private', pub: false, secret: 's2' },
+      ])
+    },
+    { dataProvider: db },
+  )
+}
+
+describe('withRemult from', () => {
+  useRealAsyncStorage()
+
+  it('copies user, context and apiClient into a new remult', async () => {
+    const dbA = new InMemoryDataProvider()
+    const dbB = new InMemoryDataProvider()
+    await withRemult(
+      async (parent) => {
+        parent.user = { id: 'u1', roles: ['admin'] }
+        ;(parent.context as any).tenant = 't1'
+        parent.apiClient.url = '/parent-api'
+
+        await withRemult(
+          async (r) => {
+            expect(r).not.toBe(parent)
+            expect(remult.user).toEqual({ id: 'u1', roles: ['admin'] })
+            expect(remult.isAllowed('admin')).toBe(true)
+            expect((remult.context as any).tenant).toBe('t1')
+            expect(remult.apiClient.url).toBe('/parent-api')
+            expect(remult.dataProvider).toBe(dbB)
+          },
+          { from: remult, dataProvider: dbB },
+        )
+
+        expect(remult.dataProvider).toBe(dbA)
+      },
+      { dataProvider: dbA },
+    )
+  })
+
+  it('does not share the apiClient object with the parent', async () => {
+    await withRemult(async (parent) => {
+      parent.apiClient.url = '/parent-api'
+      await withRemult(
+        async (r) => {
+          r.apiClient.url = '/child-api'
+        },
+        { from: parent },
+      )
+      expect(parent.apiClient.url).toBe('/parent-api')
+    })
+  })
+})
+
+describe('withFetch with async storage', () => {
+  useRealAsyncStorage()
+
+  it('reads through the fetch, keeps the user, leaves the request remult untouched', async () => {
+    const dbA = new InMemoryDataProvider()
+    const { calls, http } = mockHttp([{ id: 7, title: 'from api' }])
+    await withRemult(
+      async () => {
+        remult.user = { id: 'u1' }
+        const rows = await withFetch(http, async (r) => {
+          expect(r.user?.id).toBe('u1')
+          expect(remult.user?.id).toBe('u1')
+          expect(remult.apiClient.httpClient).toBe(http)
+          return repo(Task).find()
+        })
+        expect(rows.map((r) => r.id)).toEqual([7])
+        expect(calls).toEqual(['/api/withFetchTasks'])
+        expect(remult.dataProvider).toBe(dbA)
+        expect(remult.apiClient.httpClient).toBeUndefined()
+      },
+      { dataProvider: dbA },
+    )
+  })
+
+  it('url option overrides the api root', async () => {
+    const { calls, http } = mockHttp()
+    await withRemult(async () => {
+      await withFetch(http, (r) => r.repo(Task).find(), { url: '/custom' })
+      expect(calls).toEqual(['/custom/withFetchTasks'])
+    })
+  })
+
+  it('a nested withFetch inherits the outer api root', async () => {
+    const outer = mockHttp()
+    const inner = mockHttp()
+    await withRemult(async () => {
+      await withFetch(
+        outer.http,
+        () => withFetch(inner.http, (r) => r.repo(Task).find()),
+        { url: '/custom' },
+      )
+      expect(outer.calls).toEqual([])
+      expect(inner.calls).toEqual(['/custom/withFetchTasks'])
+    })
+  })
+
+  it('applies the api rules of the endpoint', async () => {
+    const db = new InMemoryDataProvider()
+    await seedGated(db)
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        await withFetch(http, async () => {
+          const rows = await repo(GatedTask).find()
+          expect(rows.map((r) => r.id)).toEqual([1]) // apiPrefilter
+          expect(rows[0].secret).toBeFalsy() // includeInApi: false
+          await expect(repo(GatedTask).delete(1)).rejects.toMatchObject({
+            httpStatusCode: 403, // allowApiDelete: false
+          })
+        })
+        expect(await repo(GatedTask).count()).toBe(2) // privileged again outside
+      },
+      { dataProvider: db },
+    )
+  })
+
+  it('dispatches a static BackendMethod like a client call', async () => {
+    const db = new InMemoryDataProvider()
+    await seedGated(db)
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        expect(await GatedMethods.forbiddenCount()).toBe(2) // direct server call, no gate
+        await expect(
+          withFetch(http, () => GatedMethods.forbiddenCount()),
+        ).rejects.toMatchObject({ httpStatusCode: 403 }) // allowed enforced at the endpoint
+        expect(await withFetch(http, () => GatedMethods.totalCount())).toBe(2) // body runs privileged there
+      },
+      { dataProvider: db },
+    )
+  })
+
+  it('dispatches an instance BackendMethod like a client call', async () => {
+    const db = new InMemoryDataProvider()
+    const http = apiHttpClient(db)
+    await withRemult(
+      async () => {
+        const c = new GatedController()
+        c.note = 'hi'
+        expect(await c.echo()).toBe('hi!') // direct server call
+        await expect(
+          withFetch(http, () => c.forbiddenNote()),
+        ).rejects.toMatchObject({ httpStatusCode: 403 })
+        expect(await withFetch(http, () => c.echo())).toBe('hi!')
+      },
+      { dataProvider: db },
+    )
+  })
+
+  it('concurrent loads each keep their own fetch', async () => {
+    const a = mockHttp()
+    const b = mockHttp()
+    const gate = deferred()
+    await withRemult(async () => {
+      const loadA = withFetch(a.http, async (r) => {
+        await gate.promise
+        expect(remult.apiClient.httpClient).toBe(a.http)
+        return r.repo(Task).find()
+      })
+      const loadB = withFetch(b.http, (r) => r.repo(Task).find())
+      await loadB
+      gate.resolve()
+      await loadA
+      expect(a.calls).toEqual(['/api/withFetchTasks'])
+      expect(b.calls).toEqual(['/api/withFetchTasks'])
+    })
+  })
+
+  it('a BackendMethod outside a request cycle still runs in process', async () => {
+    expect(await GatedMethods.ping()).toBe('pong')
+  })
+
+  it('works outside a request cycle', async () => {
+    const { calls, http } = mockHttp()
+    await withFetch(http, async (r) => {
+      expect(r.user).toBeUndefined()
+      await r.repo(Task).find()
+    })
+    expect(calls).toEqual(['/api/withFetchTasks'])
+  })
+})
+
+describe('withFetch without async storage', () => {
+  let runningOnServer: boolean
+  beforeEach(() => {
+    runningOnServer = remultStatic.actionInfo.runningOnServer
+    remultStatic.actionInfo.runningOnServer = false
+    RemultAsyncLocalStorage.disable()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
+  })
+  afterEach(() => {
+    remultStatic.actionInfo.runningOnServer = runningOnServer
+    remult.user = undefined
+  })
+
+  it('reads through the callback remult, global remult untouched', async () => {
+    const { calls, http } = mockHttp([{ id: 3, title: 'x' }])
+    const rows = await withFetch(http, (r) => r.repo(Task).find())
+    expect(rows.map((r) => r.id)).toEqual([3])
+    expect(calls).toEqual(['/api/withFetchTasks'])
+    expect(remult.apiClient.httpClient).toBeUndefined()
+  })
+
+  it('copies the user of the default remult', async () => {
+    remult.user = { id: 'c1' }
+    const { http } = mockHttp()
+    await withFetch(http, async (r) => {
+      expect(r.user?.id).toBe('c1')
+    })
+  })
+})

--- a/projects/tests/with-fetch.spec.ts
+++ b/projects/tests/with-fetch.spec.ts
@@ -124,12 +124,6 @@ function mockHttp(rows: any[] = []) {
   }
 }
 
-function deferred() {
-  let resolve!: () => void
-  const promise = new Promise<void>((res) => (resolve = res))
-  return { promise, resolve }
-}
-
 function useRealAsyncStorage() {
   beforeEach(() => {
     remultStatic.asyncContext = new RemultAsyncLocalStorage(
@@ -301,16 +295,17 @@ describe('withFetch with async storage', () => {
   it('concurrent loads each keep their own fetch', async () => {
     const a = mockHttp()
     const b = mockHttp()
-    const gate = deferred()
+    let open!: () => void
+    const gate = new Promise<void>((r) => (open = r))
     await withRemult(async () => {
       const loadA = withFetch(a.http, async (r) => {
-        await gate.promise
+        await gate
         expect(remult.apiClient.httpClient).toBe(a.http)
         return r.repo(Task).find()
       })
       const loadB = withFetch(b.http, (r) => r.repo(Task).find())
       await loadB
-      gate.resolve()
+      open()
       await loadA
       expect(a.calls).toEqual(['/api/withFetchTasks'])
       expect(b.calls).toEqual(['/api/withFetchTasks'])

--- a/projects/tests/with-fetch.spec.ts
+++ b/projects/tests/with-fetch.spec.ts
@@ -149,50 +149,6 @@ async function seedGated(db: DataProvider) {
   )
 }
 
-describe('withRemult from', () => {
-  useRealAsyncStorage()
-
-  it('copies user, context and apiClient into a new remult', async () => {
-    const dbA = new InMemoryDataProvider()
-    const dbB = new InMemoryDataProvider()
-    await withRemult(
-      async (parent) => {
-        parent.user = { id: 'u1', roles: ['admin'] }
-        ;(parent.context as any).tenant = 't1'
-        parent.apiClient.url = '/parent-api'
-
-        await withRemult(
-          async (r) => {
-            expect(r).not.toBe(parent)
-            expect(remult.user).toEqual({ id: 'u1', roles: ['admin'] })
-            expect(remult.isAllowed('admin')).toBe(true)
-            expect((remult.context as any).tenant).toBe('t1')
-            expect(remult.apiClient.url).toBe('/parent-api')
-            expect(remult.dataProvider).toBe(dbB)
-          },
-          { from: remult, dataProvider: dbB },
-        )
-
-        expect(remult.dataProvider).toBe(dbA)
-      },
-      { dataProvider: dbA },
-    )
-  })
-
-  it('does not share the apiClient object with the parent', async () => {
-    await withRemult(async (parent) => {
-      parent.apiClient.url = '/parent-api'
-      await withRemult(
-        async (r) => {
-          r.apiClient.url = '/child-api'
-        },
-        { from: parent },
-      )
-      expect(parent.apiClient.url).toBe('/parent-api')
-    })
-  })
-})
-
 describe('withFetch with async storage', () => {
   useRealAsyncStorage()
 


### PR DESCRIPTION
Smaller take on #1031: instead of scoping the `dataProvider` globally, `withFetch(fetch, cb)` runs `cb` with its own `remult` - same user, context and apiClient, data access through `fetch`. `BackendMethod` calls inside go over the same fetch, so `allowed` is enforced at the endpoint.

Replaces the deprecated `remult.useFetch` in a SvelteKit universal `load`. ~60 lines in core, no existing signature touched.

```ts
export const load = (event) =>
  withFetch(event.fetch, (remult) => remult.repo(Task).find())
```

Use the `remult` the callback gets: in the browser there is no async context, so the global one is not scoped there.