### PR TITLE
feat: withApiRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added `withApiRules(callback, { fetch? })`: runs the callback in client mode, so `repo(...)` reads and `BackendMethod` calls inside go through the api as the current user and every api rule applies. Meant for a SvelteKit universal `load` (same behaviour on SSR and CSR) and for server code that wants the caller's view of the data; replaces the deprecated `remult.useFetch`.
+
 ## [3.3.17] - 2026-08-24
 
 - Fixed `TypeError: Cannot delete property` on client save when a field has `includeInApi: false` and the entity was subscribed (e.g. grid dirty tracking)

--- a/docs/docs/installation/framework/sveltekit.md
+++ b/docs/docs/installation/framework/sveltekit.md
@@ -107,28 +107,60 @@ export const handle = sequence(
 
 ## Extra - Universal load & SSR
 
-To use remult in an SSR `PageLoad`, route the read through the API using the `event`'s fetch: it works on SSR and CSR (no double fetch on the client), and applies all API rules even when it runs on the server.
+A universal `load` runs on the server for SSR and in the browser on navigation. On
+the server, `repo(...)` reads the database directly and skips every API rule; in
+the browser the same line goes through the API. `withApiRules` removes that split:
+inside it, reads and `BackendMethod` calls always go through the API as the current
+user, so `allowApi*`, `apiPrefilter`, `includeInApi` and `allowed` apply on both
+sides.
 
-Scope it to the read with `withRemult` rather than mutating the shared request `remult`. A universal `load` runs **concurrently** with any `+page.server.ts`, so reassigning the global data provider there (as the deprecated `remult.useFetch` does) would change the provider that other load is using.
+Pass the `event`'s fetch so SvelteKit can serialize the SSR response into the page
+payload instead of the browser fetching it again.
 
 ::: code-group
 
 ```ts [src/routes/+page.ts]
-import { RestDataProvider, withRemult } from 'remult'
+import { repo, withApiRules } from 'remult'
 import type { PageLoad } from './$types'
 
 export const load = (async (event) => {
-  return withRemult((remult) => remult.repo(Task).find(), {
-    dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })),
+  const tasks = await withApiRules(() => repo(Task).find(), {
+    fetch: event.fetch,
   })
+  return { tasks }
 }) satisfies PageLoad
 ```
 
 :::
 
+In the browser this is already how remult reads, so `withApiRules` is a no-op there
+and both sides return the same rows.
+
+Do not reassign the shared request `remult` instead (what the deprecated
+`remult.useFetch` does): a universal `load` runs **concurrently** with any
+`+page.server.ts`, so it would change the data provider that other load is using.
+
 ::: tip
 firstly ships a ready-made wrapper (`remultApiUniversalLoad`) that also handles CSR/hydration reuse - see [remultApiLoad.ts](https://github.com/jycouet/firstly/blob/main/packages/firstly/src/lib/svelte/remultApiLoad.ts).
 :::
+
+## Extra - API rules on the server
+
+The same applies to a `+page.server.ts`, a hook or any server-only code: `repo(...)`
+is privileged there. Wrap a read in `withApiRules` to get the current user's view of
+it instead. Without a `fetch` the call stays in process - it goes through the api
+that is already mounted, without a network roundtrip.
+
+```ts [src/routes/+page.server.ts]
+import { repo, withApiRules } from 'remult'
+
+export const load = async () => ({
+  // every row and field
+  all: await repo(Task).find(),
+  // only what this user may see through the api
+  mine: await withApiRules(() => repo(Task).find()),
+})
+```
 
 ## Extra - Server load
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2477,7 +2477,10 @@ export declare class Remult {
    */
   useFetch(fetch: ApiClient["httpClient"]): void
   /** The current data provider */
-  dataProvider: DataProvider
+  /** The current data provider - an enclosing `withApiRules` wins, assignment sets the instance default */
+  get dataProvider(): DataProvider
+  set dataProvider(dataProvider: DataProvider)
+  private _dataProvider?
   /** Creates a new instance of the `remult` object.
    *
    * Can receive either an HttpProvider or a DataProvider as a parameter - which will be used to fetch data from.
@@ -2517,7 +2520,10 @@ export declare class Remult {
    */
   readonly context: RemultContext
   /** The api client that will be used by `remult` to perform calls to the `api` */
-  apiClient: ApiClient
+  /** The api client that will be used by `remult` to perform calls to the `api` */
+  get apiClient(): ApiClient
+  set apiClient(apiClient: ApiClient)
+  private _apiClient?
 }
 export interface RemultContext {
   headers?: {
@@ -3637,6 +3643,14 @@ export declare function valueValidator<valueType>(
   entity: any,
   e: ValidateFieldEvent<any, valueType>,
 ) => string | boolean | Promise<string | boolean>
+export declare function withApiRules<T>(
+  callback: () => Promise<T>,
+  options?: {
+    /** The framework's fetch, e.g. SvelteKit's `event.fetch`. Without it the call stays in process */
+    fetch?: ApiClient["httpClient"]
+    url?: string
+  },
+): Promise<T>
 export declare function withRemult<T>(
   callback: (remult: Remult) => Promise<T>,
   options?: {

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2476,7 +2476,6 @@ export declare class Remult {
    * See the SvelteKit "Universal load & SSR" doc.
    */
   useFetch(fetch: ApiClient["httpClient"]): void
-  /** The current data provider */
   /** The current data provider - an enclosing `withApiRules` wins, assignment sets the instance default */
   get dataProvider(): DataProvider
   set dataProvider(dataProvider: DataProvider)
@@ -2519,7 +2518,6 @@ export declare class Remult {
    * Check out the [extensibility section](/docs/custom-options#enhancing-field-and-entity-definitions-with-custom-options) for more custom options.
    */
   readonly context: RemultContext
-  /** The api client that will be used by `remult` to perform calls to the `api` */
   /** The api client that will be used by `remult` to perform calls to the `api` */
   get apiClient(): ApiClient
   set apiClient(apiClient: ApiClient)

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -147,6 +147,7 @@ export {
   Allow,
   Remult,
   withRemult,
+  asApiClient,
   RemultContext,
   ApiClient,
   isBackend,

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -147,7 +147,7 @@ export {
   Allow,
   Remult,
   withRemult,
-  asApiClient,
+  withApiRules,
   RemultContext,
   ApiClient,
   isBackend,

--- a/projects/core/server/in-process-api-client.ts
+++ b/projects/core/server/in-process-api-client.ts
@@ -1,5 +1,10 @@
 import { remult } from '../index.js'
-import type { ApiClient } from '../src/context.js'
+export type InProcessHttpClient = {
+  get(url: string): Promise<any>
+  put(url: string, body: any): Promise<any>
+  post(url: string, body: any): Promise<any>
+  delete(url: string): Promise<any>
+}
 import { buildInProcessRequest } from './in-process-request.js'
 import type { RemultServer } from './remult-api-server.js'
 
@@ -11,7 +16,7 @@ import type { RemultServer } from './remult-api-server.js'
  */
 export function buildInProcessHttpClient<RequestType>(
   server: RemultServer<RequestType>,
-): NonNullable<ApiClient['httpClient']> {
+): InProcessHttpClient {
   const call = async (method: string, url: string, body?: any) => {
     const result = await server.handle(
       buildInProcessRequest({

--- a/projects/core/server/in-process-api-client.ts
+++ b/projects/core/server/in-process-api-client.ts
@@ -1,0 +1,68 @@
+import type { DataProvider } from '../index.js'
+import { remult } from '../index.js'
+import type { ApiClient } from '../src/context.js'
+import type { RemultServerOptions } from './index.js'
+import {
+  createRemultServerCore,
+  type GenericRequestInfo,
+  type RemultServerImplementation,
+} from './remult-api-server.js'
+
+type InProcessRequest = GenericRequestInfo & { body?: any; user?: any }
+
+/**
+ * An http client that runs the request through this process' api pipeline instead
+ * of the network - same entities, controllers and data provider as the mounted
+ * api, so every api rule applies, minus the roundtrip.
+ *
+ * It needs a second server because the mounted one speaks its framework's request
+ * type; this one speaks `{ url, method, body }`.
+ */
+export function buildInProcessHttpClient<RequestType>(
+  options: RemultServerOptions<RequestType>,
+  dataProvider: Promise<DataProvider>,
+): NonNullable<ApiClient['httpClient']> {
+  let server: RemultServerImplementation<InProcessRequest> | undefined
+
+  const call = async (method: string, url: string, body?: any) => {
+    if (!server)
+      server = createRemultServerCore<InProcessRequest>(
+        {
+          ...(options as RemultServerOptions<InProcessRequest>),
+          dataProvider,
+          // the mounted api already ensured it, and its initApi already ran
+          ensureSchema: false,
+          initApi: undefined,
+          logApiEndPoints: false,
+          // the caller is already authenticated, the framework request is gone
+          getUser: async (req) => req.user,
+        },
+        {
+          getRequestBody: async (req) => req.body,
+          buildGenericRequestInfo: (req) => ({
+            internal: req,
+            public: { headers: new Headers() },
+          }),
+          ignoreAsyncStorage: true,
+        },
+      ) as RemultServerImplementation<InProcessRequest>
+
+    const result = await server.handle({
+      url,
+      method,
+      body,
+      user: remult.user ? { ...remult.user } : undefined,
+    })
+    if ((result?.statusCode ?? 200) >= 400)
+      throw { ...result?.data, status: result?.statusCode ?? 500 }
+    // the wire would have done it, and callers must not reach the server's rows
+    return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
+  }
+
+  return {
+    get: (url) => call('GET', url),
+    put: (url, body) => call('PUT', url, body),
+    post: (url, body) => call('POST', url, body),
+    delete: (url) => call('DELETE', url),
+  }
+}

--- a/projects/core/server/in-process-api-client.ts
+++ b/projects/core/server/in-process-api-client.ts
@@ -1,61 +1,29 @@
-import type { DataProvider } from '../index.js'
 import { remult } from '../index.js'
 import type { ApiClient } from '../src/context.js'
-import type { RemultServerOptions } from './index.js'
-import {
-  createRemultServerCore,
-  type GenericRequestInfo,
-  type RemultServerImplementation,
-} from './remult-api-server.js'
-
-type InProcessRequest = GenericRequestInfo & { body?: any; user?: any }
+import { buildInProcessRequest } from './in-process-request.js'
+import type { RemultServer } from './remult-api-server.js'
 
 /**
- * An http client that runs the request through this process' api pipeline instead
- * of the network - same entities, controllers and data provider as the mounted
- * api, so every api rule applies, minus the roundtrip.
- *
- * It needs a second server because the mounted one speaks its framework's request
- * type; this one speaks `{ url, method, body }`.
+ * An http client that hands the request to the api mounted in this process
+ * instead of the network - same server, same routes, same rules, minus the
+ * roundtrip. The user comes from the ambient remult, since there is no framework
+ * request to read it from.
  */
 export function buildInProcessHttpClient<RequestType>(
-  options: RemultServerOptions<RequestType>,
-  dataProvider: Promise<DataProvider>,
+  server: RemultServer<RequestType>,
 ): NonNullable<ApiClient['httpClient']> {
-  let server: RemultServerImplementation<InProcessRequest> | undefined
-
   const call = async (method: string, url: string, body?: any) => {
-    if (!server)
-      server = createRemultServerCore<InProcessRequest>(
-        {
-          ...(options as RemultServerOptions<InProcessRequest>),
-          dataProvider,
-          // the mounted api already ensured it, and its initApi already ran
-          ensureSchema: false,
-          initApi: undefined,
-          logApiEndPoints: false,
-          // the caller is already authenticated, the framework request is gone
-          getUser: async (req) => req.user,
-        },
-        {
-          getRequestBody: async (req) => req.body,
-          buildGenericRequestInfo: (req) => ({
-            internal: req,
-            public: { headers: new Headers() },
-          }),
-          ignoreAsyncStorage: true,
-        },
-      ) as RemultServerImplementation<InProcessRequest>
-
-    const result = await server.handle({
-      url,
-      method,
-      body,
-      user: remult.user ? { ...remult.user } : undefined,
-    })
+    const result = await server.handle(
+      buildInProcessRequest({
+        url,
+        method,
+        body,
+        user: remult.user ? { ...remult.user } : undefined,
+      }) as RequestType,
+    )
     if ((result?.statusCode ?? 200) >= 400)
       throw { ...result?.data, status: result?.statusCode ?? 500 }
-    // the wire would have done it, and callers must not reach the server's rows
+    // the wire would have done it, and the caller must not reach the server's own rows
     return result?.data ? JSON.parse(JSON.stringify(result.data)) : undefined
   }
 

--- a/projects/core/server/in-process-request.ts
+++ b/projects/core/server/in-process-request.ts
@@ -1,0 +1,34 @@
+import type { UserInfo } from '../src/context.js'
+import type { GenericRequest, GenericRequestInfo } from './remult-api-server.js'
+
+const inProcessRequest = Symbol.for('remult-in-process-request')
+
+/**
+ * A request that skips the framework adapter, so the api that is already mounted
+ * can serve an in-process call instead of a second server being stood up for it.
+ */
+export type InProcessRequest = GenericRequestInfo & {
+  [inProcessRequest]: true
+  body?: any
+  user?: UserInfo
+}
+
+export function buildInProcessRequest(req: {
+  url: string
+  method: string
+  body?: any
+  user?: UserInfo
+}): InProcessRequest {
+  return { ...req, [inProcessRequest]: true }
+}
+
+export function isInProcessRequest(req: any): req is InProcessRequest {
+  return req?.[inProcessRequest] === true
+}
+
+export function inProcessRequestInfo(req: InProcessRequest): {
+  internal: GenericRequestInfo
+  public: GenericRequest
+} {
+  return { internal: req, public: { headers: new Headers() } }
+}

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -13,6 +13,8 @@ export function initAsyncHooks() {
   remultStatic.asyncContext = new RemultAsyncLocalStorage(
     new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
   )
+  remultStatic.apiClientScope.core =
+    new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore()
   let test = new AsyncLocalStorage()
   test.run(1, async () => {
     await Promise.resolve()
@@ -23,6 +25,8 @@ export function initAsyncHooks() {
       remultStatic.asyncContext = new RemultAsyncLocalStorage(
         new StubRemultAsyncLocalStorageCore(),
       )
+      // a stub cannot keep concurrent scopes apart, better to refuse than to leak one into another request
+      remultStatic.apiClientScope.core = undefined
     }
   })
 }

--- a/projects/core/server/remult-api-server.ts
+++ b/projects/core/server/remult-api-server.ts
@@ -4,7 +4,6 @@ import type { ClassType } from '../classType.js'
 import type {
   Allowed,
   AllowedForInstance,
-  ApiClient,
   RemultContext,
   UserInfo,
 } from '../src/context.js'
@@ -230,10 +229,15 @@ export function createRemultServerCore<RequestType>(
     dataProvider,
     serverCoreOptions,
   )
-  // per server, and the last one mounted wins - like `remultStatic.defaultDataProvider`
-  let inProcessHttpClient: NonNullable<ApiClient['httpClient']> | undefined
-  remultStatic.buildInProcessHttpClient = () =>
-    (inProcessHttpClient ??= buildInProcessHttpClient(bridge))
+  // `withApiRules` must reach the app's api, and a server that opts out of async
+  // storage is a test helper's, not the app's. Last one mounted wins otherwise.
+  if (!serverCoreOptions.ignoreAsyncStorage) {
+    let inProcessHttpClient:
+      | ReturnType<typeof buildInProcessHttpClient>
+      | undefined
+    remultStatic.buildInProcessHttpClient = () =>
+      (inProcessHttpClient ??= buildInProcessHttpClient(bridge))
+  }
   return bridge
 }
 

--- a/projects/core/server/remult-api-server.ts
+++ b/projects/core/server/remult-api-server.ts
@@ -4,10 +4,12 @@ import type { ClassType } from '../classType.js'
 import type {
   Allowed,
   AllowedForInstance,
+  ApiClient,
   RemultContext,
   UserInfo,
 } from '../src/context.js'
 import { Remult, RemultAsyncLocalStorage, withRemult } from '../src/context.js'
+import { buildInProcessHttpClient } from './in-process-api-client.js'
 import type { DataApiRequest, DataApiResponse } from '../src/data-api.js'
 import { DataApi, serializeError } from '../src/data-api.js'
 import type {
@@ -179,6 +181,7 @@ export interface InitRequestOptions {
   readonly remult: Remult
 }
 
+let inProcessHttpClient: NonNullable<ApiClient['httpClient']> | undefined
 export function createRemultServerCore<RequestType>(
   options: RemultServerOptions<RequestType>,
 
@@ -218,6 +221,8 @@ export function createRemultServerCore<RequestType>(
   if (safeOptions.rootPath === undefined) safeOptions.rootPath = '/api'
 
   remultStatic.actionInfo.runningOnServer = true
+  remultStatic.buildInProcessHttpClient = () =>
+    (inProcessHttpClient ??= buildInProcessHttpClient(safeOptions, dataProvider))
   let bridge = new RemultServerImplementation<RequestType>(
     new inProcessQueueHandler(safeOptions.queueStorage),
     safeOptions,

--- a/projects/core/server/remult-api-server.ts
+++ b/projects/core/server/remult-api-server.ts
@@ -10,6 +10,10 @@ import type {
 } from '../src/context.js'
 import { Remult, RemultAsyncLocalStorage, withRemult } from '../src/context.js'
 import { buildInProcessHttpClient } from './in-process-api-client.js'
+import {
+  inProcessRequestInfo,
+  isInProcessRequest,
+} from './in-process-request.js'
 import type { DataApiRequest, DataApiResponse } from '../src/data-api.js'
 import { DataApi, serializeError } from '../src/data-api.js'
 import type {
@@ -181,7 +185,6 @@ export interface InitRequestOptions {
   readonly remult: Remult
 }
 
-let inProcessHttpClient: NonNullable<ApiClient['httpClient']> | undefined
 export function createRemultServerCore<RequestType>(
   options: RemultServerOptions<RequestType>,
 
@@ -221,14 +224,16 @@ export function createRemultServerCore<RequestType>(
   if (safeOptions.rootPath === undefined) safeOptions.rootPath = '/api'
 
   remultStatic.actionInfo.runningOnServer = true
-  remultStatic.buildInProcessHttpClient = () =>
-    (inProcessHttpClient ??= buildInProcessHttpClient(safeOptions, dataProvider))
   let bridge = new RemultServerImplementation<RequestType>(
     new inProcessQueueHandler(safeOptions.queueStorage),
     safeOptions,
     dataProvider,
     serverCoreOptions,
   )
+  // per server, and the last one mounted wins - like `remultStatic.defaultDataProvider`
+  let inProcessHttpClient: NonNullable<ApiClient['httpClient']> | undefined
+  remultStatic.buildInProcessHttpClient = () =>
+    (inProcessHttpClient ??= buildInProcessHttpClient(bridge))
   return bridge
 }
 
@@ -307,6 +312,15 @@ export class RemultServerImplementation<RequestType>
     public dataProvider: Promise<DataProvider>,
     private coreOptions: ServerCoreOptions<RequestType>,
   ) {
+    this.coreOptions = {
+      ...coreOptions,
+      buildGenericRequestInfo: (req) =>
+        isInProcessRequest(req)
+          ? inProcessRequestInfo(req)
+          : coreOptions.buildGenericRequestInfo(req),
+      getRequestBody: async (req) =>
+        isInProcessRequest(req) ? req.body : coreOptions.getRequestBody(req),
+    }
     if (options.liveQueryStorage)
       this.liveQueryStorage = options.liveQueryStorage
     if (options.subscriptionServer)
@@ -786,7 +800,9 @@ export class RemultServerImplementation<RequestType>
               remultStatic.asyncContext.setInInitRequest(true)
               try {
                 let user
-                if (this.options.getUser) user = await this.options.getUser(req)
+                if (isInProcessRequest(req)) user = req.user
+                else if (this.options.getUser)
+                  user = await this.options.getUser(req)
                 else {
                   user = (req as any)['user']
                   if (!user) user = (req as any)['auth']

--- a/projects/core/server/test-api-data-provider.ts
+++ b/projects/core/server/test-api-data-provider.ts
@@ -1,20 +1,21 @@
 import {
   InMemoryDataProvider,
-  remult,
   RestDataProvider,
   SqlDatabase,
-  type DataProvider,
   type EntityMetadata,
-  type Remult,
 } from '../index.js'
 import type { RemultServerOptions } from './index.js'
+import { remultStatic } from '../src/remult-static.js'
+import {
+  RemultAsyncLocalStorage,
+  type RemultAsyncStore,
+} from '../src/context.js'
+import { buildInProcessHttpClient } from './in-process-api-client.js'
+import type { InProcessRequest } from './in-process-request.js'
 import {
   createRemultServerCore,
-  type GenericRequestInfo,
   type RemultServerImplementation,
 } from './remult-api-server.js'
-import { remultStatic } from '../src/remult-static.js'
-import { RemultAsyncLocalStorage } from '../src/context.js'
 import { initDataProvider } from './initDataProvider.js'
 
 export function TestApiDataProvider(
@@ -26,7 +27,7 @@ export function TestApiDataProvider(
     return new InMemoryDataProvider()
   })
 
-  const server = createRemultServerCore<GenericRequestInfo & { body?: any }>(
+  const server = createRemultServerCore<InProcessRequest>(
     { ...options, dataProvider: dp },
     {
       getRequestBody: async (req) => req.body,
@@ -36,54 +37,50 @@ export function TestApiDataProvider(
       }),
       ignoreAsyncStorage: true,
     },
-  ) as RemultServerImplementation<GenericRequestInfo & { body?: any }>
+  ) as RemultServerImplementation<InProcessRequest>
+  const httpClient = buildInProcessHttpClient(server)
 
-  const lock = new AsyncLock()
-  async function handleOnServer(req: GenericRequestInfo & { body?: any }) {
-    return lock.runExclusive(async () => {
-      return await MakeServerCallWithDifferentStaticRemult(async () => {
-        if (newEntities.length > 0 && options?.ensureSchema != false) {
-          await (await dp).ensureSchema?.(newEntities)
-          newEntities = []
-        }
-        var result = await server.handle(req)
-        if ((result?.statusCode ?? 200) >= 400) {
-          throw { ...result?.data, status: result?.statusCode ?? 500 }
-        }
-        return result?.data
-          ? JSON.parse(JSON.stringify(result.data))
-          : undefined
-      })
+  // With real async storage the api's own `withRemult` isolates the call. Without
+  // it - a plain unit test - it never becomes ambient, so the call would run on
+  // the caller's remult and read its context; swapping the factory stands in for
+  // that, and has to be serialized because it is process wide.
+  const swapLock = new AsyncLock()
+  const isolate = <T>(what: () => Promise<T>) =>
+    remultStatic.asyncContext.hasStorage()
+      ? what()
+      : swapLock.runExclusive(() => withOwnAmbientRemult(what))
+
+  // concurrent first calls would otherwise race on ensureSchema
+  const schemaLock = new AsyncLock()
+  const ensureSchema = () =>
+    schemaLock.runExclusive(async () => {
+      if (newEntities.length > 0 && options?.ensureSchema != false) {
+        await (await dp).ensureSchema?.(newEntities)
+        newEntities = []
+      }
     })
-  }
 
   const registeredEntities = new Set<string>()
   let newEntities: EntityMetadata[] = []
   return new RestDataProvider(
     () => ({
       httpClient: {
-        get: (url) =>
-          handleOnServer({
-            url: url,
-            method: 'GET',
-          }),
-        put: (url, body) =>
-          handleOnServer({
-            method: 'PUT',
-            url: url,
-            body: body,
-          }),
-        post: (url, body) =>
-          handleOnServer({
-            method: 'POST',
-            url: url,
-            body,
-          }),
-        delete: (url) =>
-          handleOnServer({
-            method: 'DELETE',
-            url: url,
-          }),
+        get: async (url) => (
+          await ensureSchema(),
+          isolate(() => httpClient.get(url))
+        ),
+        put: async (url, body) => (
+          await ensureSchema(),
+          isolate(() => httpClient.put(url, body))
+        ),
+        post: async (url, body) => (
+          await ensureSchema(),
+          isolate(() => httpClient.post(url, body))
+        ),
+        delete: async (url) => (
+          await ensureSchema(),
+          isolate(() => httpClient.delete(url))
+        ),
       },
     }),
     (entity) => {
@@ -115,28 +112,24 @@ export class AsyncLock {
   }
 }
 
-async function MakeServerCallWithDifferentStaticRemult<T>(what: () => T) {
-  var x = remultStatic.asyncContext
-  var y = remultStatic.remultFactory
-  const user = { ...remult.user! }
-  let store: {
-    remult: Remult
-    inInitRequest?: boolean
-  }
-  remultStatic.remultFactory = () => store.remult
+async function withOwnAmbientRemult<T>(what: () => Promise<T>): Promise<T> {
+  const asyncContext = remultStatic.asyncContext
+  const remultFactory = remultStatic.remultFactory
+  let store: RemultAsyncStore | undefined
+  // until the api opens its own remult, `remult` still means the caller's
+  remultStatic.remultFactory = () => store?.remult ?? remultFactory()
   try {
     remultStatic.asyncContext = new RemultAsyncLocalStorage({
       getStore: () => store,
       run: (pStore, callback) => {
         store = pStore
-        store.remult.user = user
         return callback()
       },
       wasImplemented: 'yes',
     })
     return await what()
   } finally {
-    remultStatic.asyncContext = x
-    remultStatic.remultFactory = y
+    remultStatic.asyncContext = asyncContext
+    remultStatic.remultFactory = remultFactory
   }
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -75,7 +75,11 @@ export class RemultAsyncLocalStorage {
     } else return callback(remult)
   }
   isInInitRequest() {
-    return this.remultObjectStorage?.getStore()?.inInitRequest
+    const store = this.remultObjectStorage?.getStore()
+    if (!store?.inInitRequest) return false
+    // inside a `withApiRules` scope the in-process request needs its own remult:
+    // reusing this one would serve it through the api again, forever
+    return remultStatic.apiClientScope?.get()?.remult !== store.remult
   }
   setInInitRequest(val: boolean) {
     const store = this.remultObjectStorage?.getStore()

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -44,6 +44,10 @@ import { initDataProvider } from '../server/initDataProvider.js'
 import { SubscribableImp } from './remult3/SubscribableImp.js'
 import { getEntitySettings } from './remult3/getEntityRef.js'
 
+export type RemultAsyncStore = {
+  remult: Remult
+  inInitRequest?: boolean
+}
 export class RemultAsyncLocalStorage {
   static enable() {
     remultStatic.remultFactory = () => {
@@ -60,10 +64,7 @@ export class RemultAsyncLocalStorage {
   }
   constructor(
     private readonly remultObjectStorage:
-      | RemultAsyncLocalStorageCore<{
-          remult: Remult
-          inInitRequest?: boolean
-        }>
+      | RemultAsyncLocalStorageCore<RemultAsyncStore>
       | undefined,
   ) {}
   async run<T>(
@@ -85,6 +86,9 @@ export class RemultAsyncLocalStorage {
     const store = this.remultObjectStorage?.getStore()
     if (!store) return
     if (val || this.remultObjectStorage?.isStub) store.inInitRequest = val
+  }
+  hasStorage() {
+    return !!this.remultObjectStorage
   }
   getStore() {
     if (!this.remultObjectStorage) {
@@ -539,10 +543,16 @@ export interface UserInfo {
 }
 
 export declare type Allowed =
-  boolean | string | string[] | ((c?: Remult) => boolean)
+  | boolean
+  | string
+  | string[]
+  | ((c?: Remult) => boolean)
 
 export declare type AllowedForInstance<T> =
-  boolean | string | string[] | ((entity?: T, c?: Remult) => boolean)
+  | boolean
+  | string
+  | string[]
+  | ((entity?: T, c?: Remult) => boolean)
 export class Allow {
   static everyone = () => true
   static authenticated = (...args: any[]) => {

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -100,6 +100,42 @@ export type RemultAsyncLocalStorageCore<T> = {
   isStub?: boolean
 }
 
+/** An open `asApiClient` scope, pinned to the remult that was ambient when it opened */
+export type ApiClientScope = {
+  remult: Remult
+  dataProvider: DataProvider
+  apiClient: ApiClient
+}
+
+/**
+ * Deliberately its own storage rather than a field on the remult store: the two
+ * have different lifetimes - one remult spans the request, api client scopes open
+ * and close inside it - and only this one has a meaning in the browser (none).
+ */
+export class ApiClientScopeStorage {
+  /** set by `initAsyncHooks`, so it only ever exists on the server */
+  core?: RemultAsyncLocalStorageCore<ApiClientScope>
+  get() {
+    return this.core?.getStore()
+  }
+  run<T>(scope: ApiClientScope, callback: () => Promise<T>): Promise<T> {
+    return this.core!.run(scope, callback)
+  }
+}
+if (!remultStatic.apiClientScope)
+  remultStatic.apiClientScope = new ApiClientScopeStorage()
+
+/** True while the ambient remult is reading through the api because of `asApiClient` */
+export function inApiClientScope() {
+  const scope = remultStatic.apiClientScope?.get()
+  if (!scope) return false
+  try {
+    return remultStatic.remultFactory() === scope.remult
+  } catch {
+    return false
+  }
+}
+
 export function isBackend() {
   return remultStatic.actionInfo.runningOnServer || !remult.dataProvider.isProxy
 }
@@ -249,7 +285,16 @@ export class Remult {
     }))
   }
   /** The current data provider */
-  dataProvider: DataProvider = new RestDataProvider(() => this.apiClient)
+  /** The current data provider - an enclosing `asApiClient` wins, assignment sets the instance default */
+  get dataProvider(): DataProvider {
+    const scope = remultStatic.apiClientScope?.get()
+    if (scope?.remult === this) return scope.dataProvider
+    return (this._dataProvider ??= new RestDataProvider(() => this.apiClient))
+  }
+  set dataProvider(dataProvider: DataProvider) {
+    this._dataProvider = dataProvider
+  }
+  private _dataProvider?: DataProvider
   /* @internal */
   repCache = new Map<DataProvider, Map<ClassType<any>, Repository<unknown>>>()
   /** Creates a new instance of the `remult` object.
@@ -339,10 +384,19 @@ export class Remult {
    */
   readonly context: RemultContext = {} as RemultContext
   /** The api client that will be used by `remult` to perform calls to the `api` */
-  apiClient: ApiClient = {
-    url: '/api',
-    subscriptionClient: new SseSubscriptionClient(),
+  /** The api client that will be used by `remult` to perform calls to the `api` */
+  get apiClient(): ApiClient {
+    const scope = remultStatic.apiClientScope?.get()
+    if (scope?.remult === this) return scope.apiClient
+    return (this._apiClient ??= {
+      url: '/api',
+      subscriptionClient: new SseSubscriptionClient(),
+    })
   }
+  set apiClient(apiClient: ApiClient) {
+    this._apiClient = apiClient
+  }
+  private _apiClient?: ApiClient
 }
 
 remultStatic.defaultRemultFactory = () => new Remult()
@@ -591,4 +645,55 @@ export async function withRemult<T>(
   )
 
   return remultStatic.asyncContext.run(remult, (r) => callback(r))
+}
+
+/**
+ * Runs `callback` in client mode: every `repo(...)` read and every `BackendMethod`
+ * call inside goes through the api as the current user, so `allowApi*`,
+ * `apiPrefilter`, `includeInApi` and `allowed` are enforced.
+ *
+ * In the browser this is already how remult reads, so it is a no-op there and the
+ * same universal `load` behaves the same on SSR and on CSR.
+ * @example
+ * // +page.ts
+ * export const load = async (event) => ({
+ *   tasks: await asApiClient(() => repo(Task).find(), { fetch: event.fetch }),
+ * })
+ */
+export function asApiClient<T>(
+  callback: () => Promise<T>,
+  options?: {
+    /** The framework's fetch, e.g. SvelteKit's `event.fetch`. Without it the call stays in process */
+    fetch?: ApiClient['httpClient']
+    url?: string
+  },
+): Promise<T> {
+  if (!remultStatic.actionInfo.runningOnServer) return callback()
+
+  const scope = remultStatic.apiClientScope
+  if (!scope.core)
+    throw new Error(
+      'asApiClient needs async_hooks on the server - it is wired by createRemultServer, make sure your api is created before this runs',
+    )
+
+  const httpClient = options?.fetch ?? remultStatic.buildInProcessHttpClient?.()
+  if (!httpClient)
+    throw new Error(
+      'asApiClient has no way to reach the api - pass `{ fetch }`, or create your api with createRemultServer so it can be called in process',
+    )
+
+  const remult = remultStatic.remultFactory()
+  const apiClient: ApiClient = {
+    ...remult.apiClient,
+    httpClient,
+    url: options?.url ?? remult.apiClient.url,
+  }
+  return scope.run(
+    {
+      remult,
+      apiClient,
+      dataProvider: new RestDataProvider(() => apiClient),
+    },
+    callback,
+  )
 }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -100,7 +100,7 @@ export type RemultAsyncLocalStorageCore<T> = {
   isStub?: boolean
 }
 
-/** An open `asApiClient` scope, pinned to the remult that was ambient when it opened */
+/** An open `withApiRules` scope, pinned to the remult that was ambient when it opened */
 export type ApiClientScope = {
   remult: Remult
   dataProvider: DataProvider
@@ -125,7 +125,7 @@ export class ApiClientScopeStorage {
 if (!remultStatic.apiClientScope)
   remultStatic.apiClientScope = new ApiClientScopeStorage()
 
-/** True while the ambient remult is reading through the api because of `asApiClient` */
+/** True while the ambient remult is reading through the api because of `withApiRules` */
 export function inApiClientScope() {
   const scope = remultStatic.apiClientScope?.get()
   if (!scope) return false
@@ -285,7 +285,7 @@ export class Remult {
     }))
   }
   /** The current data provider */
-  /** The current data provider - an enclosing `asApiClient` wins, assignment sets the instance default */
+  /** The current data provider - an enclosing `withApiRules` wins, assignment sets the instance default */
   get dataProvider(): DataProvider {
     const scope = remultStatic.apiClientScope?.get()
     if (scope?.remult === this) return scope.dataProvider
@@ -657,10 +657,10 @@ export async function withRemult<T>(
  * @example
  * // +page.ts
  * export const load = async (event) => ({
- *   tasks: await asApiClient(() => repo(Task).find(), { fetch: event.fetch }),
+ *   tasks: await withApiRules(() => repo(Task).find(), { fetch: event.fetch }),
  * })
  */
-export function asApiClient<T>(
+export function withApiRules<T>(
   callback: () => Promise<T>,
   options?: {
     /** The framework's fetch, e.g. SvelteKit's `event.fetch`. Without it the call stays in process */
@@ -673,13 +673,13 @@ export function asApiClient<T>(
   const scope = remultStatic.apiClientScope
   if (!scope.core)
     throw new Error(
-      'asApiClient needs async_hooks on the server - it is wired by createRemultServer, make sure your api is created before this runs',
+      'withApiRules needs async_hooks on the server - it is wired by createRemultServer, make sure your api is created before this runs',
     )
 
   const httpClient = options?.fetch ?? remultStatic.buildInProcessHttpClient?.()
   if (!httpClient)
     throw new Error(
-      'asApiClient has no way to reach the api - pass `{ fetch }`, or create your api with createRemultServer so it can be called in process',
+      'withApiRules has no way to reach the api - pass `{ fetch }`, or create your api with createRemultServer so it can be called in process',
     )
 
   const remult = remultStatic.remultFactory()

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -292,7 +292,6 @@ export class Remult {
       httpClient: fetch,
     }))
   }
-  /** The current data provider */
   /** The current data provider - an enclosing `withApiRules` wins, assignment sets the instance default */
   get dataProvider(): DataProvider {
     const scope = remultStatic.apiClientScope?.get()
@@ -391,7 +390,6 @@ export class Remult {
    * Check out the [extensibility section](/docs/custom-options#enhancing-field-and-entity-definitions-with-custom-options) for more custom options.
    */
   readonly context: RemultContext = {} as RemultContext
-  /** The api client that will be used by `remult` to perform calls to the `api` */
   /** The api client that will be used by `remult` to perform calls to the `api` */
   get apiClient(): ApiClient {
     const scope = remultStatic.apiClientScope?.get()
@@ -543,16 +541,10 @@ export interface UserInfo {
 }
 
 export declare type Allowed =
-  | boolean
-  | string
-  | string[]
-  | ((c?: Remult) => boolean)
+  boolean | string | string[] | ((c?: Remult) => boolean)
 
 export declare type AllowedForInstance<T> =
-  | boolean
-  | string
-  | string[]
-  | ((entity?: T, c?: Remult) => boolean)
+  boolean | string | string[] | ((entity?: T, c?: Remult) => boolean)
 export class Allow {
   static everyone = () => true
   static authenticated = (...args: any[]) => {

--- a/projects/core/src/remult-static.ts
+++ b/projects/core/src/remult-static.ts
@@ -5,7 +5,7 @@ import type {
   Remult,
   RemultAsyncLocalStorage,
 } from './context.js'
-import type { ApiClient } from './context.js'
+import type { InProcessHttpClient } from '../server/in-process-api-client.js'
 import type { DataProvider } from './data-interfaces.js'
 import type { columnInfo } from './remult3/columnInfo.js'
 
@@ -19,7 +19,7 @@ let x = {
   apiClientScope: undefined as unknown as ApiClientScopeStorage,
   /** set by `createRemultServer` - lets `withApiRules` reach the mounted api without a network hop */
   buildInProcessHttpClient: undefined as unknown as
-    | (() => NonNullable<ApiClient['httpClient']>)
+    | (() => InProcessHttpClient)
     | undefined,
   columnsOfType: new Map<any, columnInfo[]>(),
   allEntities: [] as ClassType<any>[],

--- a/projects/core/src/remult-static.ts
+++ b/projects/core/src/remult-static.ts
@@ -1,5 +1,11 @@
 import type { ClassType } from '../classType.js'
-import type { ClassHelper, Remult, RemultAsyncLocalStorage } from './context.js'
+import type {
+  ApiClientScopeStorage,
+  ClassHelper,
+  Remult,
+  RemultAsyncLocalStorage,
+} from './context.js'
+import type { ApiClient } from './context.js'
 import type { DataProvider } from './data-interfaces.js'
 import type { columnInfo } from './remult3/columnInfo.js'
 
@@ -10,6 +16,11 @@ let x = {
   remultFactory: undefined as unknown as () => Remult,
   defaultRemult: undefined as unknown as Remult,
   asyncContext: undefined as unknown as RemultAsyncLocalStorage,
+  apiClientScope: undefined as unknown as ApiClientScopeStorage,
+  /** set by `createRemultServer` - lets `asApiClient` reach the mounted api without a network hop */
+  buildInProcessHttpClient: undefined as unknown as
+    | (() => NonNullable<ApiClient['httpClient']>)
+    | undefined,
   columnsOfType: new Map<any, columnInfo[]>(),
   allEntities: [] as ClassType<any>[],
   classHelpers: new Map<any, ClassHelper>(),

--- a/projects/core/src/remult-static.ts
+++ b/projects/core/src/remult-static.ts
@@ -17,7 +17,7 @@ let x = {
   defaultRemult: undefined as unknown as Remult,
   asyncContext: undefined as unknown as RemultAsyncLocalStorage,
   apiClientScope: undefined as unknown as ApiClientScopeStorage,
-  /** set by `createRemultServer` - lets `asApiClient` reach the mounted api without a network hop */
+  /** set by `createRemultServer` - lets `withApiRules` reach the mounted api without a network hop */
   buildInProcessHttpClient: undefined as unknown as
     | (() => NonNullable<ApiClient['httpClient']>)
     | undefined,

--- a/projects/core/src/server-action.ts
+++ b/projects/core/src/server-action.ts
@@ -8,6 +8,7 @@ import {
   doTransaction,
   isBackend,
   setControllerSettings,
+  inApiClientScope,
 } from './context.js'
 import type { DataApiResponse } from './data-api.js'
 import type {
@@ -35,6 +36,7 @@ interface inArgs {
 interface result {
   data: any
 }
+const dispatchOverApi = () => !isBackend() || inApiClientScope()
 export abstract class Action<inParam, outParam> implements ActionInterface {
   constructor(
     private actionUrl: string,
@@ -280,7 +282,7 @@ export function BackendMethod<type = unknown>(
       }
 
       result = async function (...args: any[]) {
-        if (!isBackend()) {
+        if (dispatchOverApi()) {
           return await serverAction.doWork(args, undefined)
         } else
           return await originalMethod.apply(
@@ -510,7 +512,7 @@ export function BackendMethod<type = unknown>(
     result = async function (...args: any[]) {
       //@ts-ignore I specifically referred to the this of the original function - so it'll be sent inside
       let self: any = this
-      if (!isBackend()) {
+      if (dispatchOverApi()) {
         return serverAction.doWork(args, self)
       } else return await originalMethod.apply(self, args)
     }

--- a/projects/test-servers/sveltekit-server/src/hooks.server.ts
+++ b/projects/test-servers/sveltekit-server/src/hooks.server.ts
@@ -1,0 +1,3 @@
+import { _api } from './routes/api/[...remult]/+server'
+
+export const handle = _api

--- a/projects/test-servers/sveltekit-server/src/routes/api/[...remult]/+server.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/api/[...remult]/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestEvent } from '@sveltejs/kit'
 
 import { Task } from '../../../shared/Task'
+import { Gated } from '../../../shared/Gated'
 import { TasksController } from '../../../shared/TasksController'
 import { remult } from 'remult'
 import { remultApi } from 'remult/remult-sveltekit'
@@ -16,9 +17,15 @@ const initRequestModule = new Module({
 })
 
 export const _api = remultApi({
-  entities: [Task],
+  entities: [Task, Gated],
   controllers: [TasksController],
   admin: true,
+  getUser: async (event) => {
+    const auth = event.request.headers.get('authorization')
+    if (auth === 'Bearer admin') return { id: 'admin', roles: ['admin'] }
+    if (auth === 'Bearer user') return { id: 'user' }
+    return undefined
+  },
   initRequest: async (event) => {
     remult.context.setHeaders = (headers) => {
       event.setHeaders(headers)

--- a/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.server.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.server.ts
@@ -1,0 +1,37 @@
+import { repo, withApiRules } from 'remult'
+import { Gated } from '../../shared/Gated'
+import { Task } from '../../shared/Task'
+import type { PageServerLoad } from './$types'
+
+const show = (rows: Gated[]) => rows.map((r) => `${r.id}:${r.secret ?? ''}`)
+
+export const load = (async (event) => {
+  if ((await repo(Gated).count()) === 0)
+    await repo(Gated).insert([
+      { id: 1, pub: true, secret: 's1' },
+      { id: 2, pub: false, secret: 's2' },
+    ])
+
+  // privileged: the database, every row and field, allowed not checked
+  const fromDb = show(await repo(Gated).find())
+  await Task.testForbidden()
+
+  // api rules, in process - no fetch, no roundtrip, same global repo()
+  const inProcess = await withApiRules(async () => show(await repo(Gated).find()))
+  const status = (e: any) => e.httpStatusCode ?? e.status ?? `no status: ${JSON.stringify(e)}`
+  const forbidden = await withApiRules(() => Task.testForbidden()).then(
+    () => 'ran',
+    status,
+  )
+  const forbiddenViaFetch = await withApiRules(() => Task.testForbidden(), {
+    fetch: event.fetch,
+  }).then(() => 'ran', status)
+
+  // api rules through SvelteKit's fetch
+  const viaFetch = await withApiRules(
+    async () => show(await repo(Gated).find()),
+    { fetch: event.fetch },
+  )
+
+  return { fromDb, inProcess, viaFetch, forbidden, forbiddenViaFetch }
+}) satisfies PageServerLoad

--- a/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.svelte
+++ b/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { PageData } from './$types'
+  export let data: PageData
+</script>
+
+<h2>withApiRules</h2>
+<pre id="result">{JSON.stringify(data)}</pre>

--- a/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.ts
+++ b/projects/test-servers/sveltekit-server/src/routes/with-api-rules/+page.ts
@@ -1,0 +1,17 @@
+import { browser } from '$app/environment'
+import { repo, withApiRules } from 'remult'
+import { Gated } from '../../shared/Gated'
+import type { PageLoad } from './$types'
+
+// the same global repo() on both sides: on SSR the scope routes it through
+// event.fetch, in the browser it already goes through the api
+export const load = (async (event) => {
+  const rows = await withApiRules(() => repo(Gated).find(), {
+    fetch: event.fetch,
+  })
+  return {
+    ...event.data,
+    universal: rows.map((r) => `${r.id}:${r.secret ?? ''}`),
+    ranOn: browser ? 'csr' : 'ssr',
+  }
+}) satisfies PageLoad

--- a/projects/test-servers/sveltekit-server/src/shared/Gated.ts
+++ b/projects/test-servers/sveltekit-server/src/shared/Gated.ts
@@ -1,0 +1,14 @@
+import { Entity, Fields, remult } from 'remult'
+
+@Entity<Gated>('gated', {
+  allowApiCrud: true,
+  apiPrefilter: () => (remult.isAllowed('admin') ? {} : { pub: true }),
+})
+export class Gated {
+  @Fields.integer()
+  id = 0
+  @Fields.boolean()
+  pub = false
+  @Fields.string({ includeInApi: 'admin' })
+  secret = ''
+}

--- a/projects/tests/api-client-mode.spec.ts
+++ b/projects/tests/api-client-mode.spec.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  BackendMethod,
+  Entity,
+  Fields,
+  InMemoryDataProvider,
+  asApiClient,
+  remult,
+  repo,
+  withRemult,
+} from '../core/index.js'
+import type { ExternalHttpProvider } from '../core/src/buildRestDataProvider.js'
+import { RemultAsyncLocalStorage } from '../core/src/context.js'
+import { remultStatic } from '../core/src/remult-static.js'
+import { AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore } from '../core/server/initAsyncHooks.js'
+import { createRemultServerCore } from '../core/server/remult-api-server.js'
+
+@Entity<Task>('apiModeTasks', {
+  allowApiCrud: true,
+  apiPrefilter: () => (remult.isAllowed('admin') ? {} : { pub: true }),
+})
+class Task {
+  @Fields.integer()
+  id = 0
+  @Fields.boolean()
+  pub = false
+  @Fields.string({ includeInApi: 'admin' })
+  secret = ''
+}
+
+class Methods {
+  @BackendMethod({ allowed: 'admin' })
+  static async adminOnly() {
+    return 'ran'
+  }
+  @BackendMethod({ allowed: true })
+  static async countAll() {
+    return repo(Task).count()
+  }
+}
+
+const rows = () =>
+  repo(Task)
+    .find()
+    .then((r) => r.map((t) => `${t.id}:${t.secret ?? ''}`))
+
+/** the server side of the story: async storage on, api mounted, one request remult */
+function useServer() {
+  let db: InMemoryDataProvider
+  beforeEach(async () => {
+    db = new InMemoryDataProvider()
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore(),
+    )
+    remultStatic.apiClientScope.core =
+      new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore()
+    RemultAsyncLocalStorage.enable()
+    createRemultServerCore<any>(
+      { entities: [Task], controllers: [Methods], dataProvider: db },
+      {
+        getRequestBody: async (req) => req.body,
+        buildGenericRequestInfo: (req) => ({
+          internal: req,
+          public: { headers: new Headers() },
+        }),
+        ignoreAsyncStorage: true,
+      },
+    )
+    await withRemult(
+      async () => {
+        await repo(Task).insert([
+          { id: 1, pub: true, secret: 's1' },
+          { id: 2, pub: false, secret: 's2' },
+        ])
+      },
+      { dataProvider: db },
+    )
+  })
+  afterEach(() => {
+    RemultAsyncLocalStorage.disable()
+    remultStatic.apiClientScope.core = undefined
+    remultStatic.asyncContext = new RemultAsyncLocalStorage(undefined!)
+    remultStatic.buildInProcessHttpClient = undefined
+    remultStatic.actionInfo.runningOnServer = false
+  })
+  return {
+    request: <T>(user: any, what: () => Promise<T>) =>
+      withRemult(
+        async () => {
+          remult.user = user
+          return what()
+        },
+        { dataProvider: db },
+      ),
+    get db() {
+      return db
+    },
+  }
+}
+
+describe('asApiClient - in process', () => {
+  const server = useServer()
+
+  it('the global repo() switches to api rules inside the scope, and back after', async () => {
+    await server.request({ id: 'u' }, async () => {
+      expect(await rows()).toEqual(['1:s1', '2:s2'])
+      expect(await asApiClient(rows)).toEqual(['1:'])
+      expect(await rows()).toEqual(['1:s1', '2:s2'])
+    })
+  })
+
+  it('carries the user, so an admin sees what an admin may see', async () => {
+    await server.request({ id: 'a', roles: ['admin'] }, async () => {
+      expect(await asApiClient(rows)).toEqual(['1:s1', '2:s2'])
+    })
+  })
+
+  it('BackendMethod goes through the api, so allowed is enforced', async () => {
+    await server.request({ id: 'u' }, async () => {
+      expect(await Methods.adminOnly()).toBe('ran')
+      await expect(
+        asApiClient(() => Methods.adminOnly()),
+      ).rejects.toMatchObject({ httpStatusCode: 403 })
+      expect(await asApiClient(() => Methods.countAll())).toBe(2)
+    })
+  })
+
+  it('writes are gated too', async () => {
+    await server.request({ id: 'u' }, async () => {
+      await expect(
+        asApiClient(() => repo(Task).insert({ id: 3 })),
+      ).resolves.toMatchObject({ id: 3 })
+      await expect(
+        asApiClient(() => repo(Task).update(2, { secret: 'hacked' })),
+      ).rejects.toBeDefined()
+    })
+  })
+
+  it('concurrent requests do not leak their scope into each other', async () => {
+    const slow = server.request({ id: 'u' }, async () => {
+      const inScope = asApiClient(async () => {
+        await new Promise((r) => setTimeout(r, 20))
+        return rows()
+      })
+      return inScope
+    })
+    const fast = server.request({ id: 'u' }, () => rows())
+    expect(await Promise.all([slow, fast])).toEqual([
+      ['1:'],
+      ['1:s1', '2:s2'],
+    ])
+  })
+
+  it('nested withRemult inside a scope gets the real database back', async () => {
+    await server.request({ id: 'u' }, async () => {
+      await asApiClient(async () => {
+        expect(await rows()).toEqual(['1:'])
+        await withRemult(
+          async () => expect(await rows()).toEqual(['1:s1', '2:s2']),
+          { dataProvider: server.db },
+        )
+      })
+    })
+  })
+})
+
+describe('asApiClient - fetch transport', () => {
+  const server = useServer()
+
+  it('uses the fetch it is given', async () => {
+    const calls: string[] = []
+    const inProcess =
+      remultStatic.buildInProcessHttpClient!() as ExternalHttpProvider
+    const fetch = {
+      get: (url: string) => {
+        calls.push(url)
+        return inProcess.get(url)
+      },
+      put: inProcess.put,
+      post: inProcess.post,
+      delete: inProcess.delete,
+    }
+    await server.request({ id: 'u' }, async () => {
+      expect(await asApiClient(rows, { fetch })).toEqual(['1:'])
+    })
+    expect(calls.length).toBe(1)
+    expect(calls[0]).toContain('/api/apiModeTasks')
+  })
+})
+
+describe('asApiClient - browser', () => {
+  it('is a no-op, because reads there already go through the api', async () => {
+    remultStatic.actionInfo.runningOnServer = false
+    let ran = false
+    const r = await asApiClient(async () => {
+      ran = true
+      return 42
+    })
+    expect(ran).toBe(true)
+    expect(r).toBe(42)
+  })
+})

--- a/projects/tests/backend-tests/all-server-tests.ts
+++ b/projects/tests/backend-tests/all-server-tests.ts
@@ -20,6 +20,7 @@ export function testAsExpressMW(
   additionalTests?: (
     withRemultForTest: (what: () => Promise<void>) => () => Promise<void>,
   ) => void,
+  options?: ServerTestOptions,
 ) {
   let destroy: () => Promise<void>
 
@@ -33,19 +34,22 @@ export function testAsExpressMW(
       }
     })
   })
-  allServerTests(port, {}, additionalTests)
+  allServerTests(port, options, additionalTests)
   afterAll(async () => {
     RemultAsyncLocalStorage.disable()
     return destroy()
   })
 }
 
+export type ServerTestOptions = {
+  skipAsyncHooks?: boolean
+  skipLiveQuery?: boolean
+  /** an initRequest throw is a 400 from the api handler, but a 500 when it happens in a framework hook */
+  initRequestCrashStatus?: number
+}
 export function allServerTests(
   port: number,
-  options?: {
-    skipAsyncHooks?: boolean
-    skipLiveQuery?: boolean
-  },
+  options?: ServerTestOptions,
   additionalTests?: (
     withRemultForTest: (what: () => Promise<void>) => () => Promise<void>,
   ) => void,
@@ -587,11 +591,9 @@ export function allServerTests(
             })
             expect('to never').toBe('be here')
           } catch (error) {
-            if (error instanceof Error) {
-              expect(error.message).toMatchInlineSnapshot(
-                `"Request failed with status code 400"`,
-              )
-            }
+            expect(axios.isAxiosError(error) && error.response?.status).toBe(
+              options?.initRequestCrashStatus ?? 400,
+            )
           }
         }),
       )

--- a/projects/tests/backend-tests/test-sveltekit-server.spec.ts
+++ b/projects/tests/backend-tests/test-sveltekit-server.spec.ts
@@ -5,11 +5,43 @@ import { handler } from '../../test-servers/sveltekit-server/build/handler.js'
 import axios from 'axios'
 import { remult } from '../../core/index.js'
 
+const REGEX_RESULT = /<pre id="result">([\s\S]*?)<\/pre>/
+const REGEX_HTML_COMMENT = /<!--[\s\S]*?-->/g
+
 describe('test sveltekit server', async () => {
   testAsExpressMW(
     3014,
     (req, res, next) => handler(req, res, next),
     (withRemultForTest) => {
+      const withApiRulesPage = async (auth?: string) => {
+        const html: string = (
+          await axios.get('http://127.0.0.1:3014/with-api-rules', {
+            headers: auth ? { authorization: `Bearer ${auth}` } : {},
+          })
+        ).data
+        const inner = html.match(REGEX_RESULT)![1]
+        return JSON.parse(inner.replace(REGEX_HTML_COMMENT, ''))
+      }
+      it('withApiRules applies the api rules, in process and through event.fetch', async () => {
+        expect(await withApiRulesPage()).toEqual({
+          fromDb: ['1:s1', '2:s2'],
+          inProcess: ['1:'],
+          viaFetch: ['1:'],
+          forbidden: 403,
+          forbiddenViaFetch: 403,
+          universal: ['1:'],
+          ranOn: 'ssr',
+        })
+        expect(await withApiRulesPage('admin')).toEqual({
+          fromDb: ['1:s1', '2:s2'],
+          inProcess: ['1:s1', '2:s2'],
+          viaFetch: ['1:s1', '2:s2'],
+          forbidden: 403,
+          forbiddenViaFetch: 403,
+          universal: ['1:s1', '2:s2'],
+          ranOn: 'ssr',
+        })
+      })
       it(
         'test headers in response',
         withRemultForTest(async () => {
@@ -27,5 +59,7 @@ describe('test sveltekit server', async () => {
         }),
       )
     },
+    // hooks.server.ts runs initRequest, so its crash surfaces as SvelteKit's 500
+    { initRequestCrashStatus: 500 },
   )
 })

--- a/projects/tests/with-api-rules.spec.ts
+++ b/projects/tests/with-api-rules.spec.ts
@@ -68,7 +68,6 @@ function useServer(extraOptions?: any) {
           internal: req,
           public: { headers: new Headers() },
         }),
-        ignoreAsyncStorage: true,
       },
     )
     await withRemult(

--- a/projects/tests/with-api-rules.spec.ts
+++ b/projects/tests/with-api-rules.spec.ts
@@ -4,7 +4,7 @@ import {
   Entity,
   Fields,
   InMemoryDataProvider,
-  asApiClient,
+  withApiRules,
   remult,
   repo,
   withRemult,
@@ -45,7 +45,7 @@ const rows = () =>
     .then((r) => r.map((t) => `${t.id}:${t.secret ?? ''}`))
 
 /** the server side of the story: async storage on, api mounted, one request remult */
-function useServer() {
+function useServer(extraOptions?: any) {
   let db: InMemoryDataProvider
   beforeEach(async () => {
     db = new InMemoryDataProvider()
@@ -56,7 +56,12 @@ function useServer() {
       new AsyncLocalStorageBridgeToRemultAsyncLocalStorageCore()
     RemultAsyncLocalStorage.enable()
     createRemultServerCore<any>(
-      { entities: [Task], controllers: [Methods], dataProvider: db },
+      {
+        entities: [Task],
+        controllers: [Methods],
+        dataProvider: db,
+        ...extraOptions,
+      },
       {
         getRequestBody: async (req) => req.body,
         buildGenericRequestInfo: (req) => ({
@@ -98,20 +103,20 @@ function useServer() {
   }
 }
 
-describe('asApiClient - in process', () => {
+describe('withApiRules - in process', () => {
   const server = useServer()
 
   it('the global repo() switches to api rules inside the scope, and back after', async () => {
     await server.request({ id: 'u' }, async () => {
       expect(await rows()).toEqual(['1:s1', '2:s2'])
-      expect(await asApiClient(rows)).toEqual(['1:'])
+      expect(await withApiRules(rows)).toEqual(['1:'])
       expect(await rows()).toEqual(['1:s1', '2:s2'])
     })
   })
 
   it('carries the user, so an admin sees what an admin may see', async () => {
     await server.request({ id: 'a', roles: ['admin'] }, async () => {
-      expect(await asApiClient(rows)).toEqual(['1:s1', '2:s2'])
+      expect(await withApiRules(rows)).toEqual(['1:s1', '2:s2'])
     })
   })
 
@@ -119,26 +124,26 @@ describe('asApiClient - in process', () => {
     await server.request({ id: 'u' }, async () => {
       expect(await Methods.adminOnly()).toBe('ran')
       await expect(
-        asApiClient(() => Methods.adminOnly()),
+        withApiRules(() => Methods.adminOnly()),
       ).rejects.toMatchObject({ httpStatusCode: 403 })
-      expect(await asApiClient(() => Methods.countAll())).toBe(2)
+      expect(await withApiRules(() => Methods.countAll())).toBe(2)
     })
   })
 
   it('writes are gated too', async () => {
     await server.request({ id: 'u' }, async () => {
       await expect(
-        asApiClient(() => repo(Task).insert({ id: 3 })),
+        withApiRules(() => repo(Task).insert({ id: 3 })),
       ).resolves.toMatchObject({ id: 3 })
       await expect(
-        asApiClient(() => repo(Task).update(2, { secret: 'hacked' })),
+        withApiRules(() => repo(Task).update(2, { secret: 'hacked' })),
       ).rejects.toBeDefined()
     })
   })
 
   it('concurrent requests do not leak their scope into each other', async () => {
     const slow = server.request({ id: 'u' }, async () => {
-      const inScope = asApiClient(async () => {
+      const inScope = withApiRules(async () => {
         await new Promise((r) => setTimeout(r, 20))
         return rows()
       })
@@ -153,7 +158,7 @@ describe('asApiClient - in process', () => {
 
   it('nested withRemult inside a scope gets the real database back', async () => {
     await server.request({ id: 'u' }, async () => {
-      await asApiClient(async () => {
+      await withApiRules(async () => {
         expect(await rows()).toEqual(['1:'])
         await withRemult(
           async () => expect(await rows()).toEqual(['1:s1', '2:s2']),
@@ -164,7 +169,33 @@ describe('asApiClient - in process', () => {
   })
 })
 
-describe('asApiClient - fetch transport', () => {
+describe('withApiRules - reuses the mounted api', () => {
+  const server = useServer({
+    // would throw on the in-process call if it were not bypassed
+    getUser: async (req: any) => {
+      if (!req.headers) throw new Error('getUser got a request it cannot read')
+      return { id: 'from-headers' }
+    },
+    initRequest: async () => {
+      initRequestCalls++
+    },
+  })
+  let initRequestCalls = 0
+  beforeEach(() => (initRequestCalls = 0))
+
+  it('skips getUser and keeps the ambient user', async () => {
+    await server.request({ id: 'a', roles: ['admin'] }, async () => {
+      expect(await withApiRules(rows)).toEqual(['1:s1', '2:s2'])
+    })
+  })
+
+  it('runs the mounted initRequest, so it is the same pipeline', async () => {
+    await server.request({ id: 'u' }, () => withApiRules(rows))
+    expect(initRequestCalls).toBe(1)
+  })
+})
+
+describe('withApiRules - fetch transport', () => {
   const server = useServer()
 
   it('uses the fetch it is given', async () => {
@@ -181,18 +212,18 @@ describe('asApiClient - fetch transport', () => {
       delete: inProcess.delete,
     }
     await server.request({ id: 'u' }, async () => {
-      expect(await asApiClient(rows, { fetch })).toEqual(['1:'])
+      expect(await withApiRules(rows, { fetch })).toEqual(['1:'])
     })
     expect(calls.length).toBe(1)
     expect(calls[0]).toContain('/api/apiModeTasks')
   })
 })
 
-describe('asApiClient - browser', () => {
+describe('withApiRules - browser', () => {
   it('is a no-op, because reads there already go through the api', async () => {
     remultStatic.actionInfo.runningOnServer = false
     let ran = false
-    const r = await asApiClient(async () => {
+    const r = await withApiRules(async () => {
       ran = true
       return 42
     })

--- a/projects/tests/with-api-rules.spec.ts
+++ b/projects/tests/with-api-rules.spec.ts
@@ -195,6 +195,19 @@ describe('withApiRules - reuses the mounted api', () => {
   })
 })
 
+describe('withApiRules - inside an initRequest', () => {
+  const server = useServer()
+
+  // a framework hook that mounts the api as its handler keeps this flag up for the
+  // whole request, so the load below runs with it on
+  it('does not hand the in-process request the scoped remult, which would recurse', async () => {
+    await server.request({ id: 'u' }, async () => {
+      remultStatic.asyncContext.setInInitRequest(true)
+      expect(await withApiRules(rows)).toEqual(['1:'])
+    })
+  })
+})
+
 describe('withApiRules - fetch transport', () => {
   const server = useServer()
 


### PR DESCRIPTION
Replaces #1039 and #1031, which solve the same problem in narrower or heavier ways.

`repo(Task).find()` reads the database on the server and the api in the browser, without asking. A SvelteKit universal `load` runs on both sides, so the same line means two different things. `withApiRules` forces client mode on a region of server code: reads and `BackendMethod` calls inside go through the api as the current user, so `allowApi*`, `apiPrefilter`, `includeInApi` and `allowed` apply.

```ts
// +page.ts - same rows on SSR and CSR
export const load = async (event) => ({
  tasks: await withApiRules(() => repo(Task).find(), { fetch: event.fetch }),
})

// server-only code, no fetch: goes through the mounted api, in process
const mine = await withApiRules(() => repo(Task).find())
```

The scope lives in its own AsyncLocalStorage; `Remult.dataProvider` and `apiClient` consult it, which is what lets the global `repo()` follow along instead of handing you an object you must remember to use. In the browser there is nothing to scope - reads already go through the api - so it is a no-op there.

`TestApiDataProvider` now shares the same in-process transport, which retires its static-remult swap and narrows its global lock to `ensureSchema` where real async storage exists.

Notes for review: `Remult.dataProvider`/`apiClient` become getters (hot path, not benchmarked); the in-process call bypasses `getUser`, since there is no framework request to read it from.