### PR TITLE
Add browser tests for IndexedDB data provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,25 @@ jobs:
       - store_test_results:
           path: ./test-results.xml
 
+  test-browser:
+    docker:
+      - image: cimg/node:20.19-browsers
+    steps:
+      - checkout
+      - node/install-packages
+      - browser-tools/install-chrome
+      - run:
+          name: Run browser tests with coverage
+          command: npm run test:browser:ci
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            curl -Os https://cli.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov upload-process -t "$CODECOV_TOKEN" || true
+      - store_test_results:
+          path: ./test-results.xml
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
@@ -84,3 +103,4 @@ workflows:
       - build
       - test-remult
       - test-node-sqlite
+      - test-browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Breaking
+
+- `EntityDataProvider.insert` is now `insert(data: any[], options?): Promise<any[]>` (not one object). `insertMany` removed from `ProxyEntityDataProvider`.
+- `EntityDataProvider.delete` is now `delete(ids: any[]): Promise<void>`. REST: 1 id → DELETE, N → existing deleteMany.
+
+### Added
+
+- Native `IndexedDbDataProvider`: PK + declared indexes, filter prefetch, batch insert/delete in one IDB txn, optional `encrypt: true` (AES-GCM, non-extractable key in `__remult_keys`, PK+index fields plaintext, rest `_enc`+`_iv`). Docs: installation/database/indexeddb.
+- `insert([a, b], { bulk: true })` — one `EntityDataProvider.insert` after all `saving` hooks. Use for SQL multi-row `INSERT` / one IDB txn. `Validators.unique` / `count()` only see the DB, not siblings in the same array.
+
+### Changed
+
+- `repo.insert([a, b, c])` is sequential by default again (`this.insert(item)` per row). `saving` and `Validators.unique` see prior rows in the same call. Not a hook/unique break.
+- SQL/knex multi-row `INSERT ... VALUES (...),(...)` batched under bind-variable limits (default 2000, sqlite 999, D1 100). Pass `{ bulk: true }` to use it from `repo.insert`.
+
 ## [3.3.18] - 2026-08-30
 
 - Fixed `ArrayEntityDataProvider` storing omitted/`undefined` nullable fields as `undefined` instead of `null`, so filters like `{ date: null }` missed rows inserted without a value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Native `IndexedDbDataProvider`: PK + declared indexes, filter prefetch, batch insert/delete in one IDB txn, optional `encrypt: true` (AES-GCM, non-extractable key in `__remult_keys`, PK+index fields plaintext, rest `_enc`+`_iv`). Docs: installation/database/indexeddb — see docs for threat model.
+- `DroppableDataProvider` (`dropDatabase` / `dropTable`) on `IndexedDbDataProvider` and `InMemoryDataProvider`. `dropTable(Task)` or metadata; store + indexes recreated on next use.
 - `insert([a, b], { bulk: true })` — one `EntityDataProvider.insert` after all `saving` hooks. Use for SQL multi-row `INSERT` / one IDB txn. `Validators.unique` / `count()` only see the DB, not siblings in the same array.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Native `IndexedDbDataProvider`: PK + declared indexes, filter prefetch, batch insert/delete in one IDB txn, optional `encrypt: true` (AES-GCM, non-extractable key in `__remult_keys`, PK+index fields plaintext, rest `_enc`+`_iv`). Docs: installation/database/indexeddb.
+- Native `IndexedDbDataProvider`: PK + declared indexes, filter prefetch, batch insert/delete in one IDB txn, optional `encrypt: true` (AES-GCM, non-extractable key in `__remult_keys`, PK+index fields plaintext, rest `_enc`+`_iv`). Docs: installation/database/indexeddb — see docs for threat model.
 - `insert([a, b], { bulk: true })` — one `EntityDataProvider.insert` after all `saving` hooks. Use for SQL multi-row `INSERT` / one IDB txn. `Validators.unique` / `count()` only see the DB, not siblings in the same array.
 
 ### Changed

--- a/docs/.vitepress/sidebar.mjs
+++ b/docs/.vitepress/sidebar.mjs
@@ -261,6 +261,10 @@ export const sidebar = tutorials.reduce(
                 text: 'Json files',
                 link: '/docs/installation/database/json',
               },
+              {
+                text: 'IndexedDB',
+                link: '/docs/installation/database/indexeddb',
+              },
             ],
           },
         ],

--- a/docs/docs/installation/database/indexeddb.md
+++ b/docs/docs/installation/database/indexeddb.md
@@ -1,5 +1,5 @@
 ---
-llm: "Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, optional AES-GCM encryption."
+llm: "Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, dropDatabase/dropTable, optional AES-GCM encryption."
 ---
 
 # IndexedDB
@@ -46,6 +46,22 @@ console.table(await repo(Task, db).find())
 ```
 
 Stores are created on first use (`ensureSchema`). Call `db.close()` when you are done with the connection.
+
+## Drop / reset
+
+`IndexedDbDataProvider` and `InMemoryDataProvider` both implement `DroppableDataProvider` — swap them in tests.
+
+```ts
+import type { DroppableDataProvider } from 'remult'
+
+async function reset(db: DroppableDataProvider) {
+  await db.dropTable(Task) // or repo(Task).metadata
+  await db.dropDatabase()
+}
+```
+
+- **`dropTable`** — deletes that entity's object store (IDB version bump). Next insert / `ensureSchema` recreates it with the same `ensureIndexes`. Autoincrement resets.
+- **`dropDatabase`** — closes the connection and deletes the IndexedDB (including `__remult_keys` when encryption is on). The provider stays usable.
 
 ## Indexes
 
@@ -130,5 +146,6 @@ Existing plaintext rows are still readable; the next write encrypts them.
 | Shape | native object store per entity | one JSON blob per entity in a shared store |
 | Queries | IDB indexes + prefetch | load whole entity JSON, filter in memory |
 | Encryption | optional AES-GCM | none |
+| Reset | `dropTable` / `dropDatabase` | `clear()` |
 
 Use `JsonEntityIndexedDbStorage` only when you want `JsonDataProvider` over a blob. See [Offline Support](/docs/offline-support).

--- a/docs/docs/installation/database/indexeddb.md
+++ b/docs/docs/installation/database/indexeddb.md
@@ -81,13 +81,16 @@ await tasks.find({ where: { status: 'open', title: 'hi' } })
 
 ## Batch insert / delete
 
-`repo.insert([a, b])` and `deleteMany` (`delete(ids)` under the hood) each run in **one IndexedDB transaction**.
+`repo.insert([a, b], { bulk: true })` and `deleteMany` (`delete(ids)` under the hood) each run in **one IndexedDB transaction**. Default `insert([])` is sequential (one write per row).
 
 ```ts
-await tasks.insert([
-  { title: 'a', status: 'open' },
-  { title: 'b', status: 'done' },
-])
+await tasks.insert(
+  [
+    { title: 'a', status: 'open' },
+    { title: 'b', status: 'done' },
+  ],
+  { bulk: true },
+)
 await tasks.deleteMany({ where: { status: 'done' } })
 ```
 

--- a/docs/docs/installation/database/indexeddb.md
+++ b/docs/docs/installation/database/indexeddb.md
@@ -1,0 +1,131 @@
+---
+llm: "Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, optional AES-GCM encryption."
+---
+
+# IndexedDB
+
+`IndexedDbDataProvider` is a **browser-only** data provider that stores each entity in a native IndexedDB object store (one row per id). It is not the older JSON-blob helper (`JsonEntityIndexedDbStorage`).
+
+No extra package. Import from `remult`:
+
+```ts
+import { IndexedDbDataProvider, Remult } from 'remult'
+```
+
+## Basic usage
+
+```ts
+import { Entity, Fields, IndexedDbDataProvider, Remult } from 'remult'
+
+@Entity('tasks')
+class Task {
+  @Fields.cuid()
+  id = ''
+  @Fields.string()
+  title = ''
+  @Fields.string()
+  status = ''
+  @Fields.createdAt()
+  createdAt = new Date()
+}
+
+const remult = new Remult(new IndexedDbDataProvider()) // db name defaults to 'remult'
+const tasks = remult.repo(Task)
+
+await tasks.insert({ title: 'hi', status: 'open' })
+console.table(await tasks.find({ where: { status: 'open' } }))
+```
+
+Or pass it to `repo` for a one-off call:
+
+```ts
+import { IndexedDbDataProvider, repo } from 'remult'
+
+const db = new IndexedDbDataProvider()
+console.table(await repo(Task, db).find())
+```
+
+Stores are created on first use (`ensureSchema`). Call `db.close()` when you are done with the connection.
+
+## Indexes
+
+Indexes are **IDB-only** (not unique). Declare them with `ensureIndexes` — field keys are typed against the entity. Listing the primary key is skipped. Compound indexes are named by joining db names with `_`.
+
+```ts
+const db = new IndexedDbDataProvider('remult', {
+  indexes: (x) =>
+    x.ensureIndexes(Task, [
+      'status',
+      'createdAt',
+      ['status', 'createdAt'], // → index name `status_createdAt`
+    ]),
+})
+```
+
+## Filter prefetch
+
+`find` / `count` / `groupBy` first try to load a subset from IDB, then apply the rest of the filter in memory.
+
+Order:
+
+1. Primary key (single-id entities): `eq`, `in`, range (`$gt` / `$gte` / `$lt` / `$lte`)
+2. Declared indexes, longest compound first — same operators
+3. `$or` of prefetchable branches is merged
+
+Extra predicates still run in memory. `$ne`, `null`, and custom filters do not narrow the IDB read (full scan).
+
+```ts
+await tasks.find({ where: { status: 'open', title: 'hi' } })
+// prefetches via `status` index, then filters `title` in memory
+```
+
+## Batch insert / delete
+
+`repo.insert([a, b])` and `deleteMany` (`delete(ids)` under the hood) each run in **one IndexedDB transaction**.
+
+```ts
+await tasks.insert([
+  { title: 'a', status: 'open' },
+  { title: 'b', status: 'done' },
+])
+await tasks.deleteMany({ where: { status: 'done' } })
+```
+
+## Encryption
+
+`{ encrypt: true }` encrypts non-indexed fields at rest with **AES-GCM 256**. Requires the Web Crypto API (`crypto.subtle`); the constructor throws if it is missing.
+
+```ts
+const db = new IndexedDbDataProvider('remult', {
+  indexes: (x) => x.ensureIndexes(Task, ['status']),
+  encrypt: true,
+})
+```
+
+What stays plaintext vs encrypted:
+
+- **Plaintext:** primary key + indexed fields (so prefetch still works)
+- **Ciphertext:** everything else as `_enc` (payload) + `_iv` (12-byte IV)
+
+By default Remult generates a **non-extractable** `CryptoKey` and stores it in the `__remult_keys` object store. Pass `getEncryptionKey` to supply your own key (the key store is then skipped):
+
+```ts
+const db = new IndexedDbDataProvider('remult', {
+  encrypt: true,
+  getEncryptionKey: () => myAesGcmKey, // CryptoKey | Promise<CryptoKey>
+})
+```
+
+Existing plaintext rows are still readable; the next write encrypts them.
+
+**Threat model:** at-rest / other origins. This is **not** XSS protection — same-origin script can still read and decrypt.
+
+## vs `JsonEntityIndexedDbStorage`
+
+| | `IndexedDbDataProvider` | `JsonEntityIndexedDbStorage` |
+| --- | --- | --- |
+| Shape | native object store per entity | one JSON blob per entity in a shared store |
+| Queries | IDB indexes + prefetch | load whole entity JSON, filter in memory |
+| Encryption | optional AES-GCM | none |
+
+Use `JsonEntityIndexedDbStorage` only when you want `JsonDataProvider` over a blob. See [Offline Support](/docs/offline-support).

--- a/docs/docs/installation/database/indexeddb.md
+++ b/docs/docs/installation/database/indexeddb.md
@@ -96,7 +96,9 @@ await tasks.deleteMany({ where: { status: 'done' } })
 
 ## Encryption
 
-`{ encrypt: true }` encrypts non-indexed fields at rest with **AES-GCM 256**. Requires the Web Crypto API (`crypto.subtle`); the constructor throws if it is missing.
+`{ encrypt: true }` encrypts **non-indexed** fields at rest with **AES-GCM 256**. Requires the Web Crypto API (`crypto.subtle`); the constructor throws if it is missing.
+
+This is **not** full security. It stops a casual disk/profile dump and other origins (non-extractable `CryptoKey` wrapped by the browser). It does **not** protect against same-origin XSS / any JS that can use the stored `CryptoKey` to decrypt.
 
 ```ts
 const db = new IndexedDbDataProvider('remult', {
@@ -107,10 +109,10 @@ const db = new IndexedDbDataProvider('remult', {
 
 What stays plaintext vs encrypted:
 
-- **Plaintext:** primary key + indexed fields (so prefetch still works)
+- **Plaintext:** primary key + `ensureIndexes` fields — required for IDB `keyPath` / indexes (prefetch still works)
 - **Ciphertext:** everything else as `_enc` (payload) + `_iv` (12-byte IV)
 
-By default Remult generates a **non-extractable** `CryptoKey` and stores it in the `__remult_keys` object store. Pass `getEncryptionKey` to supply your own key (the key store is then skipped):
+By default Remult generates a **non-extractable** `CryptoKey` and stores it in `__remult_keys`. That auto-key is origin-bound theater vs XSS. Pass `getEncryptionKey` for a stronger secret you control (the key store is then skipped):
 
 ```ts
 const db = new IndexedDbDataProvider('remult', {
@@ -120,8 +122,6 @@ const db = new IndexedDbDataProvider('remult', {
 ```
 
 Existing plaintext rows are still readable; the next write encrypts them.
-
-**Threat model:** at-rest / other origins. This is **not** XSS protection — same-origin script can still read and decrypt.
 
 ## vs `JsonEntityIndexedDbStorage`
 

--- a/docs/docs/offline-support.md
+++ b/docs/docs/offline-support.md
@@ -1,5 +1,5 @@
 ---
-llm: "Browser-side dataProviders - JsonDataProvider over localStorage, sessionStorage, IndexedDB, or OPFS."
+llm: "Browser-side dataProviders - IndexedDbDataProvider, or JsonDataProvider over localStorage, sessionStorage, IndexedDB blobs, or OPFS."
 ---
 
 # Offline Support
@@ -29,9 +29,19 @@ export const remultLocalStorage = new Remult(new JsonDataProvider(localStorage))
 
 This approach is straightforward and suitable for small datasets that need to persist across sessions or page reloads.
 
+## Native IndexedDB
+
+For structured per-entity stores, indexes, and optional at-rest encryption, use [`IndexedDbDataProvider`](/docs/installation/database/indexeddb):
+
+```typescript
+import { IndexedDbDataProvider, Remult } from 'remult'
+
+const remult = new Remult(new IndexedDbDataProvider())
+```
+
 ## JSON Storage in IndexedDB
 
-For more complex offline storage needs, such as larger datasets and structured queries, `IndexedDB` provides a robust solution. Using Remult’s `JsonEntityIndexedDbStorage`, you can store entities in `IndexedDB`, which is supported across all major browsers. This allows for efficient offline data management while offering support for larger volumes of data compared to `localStorage` or `sessionStorage`.
+`JsonEntityIndexedDbStorage` stores each entity as one JSON blob in a shared IndexedDB store (via `JsonDataProvider`). Prefer `IndexedDbDataProvider` when you want native object stores and indexes.
 
 ```typescript
 import { JsonDataProvider } from 'remult'
@@ -44,7 +54,7 @@ const db = new JsonDataProvider(new JsonEntityIndexedDbStorage())
 console.table(await repo(Task, db).find())
 ```
 
-In this example, `JsonEntityIndexedDbStorage` is used to persist the data to `IndexedDB`. This method is ideal for applications with large data sets or those requiring more complex interactions with the stored data in offline mode.
+Use this when you already wrap storage in `JsonDataProvider`. For native stores and indexes, use `IndexedDbDataProvider`.
 
 ## JSON Storage in OPFS (Origin Private File System)
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -66,7 +66,7 @@
 - [Oracle](https://remult.dev/docs/installation/database/oracle): Oracle via createKnexDataProvider with the oracledb client on the dataProvider option.
 - [D1](https://remult.dev/docs/installation/database/d1): Cloudflare D1 via createD1DataProvider from remult/remult-d1 on the dataProvider option.
 - [Json files](https://remult.dev/docs/installation/database/json): JSON file storage via JsonDataProvider + JsonEntityFileStorage on the dataProvider option.
-- [IndexedDB](https://remult.dev/docs/installation/database/indexeddb): Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, optional AES-GCM encryption.
+- [IndexedDB](https://remult.dev/docs/installation/database/indexeddb): Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, dropDatabase/dropTable, optional AES-GCM encryption.
 
 ### Server-side Code
 - [Backend Methods](https://remult.dev/docs/backendMethods): @BackendMethod - typed RPC calls that auto-expose REST endpoints and run server-only logic.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,7 +14,7 @@
 - **Custom filters** - `Filter.createCustom` / `SqlDatabase.filterToRaw` to express complex queries that round-trip to the server safely.
 - **Validators** - built-ins under `Validators.*` (`required`, `min`, `max`, `email`, `url`, `unique`, `regex`, `enum`, ...) or `validate: (entity) => string | undefined` for custom logic.
 - **Admin UI** - turnkey `/api/admin` panel via `admin: true` (or `admin: { allow: 'admin' }`) in `remultApi()`.
-- **Stacks** - frameworks: React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt. Servers: Express, Fastify, Hono, Elysia, Hapi, Koa, NestJS. Databases: PostgreSQL, MySQL, MongoDB, SQLite (better/sqljs/bun), MSSQL, Turso, DuckDB, Oracle, Cloudflare D1, JSON files.
+- **Stacks** - frameworks: React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt. Servers: Express, Fastify, Hono, Elysia, Hapi, Koa, NestJS. Databases: PostgreSQL, MySQL, MongoDB, SQLite (better/sqljs/bun), MSSQL, Turso, DuckDB, Oracle, Cloudflare D1, JSON files, IndexedDB.
 
 ## Documentation
 
@@ -32,7 +32,7 @@
 - [Lifecycle Hooks](https://remult.dev/docs/lifecycle-hooks): Entity hooks - validation, saving, saved, deleting, deleted - for custom logic at persistence boundaries.
 - [Migrations](https://remult.dev/docs/migrations): Automatic ensureSchema sync vs. explicit migration files generated and applied via the migrations CLI.
 - [Generate from Existing DB](https://remult.dev/docs/entities-codegen-from-db-schema): Generate entity classes from an existing database schema using remult-kit.
-- [Offline Support](https://remult.dev/docs/offline-support): Browser-side dataProviders - JsonDataProvider over localStorage, sessionStorage, IndexedDB, or OPFS.
+- [Offline Support](https://remult.dev/docs/offline-support): Browser-side dataProviders - IndexedDbDataProvider, or JsonDataProvider over localStorage, sessionStorage, IndexedDB blobs, or OPFS.
 - [Active Record & EntityBase](https://remult.dev/docs/active-record): Active Record pattern via EntityBase/IdEntity - mutable instances with save/delete methods bound to rows.
 - [Entity Backend Methods](https://remult.dev/docs/entity-backend-methods): @BackendMethod on entity instances - round-trips the full (possibly unsaved) entity state to the server.
 - [Mutable Controllers](https://remult.dev/docs/mutable-controllers): @Controller classes with stateful fields that round-trip between client and server on BackendMethod calls.
@@ -66,6 +66,7 @@
 - [Oracle](https://remult.dev/docs/installation/database/oracle): Oracle via createKnexDataProvider with the oracledb client on the dataProvider option.
 - [D1](https://remult.dev/docs/installation/database/d1): Cloudflare D1 via createD1DataProvider from remult/remult-d1 on the dataProvider option.
 - [Json files](https://remult.dev/docs/installation/database/json): JSON file storage via JsonDataProvider + JsonEntityFileStorage on the dataProvider option.
+- [IndexedDB](https://remult.dev/docs/installation/database/indexeddb): Browser IndexedDbDataProvider from remult - native object stores, typed indexes, filter prefetch, batch insert/delete, optional AES-GCM encryption.
 
 ### Server-side Code
 - [Backend Methods](https://remult.dev/docs/backendMethods): @BackendMethod - typed RPC calls that auto-expose REST endpoints and run server-only logic.

--- a/docs/scripts/sync-llms.mjs
+++ b/docs/scripts/sync-llms.mjs
@@ -208,7 +208,7 @@ const header = `# Remult
 - **Custom filters** - \`Filter.createCustom\` / \`SqlDatabase.filterToRaw\` to express complex queries that round-trip to the server safely.
 - **Validators** - built-ins under \`Validators.*\` (\`required\`, \`min\`, \`max\`, \`email\`, \`url\`, \`unique\`, \`regex\`, \`enum\`, ...) or \`validate: (entity) => string | undefined\` for custom logic.
 - **Admin UI** - turnkey \`/api/admin\` panel via \`admin: true\` (or \`admin: { allow: 'admin' }\`) in \`remultApi()\`.
-- **Stacks** - frameworks: React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt. Servers: Express, Fastify, Hono, Elysia, Hapi, Koa, NestJS. Databases: PostgreSQL, MySQL, MongoDB, SQLite (better/sqljs/bun), MSSQL, Turso, DuckDB, Oracle, Cloudflare D1, JSON files.
+- **Stacks** - frameworks: React, Angular, Vue, SvelteKit, Next.js, SolidStart, Nuxt. Servers: Express, Fastify, Hono, Elysia, Hapi, Koa, NestJS. Databases: PostgreSQL, MySQL, MongoDB, SQLite (better/sqljs/bun), MSSQL, Turso, DuckDB, Oracle, Cloudflare D1, JSON files, IndexedDB.
 
 `
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -448,6 +448,11 @@ export declare function describeEntity<entityType extends ClassType<any>>(
   fields: FieldsDescriptor<entityType>,
   options?: EntityOptions<InstanceType<entityType>>,
 ): void
+export interface DroppableDataProvider extends DataProvider {
+  dropDatabase(): Promise<void>
+  /** Recreated with indexes on next use (`ensureSchema` / first write). */
+  dropTable(entity: EntityMetadataOverloads): Promise<void>
+}
 export declare function Entity<entityType>(
   key: string,
   ...options: (
@@ -1934,7 +1939,7 @@ export interface IdMetadata<entityType = unknown> {
     items: Partial<MembersOnly<entityType>>[],
   ): EntityFilter<entityType>
 }
-export declare class IndexedDbDataProvider implements DataProvider {
+export declare class IndexedDbDataProvider implements DroppableDataProvider {
   private dbName
   constructor(dbName?: string, options?: IndexedDbDataProviderOptions)
   getEntityDataProvider(entity: EntityMetadata): EntityDataProvider
@@ -1943,10 +1948,31 @@ export declare class IndexedDbDataProvider implements DataProvider {
   ): Promise<void>
   ensureSchema(entities: EntityMetadata[]): Promise<void>
   close(): void
+  dropDatabase(): Promise<void>
+  dropTable(entity: EntityMetadataOverloads): Promise<void>
 }
 export type IndexedDbDataProviderOptions = {
+  /** IDB-only indexes (not unique). PK is skipped. Compound names join db names with `_`. */
   indexes?: (x: IndexedDbIndexBuilder) => void
+  /**
+   * AES-GCM 256 on non-indexed fields (`_enc` + `_iv`). Requires `crypto.subtle`.
+   *
+   * Not full security. Stops casual disk/profile dump and other origins
+   * (non-extractable `CryptoKey` wrapped by the browser). Does **not** protect
+   * against same-origin XSS / any JS that can use the stored `CryptoKey` to decrypt.
+   *
+   * PK + `ensureIndexes` fields stay plaintext (required for IDB keyPath/indexes).
+   * Only non-indexed fields go into `_enc`.
+   *
+   * Default auto-key is origin-bound theater vs XSS. Pass `getEncryptionKey` for
+   * a stronger secret you control.
+   */
   encrypt?: boolean
+  /**
+   * Your AES-GCM `CryptoKey` (or Promise). Skips `__remult_keys`. Stronger than
+   * the default origin-bound auto-key — still not XSS-safe if same-origin JS can
+   * call this and decrypt.
+   */
   getEncryptionKey?: () => CryptoKey | Promise<CryptoKey>
 }
 //[ ] CryptoKey from TBD is not exported
@@ -1960,13 +1986,15 @@ export type IndexedDbIndexDef<entityType> =
   | keyof MembersOnly<entityType>
   | readonly (keyof MembersOnly<entityType>)[]
 export declare class InMemoryDataProvider
-  implements DataProvider, __RowsOfDataForTesting
+  implements DroppableDataProvider, __RowsOfDataForTesting
 {
   transaction(
     action: (dataProvider: DataProvider) => Promise<void>,
   ): Promise<void>
   rows: any
   getEntityDataProvider(entity: EntityMetadata): EntityDataProvider
+  dropDatabase(): Promise<void>
+  dropTable(entity: EntityMetadataOverloads): Promise<void>
   toString(): string
 }
 export declare class InMemoryLiveQueryStorage implements LiveQueryStorage {
@@ -1989,7 +2017,17 @@ export declare class InMemoryLiveQueryStorage implements LiveQueryStorage {
   ): Promise<void>
 }
 export declare type InsertOrUpdateOptions = {
-  select: "none"
+  select?: "none"
+  /**
+   * One provider statement/txn (SQL multi-row `INSERT`, IDB one txn).
+   *
+   * Default / omitted (`false`): `insert([a,b,c])` inserts one-by-one so
+   * `saving` and `Validators.unique` see prior rows in the same call.
+   *
+   * When `true`: all `saving` hooks run before any write; `Validators.unique`
+   * / `count()` only see the DB, not siblings in the same array.
+   */
+  bulk?: boolean
 }
 export declare function isBackend(): boolean
 export declare class JsonDataProvider implements DataProvider {
@@ -2834,11 +2872,14 @@ export interface Repository<entityType> {
     item: Partial<MembersOnly<entityType>>,
     options?: InsertOrUpdateOptions,
   ): Promise<entityType>
-  /**Insert an item or item[] to the data source
+  /**Insert an item or item[] to the data source.
+   * Arrays insert one-by-one by default. Pass `{ bulk: true }` for one provider statement/txn.
    * @example
    * await taskRepo.insert({title:"task a"})
    * @example
    * await taskRepo.insert([{title:"task a"}, {title:"task b", completed:true }])
+   * @example
+   * await taskRepo.insert([{title:"a"}, {title:"b"}], { bulk: true })
    */
   insert(
     item: Partial<MembersOnly<entityType>>[],

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -105,8 +105,8 @@ export declare class ArrayEntityDataProvider implements EntityDataProvider {
   count(where?: Filter): Promise<number>
   find(options?: EntityDataProviderFindOptions): Promise<any[]>
   update(id: any, data: any): Promise<any>
-  delete(id: any): Promise<void>
-  insert(data: any): Promise<any>
+  delete(ids: any[]): Promise<void>
+  insert(data: any[]): Promise<any[]>
 }
 //[ ] CustomArrayFilter from TBD is not exported
 export declare function BackendMethod<type = unknown>(
@@ -485,8 +485,8 @@ export interface EntityDataProvider {
   find(options?: EntityDataProviderFindOptions): Promise<Array<any>>
   groupBy(options?: EntityDataProviderGroupByOptions): Promise<any[]>
   update(id: any, data: any, options?: InsertOrUpdateOptions): Promise<any>
-  delete(id: any): Promise<void>
-  insert(data: any, options?: InsertOrUpdateOptions): Promise<any>
+  delete(ids: any[]): Promise<void>
+  insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]>
 }
 export interface EntityDataProviderFindOptions {
   select?: string[]
@@ -1934,6 +1934,28 @@ export interface IdMetadata<entityType = unknown> {
     items: Partial<MembersOnly<entityType>>[],
   ): EntityFilter<entityType>
 }
+export declare class IndexedDbDataProvider implements DataProvider {
+  private dbName
+  constructor(dbName?: string, options?: IndexedDbDataProviderOptions)
+  getEntityDataProvider(entity: EntityMetadata): EntityDataProvider
+  transaction(
+    action: (dataProvider: DataProvider) => Promise<void>,
+  ): Promise<void>
+  ensureSchema(entities: EntityMetadata[]): Promise<void>
+  close(): void
+}
+export type IndexedDbDataProviderOptions = {
+  indexes?: (x: IndexedDbIndexBuilder) => void
+}
+export declare class IndexedDbIndexBuilder {
+  ensureIndexes<entityType>(
+    entity: ClassType<entityType>,
+    indexes: readonly IndexedDbIndexDef<entityType>[],
+  ): this
+}
+export type IndexedDbIndexDef<entityType> =
+  | keyof MembersOnly<entityType>
+  | readonly (keyof MembersOnly<entityType>)[]
 export declare class InMemoryDataProvider
   implements DataProvider, __RowsOfDataForTesting
 {
@@ -2180,7 +2202,9 @@ export interface LiveQueryStorage {
 export declare type MembersOnly<T> = {
   [K in keyof Omit<T, keyof EntityBase> as T[K] extends Function
     ? never
-    : K]: T[K]
+    : K extends string
+      ? K
+      : never]: T[K]
 }
 export type MembersToInclude<T> = {
   [K in keyof ObjectMembersOnly<T>]?:
@@ -2793,7 +2817,7 @@ export interface Repository<entityType> {
    */
   validate(
     item: Partial<entityType>,
-    ...fields: Extract<keyof MembersOnly<entityType>, string>[]
+    ...fields: (keyof MembersOnly<entityType>)[]
   ): Promise<ErrorInfo<entityType> | undefined>
   /** saves an item or item[] to the data source. It assumes that if an `id` value exists, it's an existing row - otherwise it's a new row
    * @example
@@ -3183,6 +3207,8 @@ export interface SqlImplementation extends HasWrapIdentifier {
   doesNotSupportReturningSyntax?: boolean
   doesNotSupportReturningSyntaxOnlyForUpdate?: boolean
   orderByNullsFirst?: boolean
+  /** Bound-variable cap per statement. Default 2000 (SQL Server is 2100). */
+  maxParametersInOneSqlStatement?: number
   end(): Promise<void>
   afterMutation?: VoidFunction
 }
@@ -3192,7 +3218,7 @@ export interface SqlResult {
 }
 export declare function standardSchema<
   entityType,
-  fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],
+  fieldsType extends (keyof MembersOnly<entityType>)[] = [],
 >(
   repo: Repository<entityType>,
   ...fields: fieldsType
@@ -3429,6 +3455,7 @@ export interface ValueConverter<valueType> {
   toJson?(val: valueType): any
   /**
    * Converts a value from the database format to the valueType.
+   * Defaults to `fromJson` when not provided.
    *
    * @param val The value to convert.
    * @returns The converted value.
@@ -3439,6 +3466,7 @@ export interface ValueConverter<valueType> {
   fromDb?(val: any): valueType
   /**
    * Converts a value of valueType to the database format.
+   * Defaults to `toJson` when not provided.
    *
    * @param val The value to convert.
    * @returns The converted value.
@@ -3450,6 +3478,7 @@ export interface ValueConverter<valueType> {
   toDbSql?(val: string): string
   /**
    * Converts a value of valueType to a string suitable for an HTML input element.
+   * Defaults to `toJson` when not provided.
    *
    * @param val The value to convert.
    * @param inputType The type of the input element (optional).
@@ -3461,6 +3490,7 @@ export interface ValueConverter<valueType> {
   toInput?(val: valueType, inputType?: string): string
   /**
    * Converts a string from an HTML input element to the valueType.
+   * Defaults to `fromJson` when not provided.
    *
    * @param val The value to convert.
    * @param inputType The type of the input element (optional).
@@ -4486,7 +4516,7 @@ export declare class KnexDataProvider
     wrapIdentifier?: (name: string) => string,
   ): Promise<(knex: Knex.QueryBuilder) => void>
   isProxy?: boolean
-  ensureSchema(entities: EntityMetadata<any>[]): Promise<void>
+  ensureSchema(entities: EntityMetadata[]): Promise<void>
 }
 //[ ] MigrationCode from ../migrations/migration-types.js is not exported
 //[ ] MigrationBuilder from ../migrations/migration-types.js is not exported
@@ -4499,7 +4529,7 @@ export declare class KnexDataProvider
 //[ ] RepositoryOverloads from ../src/remult3/RepositoryImplementation.js is not exported
 export declare class KnexSchemaBuilder {
   private knex
-  ensureSchema(entities: EntityMetadata<any>[]): Promise<void>
+  ensureSchema(entities: EntityMetadata[]): Promise<void>
   createIfNotExist(entity: EntityMetadata): Promise<void>
   createTableKnexCommand(
     entity: EntityMetadata,
@@ -4591,6 +4621,7 @@ export declare class SqliteCoreDataProvider
     doesNotSupportReturningSyntaxOnlyForUpdate?: boolean,
   )
   orderByNullsFirst?: boolean
+  maxParametersInOneSqlStatement: number
   getLimitSqlSyntax(limit: number, offset: number): string
   afterMutation?: VoidFunction
   provideMigrationBuilder(builder: MigrationCode): MigrationBuilder
@@ -4709,6 +4740,7 @@ export interface D1Client {
 }
 export declare class D1DataProvider extends SqliteCoreDataProvider {
   private d1
+  maxParametersInOneSqlStatement: number
   /**
    * For production or local d1 using binding
    *

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -1946,7 +1946,10 @@ export declare class IndexedDbDataProvider implements DataProvider {
 }
 export type IndexedDbDataProviderOptions = {
   indexes?: (x: IndexedDbIndexBuilder) => void
+  encrypt?: boolean
+  getEncryptionKey?: () => CryptoKey | Promise<CryptoKey>
 }
+//[ ] CryptoKey from TBD is not exported
 export declare class IndexedDbIndexBuilder {
   ensureIndexes<entityType>(
     entity: ClassType<entityType>,

--- a/misc/vitest.config.web.ts
+++ b/misc/vitest.config.web.ts
@@ -1,28 +1,44 @@
+/// <reference types="@vitest/browser/providers/webdriverio" />
 import { config } from 'dotenv'
 import { defineConfig } from 'vitest/config'
 
 config()
 
+process.env['IGNORE_GLOBAL_REMULT_IN_TESTS'] = 'true'
+
+const ci = !!process.env.CI
+
 export default defineConfig({
   test: {
-    threads: false,
-
-    include: [
-      './projects/tests/**/*.spec-browser.ts',
-      //'./projects/tests/tests/try-test.spec-browser.ts',
-      //'./projects/tests/dbs/sql-lite.spec.ts',
-    ],
-    //  reporters: ['dot'],
+    include: ['./projects/tests/**/*.spec-browser.ts'],
+    reporters: ['default', 'junit'],
+    outputFile: './test-results.xml',
     globals: false,
-    browser: {
-      name: 'chrome',
-      enabled: true,
+    setupFiles: ['./projects/tests/browser-setup.ts'],
+    coverage: {
+      enabled: false,
+      provider: 'istanbul',
+      reporter: ['json', 'html'],
+      include: ['projects/core/**'],
     },
-    // coverage: {
-    //   enabled: false,
-    //   provider: 'v8',
-    //   reporter: ['text', 'json', 'html'],
-    //   include: ['**'],
-    // },
+    browser: {
+      enabled: true,
+      provider: 'webdriverio',
+      headless: ci,
+      instances: [
+        {
+          browser: 'chrome',
+          ...(ci
+            ? {
+                capabilities: {
+                  'goog:chromeOptions': {
+                    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+                  },
+                },
+              }
+            : {}),
+        },
+      ],
+    },
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "3.3.19-next.1",
+  "version": "3.3.19-next.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "3.3.19-next.1",
+      "version": "3.3.19-next.2",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250613.0",
         "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "3.3.18",
+  "version": "3.3.19-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "3.3.18",
+      "version": "3.3.19-next.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250613.0",
         "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "3.3.19-next.0",
+  "version": "3.3.19-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "3.3.19-next.0",
+      "version": "3.3.19-next.1",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250613.0",
         "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "3.3.19-next.2",
+  "version": "3.3.19-next.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "3.3.19-next.2",
+      "version": "3.3.19-next.3",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250613.0",
         "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
         "@vitest/browser": "3.1.2",
+        "@vitest/coverage-istanbul": "^3.1.2",
         "@vitest/coverage-v8": "3.1.2",
         "@vitest/ui": "3.1.2",
         "ably": "^1.2.33",
@@ -9964,6 +9965,43 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.1.2.tgz",
+      "integrity": "sha512-PXjSd4g7SxlC9WJ00jbMMFJob+LcjXUYow5vpXuZe/acjhlEQgCaf6npm+W9Mg/ahiFKtIAHI+P8A9n2JfZilg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.3",
+        "debug": "^4.4.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magicast": "^0.3.5",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.1.2"
+      }
+    },
+    "node_modules/@vitest/coverage-istanbul/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.2.tgz",
@@ -18439,6 +18477,36 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "3.3.19-next.1",
+  "version": "3.3.19-next.2",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "3.3.19-next.2",
+  "version": "3.3.19-next.3",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "3.3.19-next.0",
+  "version": "3.3.19-next.1",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "3.3.18",
+  "version": "3.3.19-next.0",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",
+    "test:browser": "vitest --config misc/vitest.config.web.ts",
+    "test:browser:ci": "vitest run --config misc/vitest.config.web.ts --coverage",
     "release": "rimraf dist && npm run build && npm run patch-versions",
     "build": "tsc -p projects/core/tsconfig.build.json && tsc -p projects/core/tsconfig.build.esm.json && tsx misc/build-packagejson-core.ts && copyfiles README.md dist/remult && copyfiles LICENSE dist/remult && tsx misc/dedupe-admin-html.ts && tsx misc/extract-public-api.ts",
     "build-tests": "tsc -p tsconfig.tests.json && tsc -p projects/tests/strict/tsconfig.check.json",
@@ -65,6 +67,7 @@
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
     "@vitest/browser": "3.1.2",
+    "@vitest/coverage-istanbul": "3.1.2",
     "@vitest/coverage-v8": "3.1.2",
     "@vitest/ui": "3.1.2",
     "ably": "^1.2.33",

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -90,6 +90,7 @@ export type { EntityOptions, PreprocessFilterEvent } from './src/entity.js'
 export { EntityError } from './src/data-interfaces.js' //V
 export type {
   DataProvider,
+  DroppableDataProvider,
   EntityDataProvider,
   EntityDataProviderGroupByOptions,
   EntityDataProviderFindOptions,

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -6,7 +6,7 @@ export type { ClassType } from './classType.js'
 /*
  * Public API Surface of remult
  */
-export {
+export type {
   ValidateFieldEvent,
   MembersOnly,
   NumericKeys,
@@ -66,9 +66,9 @@ export {
   getFields,
   ValueListFieldType,
   getValueList,
-  ValueListFieldOptions,
   ValueListInfo,
 } from './src/remult3/RepositoryImplementation.js'
+export type { ValueListFieldOptions } from './src/remult3/RepositoryImplementation.js'
 import { LabelTransformer } from './src/remult3/RepositoryImplementation.js'
 export { LabelTransformer } from './src/remult3/RepositoryImplementation.js'
 /**
@@ -77,12 +77,8 @@ export { LabelTransformer } from './src/remult3/RepositoryImplementation.js'
 export const CaptionTransformer = LabelTransformer
 export { Entity } from './src/remult3/entity.js'
 export { getEntityRef } from './src/remult3/getEntityRef.js'
-export {
-  Field,
-  Fields,
-  StringFieldOptions,
-  Relations,
-} from './src/remult3/Fields.js'
+export { Field, Fields, Relations } from './src/remult3/Fields.js'
+export type { StringFieldOptions } from './src/remult3/Fields.js'
 export { IdEntity } from './src/remult3/IdEntity.js'
 
 export {
@@ -90,23 +86,23 @@ export {
   describeBackendMethods,
   describeEntity,
 } from './src/remult3/classDescribers.js'
-export { EntityOptions, PreprocessFilterEvent } from './src/entity.js'
-export {
+export type { EntityOptions, PreprocessFilterEvent } from './src/entity.js'
+export { EntityError } from './src/data-interfaces.js' //V
+export type {
   DataProvider,
   EntityDataProvider,
   EntityDataProviderGroupByOptions,
   EntityDataProviderFindOptions,
   ErrorInfo,
-  EntityError,
   RestDataProviderHttpProvider,
-} from './src/data-interfaces.js' //V
-export {
+} from './src/data-interfaces.js'
+export type {
   SqlCommand,
   SqlCommandWithParameters,
   SqlImplementation,
   SqlResult,
 } from './src/sql-command.js' //V
-export {
+export type {
   FieldMetadata,
   FieldOptions,
   FieldValidator,
@@ -121,60 +117,65 @@ export { SqlDatabase } from './src/data-providers/sql-database.js' //V
 export {
   CustomSqlFilterBuilder,
   dbNamesOf,
+} from './src/filter/filter-consumer-bridge-to-sql-request.js'
+export type {
   dbNamesOfOptions,
   CustomSqlFilterBuilderFunction,
   EntityDbNames,
 } from './src/filter/filter-consumer-bridge-to-sql-request.js'
 
-export {
-  JsonDataProvider,
-  JsonEntityStorage,
-} from './src/data-providers/json-data-provider.js' //V
+export { JsonDataProvider } from './src/data-providers/json-data-provider.js' //V
+export type { JsonEntityStorage } from './src/data-providers/json-data-provider.js'
 export { JsonEntityOpfsStorage } from './src/data-providers/json-entity-opfs-storage.js'
 export { JsonEntityIndexedDbStorage } from './src/data-providers/json-entity-indexed-db-data-provider.js'
 
 //export * from './src/data-api'; //reconsider if to make internal
 export {
   Controller,
-  BackendMethodOptions,
   BackendMethod,
   ProgressListener,
   ForbiddenError,
 } from './src/server-action.js'
+export type { BackendMethodOptions } from './src/server-action.js'
 
 export {
-  Allowed,
   Allow,
   Remult,
   withRemult,
+  isBackend,
+  EventSource,
+} from './src/context.js'
+export type {
+  Allowed,
   RemultContext,
   ApiClient,
-  isBackend,
   AllowedForInstance,
   EventDispatcher,
-  EventSource,
   UserInfo,
 } from './src/context.js'
-export { ExternalHttpProvider } from './src/buildRestDataProvider.js'
-export { SortSegment, Sort } from './src/sort.js'
+export type { ExternalHttpProvider } from './src/buildRestDataProvider.js'
+export { Sort } from './src/sort.js'
+export type { SortSegment } from './src/sort.js'
 export { CompoundIdField } from './src/CompoundIdField.js'
-export {
-  Filter,
+export { Filter } from './src/filter/filter-interfaces.js'
+export type {
   FilterConsumer,
   FilterPreciseValues,
 } from './src/filter/filter-interfaces.js'
 export { UrlBuilder } from './urlBuilder.js'
 export {
   Validators,
-  ValidationMessage,
-  ValueValidationMessage,
-  Validator,
-  ValidatorWithArgs,
   valueValidator,
   createValidator,
   createValidatorWithArgs,
   createValueValidatorWithArgs,
   createValueValidator,
+} from './src/validators.js'
+export type {
+  ValidationMessage,
+  ValueValidationMessage,
+  Validator,
+  ValidatorWithArgs,
 } from './src/validators.js'
 
 export { ValueConverters } from './src/valueConverters.js'
@@ -183,17 +184,17 @@ import { remult } from './src/remult-proxy.js'
 
 //export { getId } from './src/remult3/getId';
 
-export {
+export { InMemoryLiveQueryStorage } from './src/live-query/SubscriptionServer.js'
+export type {
   SubscriptionServer,
   LiveQueryStorage,
   StoredQuery,
-  InMemoryLiveQueryStorage,
 } from './src/live-query/SubscriptionServer.js'
-export {
+export { SubscriptionChannel } from './src/live-query/SubscriptionChannel.js'
+export type {
   SubscriptionListener,
   SubscriptionClientConnection,
   SubscriptionClient,
-  SubscriptionChannel,
   LiveQueryChange,
   Unsubscribe,
 } from './src/live-query/SubscriptionChannel.js'

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -128,6 +128,7 @@ export { JsonDataProvider } from './src/data-providers/json-data-provider.js' //
 export type { JsonEntityStorage } from './src/data-providers/json-data-provider.js'
 export { JsonEntityOpfsStorage } from './src/data-providers/json-entity-opfs-storage.js'
 export { JsonEntityIndexedDbStorage } from './src/data-providers/json-entity-indexed-db-data-provider.js'
+export { IndexedDbDataProvider } from './src/data-providers/indexed-db-data-provider.js'
 
 //export * from './src/data-api'; //reconsider if to make internal
 export {

--- a/projects/core/index.ts
+++ b/projects/core/index.ts
@@ -128,7 +128,14 @@ export { JsonDataProvider } from './src/data-providers/json-data-provider.js' //
 export type { JsonEntityStorage } from './src/data-providers/json-data-provider.js'
 export { JsonEntityOpfsStorage } from './src/data-providers/json-entity-opfs-storage.js'
 export { JsonEntityIndexedDbStorage } from './src/data-providers/json-entity-indexed-db-data-provider.js'
-export { IndexedDbDataProvider } from './src/data-providers/indexed-db-data-provider.js'
+export {
+  IndexedDbDataProvider,
+  IndexedDbIndexBuilder,
+} from './src/data-providers/indexed-db-data-provider.js'
+export type {
+  IndexedDbDataProviderOptions,
+  IndexedDbIndexDef,
+} from './src/data-providers/indexed-db-data-provider.js'
 
 //export * from './src/data-api'; //reconsider if to make internal
 export {

--- a/projects/core/remult-d1.ts
+++ b/projects/core/remult-d1.ts
@@ -13,6 +13,7 @@ export function createD1DataProvider(d1: D1Database) {
 }
 
 export class D1DataProvider extends SqliteCoreDataProvider {
+  maxParametersInOneSqlStatement = 100
   /**
    * For production or local d1 using binding
    *

--- a/projects/core/remult-knex/index.ts
+++ b/projects/core/remult-knex/index.ts
@@ -330,19 +330,113 @@ class KnexEntityDataProvider implements EntityDataProvider {
     if (options?.select === 'none') return undefined!
     return getRowAfterUpdate(this.entity, this, data, id, 'update')
   }
-  async delete(id: any): Promise<void> {
+  async delete(ids: any[]): Promise<void> {
+    if (ids.length === 0) return
     const e = await this.init()
     let f = new FilterConsumerBridgeToKnexRequest(e, this.rawSqlWrapIdentifier)
     Filter.fromEntityFilter(
       this.entity,
-      this.entity.idMetadata.getIdFilter(id),
+      this.entity.idMetadata.getIdFilter(...ids),
     ).__applyToConsumer(f)
     let where = await f.resolveWhere()
     await this.getEntityFrom(e)
       .delete()
       .where((b) => where.forEach((w) => w(b)))
   }
-  async insert(data: any, options?: InsertOrUpdateOptions): Promise<any> {
+  async insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]> {
+    if (data.length === 0) return []
+    if (
+      isMysqlKnex(this.knex) &&
+      isAutoIncrement(this.entity.idMetadata.field) &&
+      options?.select !== 'none'
+    ) {
+      const result: any[] = []
+      for (const row of data) result.push(await this.insertOne(row, options))
+      return result
+    }
+    const e = await this.init()
+    const batches = splitByMaxParameters(
+      data,
+      (row) => countKnexInsertBindParameters(this.entity, e, row),
+      knexMaxParametersInOneSqlStatement(this.knex),
+    )
+    const result: any[] = []
+    for (const batch of batches)
+      result.push(...(await this.insertBatch(batch, e, options)))
+    return result
+  }
+
+  private async insertBatch(
+    batch: any[],
+    e: EntityDbNamesBase,
+    options?: InsertOrUpdateOptions,
+  ): Promise<any[]> {
+    const cols: FieldMetadata[] = []
+    for (const x of this.entity.fields) {
+      if (isDbReadonly(x, e)) continue
+      if (
+        batch.some(
+          (row) =>
+            translateValueAndHandleArrayAndHandleArray(x, row[x.key]) !=
+            undefined,
+        )
+      )
+        cols.push(x)
+    }
+
+    const insertObjects = [] as any[]
+    for (const row of batch) {
+      const insertObject: any = {}
+      for (const x of cols) {
+        const v = translateValueAndHandleArrayAndHandleArray(x, row[x.key])
+        const key = await e.$dbNameOf(x)
+        if (v != undefined) insertObject[key] = v
+        else if (x.allowNull) insertObject[key] = null
+        else insertObject[key] = this.knex.raw('DEFAULT')
+      }
+      insertObjects.push(insertObject)
+    }
+
+    let insert = this.getEntityFrom(e).insert(insertObjects)
+    const wantRows = options?.select !== 'none'
+    if (isAutoIncrement(this.entity.idMetadata.field) && wantRows) {
+      const result = await insert.returning(this.entity.idMetadata.field.dbName)
+      const ids = result.map((r: any) =>
+        r && typeof r === 'object'
+          ? r[this.entity.idMetadata.field.dbName]
+          : r,
+      )
+      return this.loadRowsByIds(ids)
+    }
+    await insert
+    if (!wantRows) return batch.map(() => undefined!)
+    return this.loadRowsByIds(
+      batch.map((row) => this.entity.idMetadata.getId(row)),
+    )
+  }
+
+  private async loadRowsByIds(ids: any[]): Promise<any[]> {
+    const found = await this.find({
+      where: Filter.fromEntityFilter(
+        this.entity,
+        this.entity.idMetadata.getIdFilter(...ids),
+      ),
+    })
+    const byId = new Map(
+      found.map((row) => [this.entity.idMetadata.getId(row) + '', row]),
+    )
+    return ids.map((id) => {
+      const row = byId.get(id + '')
+      if (!row)
+        throw new Error(
+          `Failed to insert row - result contained ${found.length} rows`,
+        )
+      return row
+    })
+  }
+
+  //@internal
+  async insertOne(data: any, options?: InsertOrUpdateOptions): Promise<any> {
     const e = await this.init()
 
     let insertObject: any = {}
@@ -742,6 +836,55 @@ export async function createKnexDataProvider(config: Knex.Config) {
   let result = new KnexDataProvider(k)
   return result
 }
+const defaultMaxParametersInOneSqlStatement = 2000
+
+function isMysqlKnex(knex: Knex) {
+  const client = knex.client.config.client
+  return client === 'mysql2' || client === 'mysql'
+}
+
+function knexMaxParametersInOneSqlStatement(knex: Knex) {
+  const client = String(knex.client.config.client ?? '')
+  if (client.includes('sqlite')) return 999
+  return defaultMaxParametersInOneSqlStatement
+}
+
+function splitByMaxParameters<T>(
+  items: T[],
+  parametersInItem: (item: T) => number,
+  maxParameters: number,
+): T[][] {
+  const batches: T[][] = []
+  let batch: T[] = []
+  let params = 0
+  for (const item of items) {
+    const n = parametersInItem(item)
+    if (batch.length > 0 && params + n > maxParameters) {
+      batches.push(batch)
+      batch = []
+      params = 0
+    }
+    batch.push(item)
+    params += n
+  }
+  if (batch.length) batches.push(batch)
+  return batches
+}
+
+function countKnexInsertBindParameters(
+  entity: EntityMetadata,
+  e: EntityDbNamesBase,
+  row: any,
+): number {
+  let n = 0
+  for (const x of entity.fields) {
+    if (isDbReadonly(x, e)) continue
+    if (translateValueAndHandleArrayAndHandleArray(x, row[x.key]) != undefined)
+      n++
+  }
+  return n
+}
+
 function translateValueAndHandleArrayAndHandleArray(
   field: FieldMetadata<any>,
   val: any,

--- a/projects/core/remult-mongo.ts
+++ b/projects/core/remult-mongo.ts
@@ -319,30 +319,38 @@ class MongoEntityDataProvider implements EntityDataProvider {
     if (options?.select === 'none') return undefined!
     return getRowAfterUpdate(this.entity, this, data, id, 'update')
   }
-  async delete(id: any): Promise<void> {
+  async delete(ids: any[]): Promise<void> {
+    if (ids.length === 0) return
     const { e, collection } = await this.collection()
     let f = new FilterConsumerBridgeToMongo(e)
     Filter.fromEntityFilter(
       this.entity,
-      this.entity.idMetadata.getIdFilter(id),
+      this.entity.idMetadata.getIdFilter(...ids),
     ).__applyToConsumer(f)
-    await collection.deleteOne(await f.resolveWhere(), {
+    await collection.deleteMany(await f.resolveWhere(), {
       session: this.session,
     })
   }
-  async insert(data: any, options?: InsertOrUpdateOptions): Promise<any> {
+  async insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]> {
+    if (data.length === 0) return []
     let { collection, e } = await this.collection()
-    let r = await collection.insertOne(await this.translateToDb(data, e), {
-      session: this.session,
-    })
-    if (options?.select === 'none') return undefined!
-    return await this.translateFromDb(
-      await collection.findOne(
-        { _id: r.insertedId },
-        { session: this.session },
-      ),
-      e,
-    )
+    const docs = []
+    for (const row of data) docs.push(await this.translateToDb(row, e))
+    const r = await collection.insertMany(docs, { session: this.session })
+    if (options?.select === 'none') return data.map(() => undefined!)
+    const result: any[] = []
+    for (let i = 0; i < data.length; i++) {
+      result.push(
+        await this.translateFromDb(
+          await collection.findOne(
+            { _id: r.insertedIds[i] },
+            { session: this.session },
+          ),
+          e,
+        ),
+      )
+    }
+    return result
   }
 
   private async collection() {

--- a/projects/core/remult-sqlite-core.ts
+++ b/projects/core/remult-sqlite-core.ts
@@ -31,6 +31,7 @@ export class SqliteCoreDataProvider
   ) {}
 
   orderByNullsFirst?: boolean
+  maxParametersInOneSqlStatement = 999
 
   getLimitSqlSyntax(limit: number, offset: number) {
     return ' limit ' + limit + ' offset ' + offset

--- a/projects/core/src/data-interfaces.ts
+++ b/projects/core/src/data-interfaces.ts
@@ -39,11 +39,10 @@ export interface EntityDataProvider {
   find(options?: EntityDataProviderFindOptions): Promise<Array<any>>
   groupBy(options?: EntityDataProviderGroupByOptions): Promise<any[]>
   update(id: any, data: any, options?: InsertOrUpdateOptions): Promise<any>
-  delete(id: any): Promise<void>
-  insert(data: any, options?: InsertOrUpdateOptions): Promise<any>
+  delete(ids: any[]): Promise<void>
+  insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]>
 }
 export interface ProxyEntityDataProvider {
-  insertMany(data: any[], options?: InsertOrUpdateOptions): Promise<any[]>
   deleteMany(where: Filter | 'all'): Promise<number>
   updateMany(where: Filter | 'all', data: any): Promise<number>
   query(
@@ -131,11 +130,14 @@ export class DataProviderPromiseWrapper implements DataProvider {
 
 class EntityDataProviderPromiseWrapper implements EntityDataProvider {
   constructor(private dataProvider: Promise<EntityDataProvider>) {}
-  delete(id: any): Promise<void> {
-    return this.dataProvider.then((dp) => dp.delete(id))
+  delete(ids: any[]): Promise<void> {
+    return this.dataProvider.then((dp) => dp.delete(ids))
   }
-  insert(data: any): Promise<any> {
-    return this.dataProvider.then((dp) => dp.insert(data))
+  insert(
+    data: any[],
+    options?: InsertOrUpdateOptions,
+  ): Promise<any[]> {
+    return this.dataProvider.then((dp) => dp.insert(data, options))
   }
   count(where: Filter): Promise<number> {
     return this.dataProvider.then((dp) => dp.count(where))

--- a/projects/core/src/data-interfaces.ts
+++ b/projects/core/src/data-interfaces.ts
@@ -6,6 +6,7 @@ import type {
   MembersOnly,
   InsertOrUpdateOptions,
 } from './remult3/remult3.js'
+import type { EntityMetadataOverloads } from './remult3/RepositoryImplementation.js'
 import { Sort } from './sort.js'
 
 export interface DataProvider {
@@ -15,6 +16,13 @@ export interface DataProvider {
   ): Promise<void>
   ensureSchema?(entities: EntityMetadata[]): Promise<void>
   isProxy?: boolean
+}
+
+/** `InMemoryDataProvider` + `IndexedDbDataProvider` — swap in tests. */
+export interface DroppableDataProvider extends DataProvider {
+  dropDatabase(): Promise<void>
+  /** Recreated with indexes on next use (`ensureSchema` / first write). */
+  dropTable(entity: EntityMetadataOverloads): Promise<void>
 }
 export interface Storage {
   ensureSchema(): Promise<void>

--- a/projects/core/src/data-providers/array-entity-data-provider.ts
+++ b/projects/core/src/data-providers/array-entity-data-provider.ts
@@ -213,7 +213,7 @@ export class ArrayEntityDataProvider implements EntityDataProvider {
     return this.__names
   }
   //@internal
-  private verifyThatRowHasAllNotNullColumns(r: any, names: EntityDbNamesBase) {
+  verifyThatRowHasAllNotNullColumns(r: any, names: EntityDbNamesBase) {
     for (const f of this.entity.fields) {
       const key = names.$dbNameOf(f)
       if (!f.isServerExpression)

--- a/projects/core/src/data-providers/array-entity-data-provider.ts
+++ b/projects/core/src/data-providers/array-entity-data-provider.ts
@@ -339,20 +339,30 @@ export class ArrayEntityDataProvider implements EntityDataProvider {
       `ArrayEntityDataProvider: Couldn't find row with id "${id}" in entity "${this.entity.key}" to update`,
     )
   }
-  async delete(id: any): Promise<void> {
+  async delete(ids: any[]): Promise<void> {
+    for (const id of ids) await this.deleteOne(id)
+  }
+  //@internal
+  async deleteOne(id: any): Promise<void> {
     const names = await this.init()
     let idMatches = this.idMatches(id, names)
     for (let i = 0; i < this.rows().length; i++) {
       if (idMatches(this.rows()[i])) {
         this.rows().splice(i, 1)
-        return Promise.resolve()
+        return
       }
     }
     throw new Error(
       `ArrayEntityDataProvider: Couldn't find row with id "${id}" in entity "${this.entity.key}" to delete`,
     )
   }
-  async insert(data: any): Promise<any> {
+  async insert(data: any[]): Promise<any[]> {
+    const result: any[] = []
+    for (const row of data) result.push(await this.insertOne(row))
+    return result
+  }
+  //@internal
+  async insertOne(data: any): Promise<any> {
     const names = await this.init()
     let j = this.translateToJson(data, names)
     let idf = this.entity.idMetadata.field

--- a/projects/core/src/data-providers/in-memory-database.ts
+++ b/projects/core/src/data-providers/in-memory-database.ts
@@ -1,10 +1,18 @@
 import type { __RowsOfDataForTesting } from '../__RowsOfDataForTesting.js'
-import type { DataProvider, EntityDataProvider } from '../data-interfaces.js'
+import type {
+  DataProvider,
+  DroppableDataProvider,
+  EntityDataProvider,
+} from '../data-interfaces.js'
+import {
+  getEntityMetadata,
+  type EntityMetadataOverloads,
+} from '../remult3/RepositoryImplementation.js'
 import type { EntityMetadata } from '../remult3/remult3.js'
 import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
 
 export class InMemoryDataProvider
-  implements DataProvider, __RowsOfDataForTesting
+  implements DroppableDataProvider, __RowsOfDataForTesting
 {
   async transaction(
     action: (dataProvider: DataProvider) => Promise<void>,
@@ -21,7 +29,16 @@ export class InMemoryDataProvider
   public getEntityDataProvider(entity: EntityMetadata): EntityDataProvider {
     let name = entity.dbName
     if (!this.rows[name]) this.rows[name] = []
-    return new ArrayEntityDataProvider(entity, () => this.rows[name])
+    return new ArrayEntityDataProvider(entity, () => {
+      if (!this.rows[name]) this.rows[name] = []
+      return this.rows[name]
+    })
+  }
+  async dropDatabase(): Promise<void> {
+    this.rows = {}
+  }
+  async dropTable(entity: EntityMetadataOverloads): Promise<void> {
+    delete this.rows[getEntityMetadata(entity).dbName]
   }
   toString() {
     return 'InMemoryDataProvider'

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -1,0 +1,199 @@
+import type {
+  DataProvider,
+  EntityDataProvider,
+  EntityDataProviderFindOptions,
+  EntityDataProviderGroupByOptions,
+} from '../data-interfaces.js'
+import { dbNamesOf } from '../filter/filter-consumer-bridge-to-sql-request.js'
+import type { Filter } from '../filter/filter-interfaces.js'
+import type { EntityMetadata } from '../remult3/remult3.js'
+import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
+
+export class IndexedDbDataProvider implements DataProvider {
+  constructor(private dbName: string = 'remult') {}
+
+  //@internal
+  db?: IDBDatabase
+  //@internal
+  private tail: Promise<void> = Promise.resolve()
+
+  getEntityDataProvider(entity: EntityMetadata): EntityDataProvider {
+    return new IndexedDbEntityDataProvider(this, entity)
+  }
+
+  async transaction(
+    action: (dataProvider: DataProvider) => Promise<void>,
+  ): Promise<void> {
+    await action(this)
+  }
+
+  async ensureSchema(entities: EntityMetadata[]): Promise<void> {
+    await this.enqueue(() => this.ensureStores(entities))
+  }
+
+  close() {
+    this.db?.close()
+    this.db = undefined
+  }
+
+  //@internal
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(fn, fn)
+    this.tail = run.then(
+      () => {},
+      () => {},
+    )
+    return run
+  }
+
+  //@internal
+  async runWithRows<T>(
+    entity: EntityMetadata,
+    mutate: boolean,
+    what: (dp: ArrayEntityDataProvider) => Promise<T>,
+  ): Promise<T> {
+    return this.enqueue(async () => {
+      await this.ensureStores([entity])
+      const storeName = storeNameOf(entity)
+      const rows = await this.getAll(storeName)
+      const result = await what(new ArrayEntityDataProvider(entity, () => rows))
+      if (mutate) await this.replaceStore(storeName, rows)
+      return result
+    })
+  }
+
+  //@internal
+  async ensureStores(entities: EntityMetadata[]) {
+    const wanted = await Promise.all(
+      entities.map(async (entity) => ({
+        name: storeNameOf(entity),
+        keyPath: await keyPathOf(entity),
+      })),
+    )
+    const db = await this.open()
+    const missing = wanted.filter((w) => !db.objectStoreNames.contains(w.name))
+    if (missing.length === 0) return
+
+    const nextVersion = db.version + 1
+    this.forget(db)
+    db.close()
+
+    await this.open(nextVersion, (upgradeDb) => {
+      for (const { name, keyPath } of missing) {
+        if (!upgradeDb.objectStoreNames.contains(name)) {
+          upgradeDb.createObjectStore(name, { keyPath })
+        }
+      }
+    })
+  }
+
+  //@internal
+  private forget(db: IDBDatabase) {
+    if (this.db === db) this.db = undefined
+  }
+
+  //@internal
+  private async open(
+    version?: number,
+    upgrade?: (db: IDBDatabase) => void,
+  ): Promise<IDBDatabase> {
+    if (this.db && version == null) return this.db
+    this.db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request =
+        version == null
+          ? indexedDB.open(this.dbName)
+          : indexedDB.open(this.dbName, version)
+      request.onerror = () => reject(request.error)
+      request.onupgradeneeded = () => upgrade?.(request.result)
+      request.onsuccess = () => {
+        const db = request.result
+        const forget = () => this.forget(db)
+        db.onclose = forget
+        db.onversionchange = () => {
+          db.close()
+          forget()
+        }
+        resolve(db)
+      }
+    })
+    return this.db
+  }
+
+  //@internal
+  private getAll(storeName: string): Promise<any[]> {
+    return this.withStore(storeName, 'readonly', (store) => store.getAll())
+  }
+
+  //@internal
+  private replaceStore(storeName: string, rows: any[]): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const tx = this.db!.transaction(storeName, 'readwrite')
+      tx.oncomplete = () => resolve()
+      tx.onabort = () => reject(tx.error)
+      tx.onerror = () => reject(tx.error)
+      const store = tx.objectStore(storeName)
+      store.clear()
+      for (const row of rows) store.put(row)
+    })
+  }
+
+  //@internal
+  private withStore<T>(
+    storeName: string,
+    mode: IDBTransactionMode,
+    op: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const tx = this.db!.transaction(storeName, mode)
+      tx.onabort = () => reject(tx.error)
+      const request = op(tx.objectStore(storeName))
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+  }
+}
+
+class IndexedDbEntityDataProvider implements EntityDataProvider {
+  constructor(
+    private provider: IndexedDbDataProvider,
+    private entity: EntityMetadata,
+  ) {}
+
+  find(options?: EntityDataProviderFindOptions): Promise<any[]> {
+    return this.provider.runWithRows(this.entity, false, (dp) =>
+      dp.find(options),
+    )
+  }
+  count(where: Filter): Promise<number> {
+    return this.provider.runWithRows(this.entity, false, (dp) =>
+      dp.count(where),
+    )
+  }
+  groupBy(options?: EntityDataProviderGroupByOptions): Promise<any[]> {
+    return this.provider.runWithRows(this.entity, false, (dp) =>
+      dp.groupBy(options),
+    )
+  }
+  insert(data: any): Promise<any> {
+    return this.provider.runWithRows(this.entity, true, (dp) => dp.insert(data))
+  }
+  update(id: any, data: any): Promise<any> {
+    return this.provider.runWithRows(this.entity, true, (dp) =>
+      dp.update(id, data),
+    )
+  }
+  delete(id: any): Promise<void> {
+    return this.provider.runWithRows(this.entity, true, (dp) => dp.delete(id))
+  }
+}
+
+function storeNameOf(entity: EntityMetadata) {
+  return entity.dbName
+}
+
+async function keyPathOf(entity: EntityMetadata): Promise<string | string[]> {
+  const names = await dbNamesOf(entity, (x) => x)
+  const fields = entity.idMetadata.fields
+  if (fields.length === 1) return names.$dbNameOf(fields[0])
+  return fields.map((f) => names.$dbNameOf(f))
+}

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -38,16 +38,36 @@ export class IndexedDbIndexBuilder {
 
 export type IndexedDbDataProviderOptions = {
   indexes?: (x: IndexedDbIndexBuilder) => void
+  encrypt?: boolean
+  getEncryptionKey?: () => CryptoKey | Promise<CryptoKey>
 }
+
+const IDB_KEYS_STORE = '__remult_keys'
+const IDB_DEK_ID = 'dek'
+const IDB_ENC = '_enc'
+const IDB_IV = '_iv'
 
 export class IndexedDbDataProvider implements DataProvider {
   //@internal
   private declaredIndexes: IndexedDbIndexBuilder['entries'] = []
+  //@internal
+  encrypt: boolean
+  //@internal
+  private customGetKey?: () => CryptoKey | Promise<CryptoKey>
+  //@internal
+  private dek?: CryptoKey
 
   constructor(
     private dbName: string = 'remult',
     options?: IndexedDbDataProviderOptions,
   ) {
+    this.encrypt = options?.encrypt === true
+    this.customGetKey = options?.getEncryptionKey
+    if (this.encrypt && !(typeof crypto !== 'undefined' && crypto.subtle)) {
+      throw new Error(
+        'Web Crypto API is required when IndexedDB encryption is enabled',
+      )
+    }
     if (options?.indexes) {
       const builder = new IndexedDbIndexBuilder()
       options.indexes(builder)
@@ -121,9 +141,20 @@ export class IndexedDbDataProvider implements DataProvider {
       this.storeIndexes(storeName),
     )
     this.lastFetch = prefetch
-    if (prefetch.type === 'all') return this.getAll(storeName)
-    const ops = prefetch.type === 'or' ? prefetch.parts : [prefetch]
-    return this.fetchOps(storeName, entity, ops)
+    const rows =
+      prefetch.type === 'all'
+        ? await this.getAll(storeName)
+        : await this.fetchOps(
+            storeName,
+            entity,
+            prefetch.type === 'or' ? prefetch.parts : [prefetch],
+          )
+    if (!this.encrypt) return rows
+    const dek = await this.loadDek()
+    const names = await dbNamesOf(entity, (x) => x)
+    return Promise.all(
+      rows.map((row) => decryptJson(storeName, row, entity, names, dek)),
+    )
   }
 
   //@internal
@@ -168,11 +199,15 @@ export class IndexedDbDataProvider implements DataProvider {
       }),
     )
     const db = await this.open()
-    const needsUpgrade = wanted.some((w) => {
-      if (!db.objectStoreNames.contains(w.name)) return true
-      const existing = this.storeIndexes(w.name).map((i) => i.name)
-      return w.indexes.some((idx) => !existing.includes(idx.name))
-    })
+    const needsKeyStore =
+      this.usesKeyStore() && !db.objectStoreNames.contains(IDB_KEYS_STORE)
+    const needsUpgrade =
+      needsKeyStore ||
+      wanted.some((w) => {
+        if (!db.objectStoreNames.contains(w.name)) return true
+        const existing = this.storeIndexes(w.name).map((i) => i.name)
+        return w.indexes.some((idx) => !existing.includes(idx.name))
+      })
     if (!needsUpgrade) return
 
     const nextVersion = db.version + 1
@@ -180,6 +215,12 @@ export class IndexedDbDataProvider implements DataProvider {
     db.close()
 
     await this.open(nextVersion, (upgradeDb, tx) => {
+      if (
+        this.usesKeyStore() &&
+        !upgradeDb.objectStoreNames.contains(IDB_KEYS_STORE)
+      ) {
+        upgradeDb.createObjectStore(IDB_KEYS_STORE, { keyPath: 'id' })
+      }
       for (const { name, keyPath, autoIncrement, indexes } of wanted) {
         const store = upgradeDb.objectStoreNames.contains(name)
           ? tx.objectStore(name)
@@ -191,6 +232,72 @@ export class IndexedDbDataProvider implements DataProvider {
         }
       }
     })
+  }
+
+  //@internal
+  private usesKeyStore() {
+    return this.encrypt && !this.customGetKey
+  }
+
+  //@internal
+  async loadDek(): Promise<CryptoKey> {
+    if (this.dek) return this.dek
+    if (this.customGetKey) {
+      const key = await this.customGetKey()
+      this.dek = key
+      return key
+    }
+    const existing = await this.withStore(IDB_KEYS_STORE, 'readonly', (s) =>
+      idbReq(s.get(IDB_DEK_ID)),
+    )
+    if (existing?.key) {
+      this.dek = existing.key
+      return existing.key
+    }
+    const generated = await crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+    const key = await this.withStore(
+      IDB_KEYS_STORE,
+      'readwrite',
+      async (s) => {
+        const rec = await idbReq(s.get(IDB_DEK_ID))
+        if (rec?.key) return rec.key as CryptoKey
+        try {
+          await idbReq(s.add({ id: IDB_DEK_ID, key: generated }))
+          return generated
+        } catch (e: any) {
+          if (e?.name === 'ConstraintError') {
+            const again = await idbReq(s.get(IDB_DEK_ID))
+            if (!again?.key)
+              throw new Error('Failed to load IndexedDB encryption key')
+            return again.key as CryptoKey
+          }
+          throw e
+        }
+      },
+    )
+    this.dek = key
+    return key
+  }
+
+  //@internal
+  async plaintextDbNames(entity: EntityMetadata): Promise<Set<string>> {
+    const names = await dbNamesOf(entity, (x) => x)
+    const set = new Set<string>()
+    for (const f of entity.idMetadata.fields) {
+      set.add(names.$dbNameOf(f))
+    }
+    for (const def of this.indexesFor(entity)) {
+      const keys = Array.isArray(def) ? [...def] : [def]
+      for (const key of keys) {
+        const field = [...entity.fields].find((f) => f.key === key)
+        if (field) set.add(names.$dbNameOf(field))
+      }
+    }
+    return set
   }
 
   //@internal
@@ -333,24 +440,63 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
         if (auto) delete json[idName]
         return json
       })
-      return this.provider.withStore(
-        storeNameOf(this.entity),
+      const storeName = storeNameOf(this.entity)
+      const dek = this.provider.encrypt
+        ? await this.provider.loadDek()
+        : undefined
+      const keep = dek
+        ? await this.provider.plaintextDbNames(this.entity)
+        : undefined
+      if (dek && auto) {
+        const keys = await this.provider.withStore(
+          storeName,
+          'readwrite',
+          async (store) => {
+            const allocated: IDBValidKey[] = []
+            for (let i = 0; i < rows.length; i++) {
+              allocated.push(await idbReq(store.add({})))
+            }
+            return allocated
+          },
+        )
+        for (let i = 0; i < rows.length; i++) {
+          rows[i][idName] = keys[i]
+        }
+      }
+      const toWrite = dek
+        ? await Promise.all(
+            rows.map((json) =>
+              encryptJson(
+                storeName,
+                json,
+                keep!,
+                keyFromRow(this.entity, names, json),
+                dek,
+              ),
+            ),
+          )
+        : rows
+      await this.provider.withStore(
+        storeName,
         'readwrite',
         async (store) => {
-          const result: any[] = []
-          for (const json of rows) {
+          for (let i = 0; i < toWrite.length; i++) {
             try {
-              const key = await idbReq(store.add(json))
-              if (auto) json[idName] = json[idName] ?? key
+              if (dek && auto) {
+                await idbReq(store.put(toWrite[i]))
+              } else {
+                const key = await idbReq(store.add(toWrite[i]))
+                if (auto) rows[i][idName] = rows[i][idName] ?? key
+              }
             } catch (e: any) {
-              if (e?.name === 'ConstraintError') throw Error('id already exists')
+              if (e?.name === 'ConstraintError')
+                throw Error('id already exists')
               throw e
             }
-            result.push(helper.translateFromJson(json, names))
           }
-          return result
         },
       )
+      return rows.map((json) => helper.translateFromJson(json, names))
     })
   }
 
@@ -360,33 +506,53 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
       const helper = new ArrayEntityDataProvider(this.entity, () => [])
       const names = await helper.init()
       const key = toIdbKey(this.entity, id)
-      return this.provider.withStore(
-        storeNameOf(this.entity),
+      const storeName = storeNameOf(this.entity)
+      const existingRaw = await this.provider.withStore(
+        storeName,
+        'readonly',
+        (store) => idbReq(store.get(key)),
+      )
+      if (existingRaw == null)
+        throw new Error(
+          `Couldn't find row with id "${id}" in entity "${this.entity.key}" to update`,
+        )
+      const dek = this.provider.encrypt
+        ? await this.provider.loadDek()
+        : undefined
+      const existing = dek
+        ? await decryptJson(storeName, existingRaw, this.entity, names, dek)
+        : existingRaw
+      const json = { ...existing }
+      const keys = Object.keys(data)
+      for (const f of this.entity.fields) {
+        if (!isDbReadonly(f, names) && keys.includes(f.key)) {
+          json[names.$dbNameOf(f)] = f.valueConverter.toJson(data[f.key])
+        }
+      }
+      helper.verifyThatRowHasAllNotNullColumns(json, names)
+      const newKey = keyFromRow(this.entity, names, json)
+      const toWrite = dek
+        ? await encryptJson(
+            storeName,
+            json,
+            await this.provider.plaintextDbNames(this.entity),
+            newKey,
+            dek,
+          )
+        : json
+      await this.provider.withStore(
+        storeName,
         'readwrite',
         async (store) => {
-          const existing = await idbReq(store.get(key))
-          if (existing == null)
-            throw new Error(
-              `Couldn't find row with id "${id}" in entity "${this.entity.key}" to update`,
-            )
-          const json = { ...existing }
-          const keys = Object.keys(data)
-          for (const f of this.entity.fields) {
-            if (!isDbReadonly(f, names) && keys.includes(f.key)) {
-              json[names.$dbNameOf(f)] = f.valueConverter.toJson(data[f.key])
-            }
-          }
-          helper.verifyThatRowHasAllNotNullColumns(json, names)
-          const newKey = keyFromRow(this.entity, names, json)
           if (!idbKeysEqual(key, newKey)) {
             const conflict = await idbReq(store.get(newKey))
             if (conflict != null) throw Error('id already exists')
             await idbReq(store.delete(key))
           }
-          await idbReq(store.put(json))
-          return helper.translateFromJson(json, names)
+          await idbReq(store.put(toWrite))
         },
       )
+      return helper.translateFromJson(json, names)
     })
   }
 
@@ -776,4 +942,72 @@ function idbReq<T>(request: IDBRequest<T>): Promise<T> {
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => reject(request.error)
   })
+}
+
+function encAad(storeName: string, id: IDBValidKey) {
+  return new TextEncoder().encode(storeName + '\0' + JSON.stringify(id))
+}
+
+function asBufferSource(value: any, label: string): BufferSource {
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer)
+    return value as BufferSource
+  throw new Error(`Failed to decrypt IndexedDB row: missing ${label}`)
+}
+
+async function encryptJson(
+  storeName: string,
+  json: any,
+  plaintext: Set<string>,
+  idbKey: IDBValidKey,
+  dek: CryptoKey,
+) {
+  const stored: any = {}
+  const payload: any = {}
+  for (const k of Object.keys(json)) {
+    if (k === IDB_ENC || k === IDB_IV) continue
+    if (plaintext.has(k)) stored[k] = json[k]
+    else payload[k] = json[k]
+  }
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  stored[IDB_ENC] = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+      additionalData: encAad(storeName, idbKey),
+    } as AlgorithmIdentifier,
+    dek,
+    new TextEncoder().encode(JSON.stringify(payload)),
+  )
+  stored[IDB_IV] = iv
+  return stored
+}
+
+async function decryptJson(
+  storeName: string,
+  row: any,
+  entity: EntityMetadata,
+  names: EntityDbNamesBase,
+  dek: CryptoKey,
+) {
+  if (row == null || row[IDB_ENC] == null) return row
+  const idbKey = keyFromRow(entity, names, row)
+  try {
+    const plain = await crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: asBufferSource(row[IDB_IV], IDB_IV),
+        additionalData: encAad(storeName, idbKey),
+      } as AlgorithmIdentifier,
+      dek,
+      asBufferSource(row[IDB_ENC], IDB_ENC) as BufferSource,
+    )
+    const payload = JSON.parse(new TextDecoder().decode(plain))
+    const result = { ...row, ...payload }
+    delete result[IDB_ENC]
+    delete result[IDB_IV]
+    return result
+  } catch (e: any) {
+    if (e?.message?.startsWith('Failed to decrypt IndexedDB row')) throw e
+    throw new Error(`Failed to decrypt IndexedDB row in "${storeName}"`)
+  }
 }

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -9,14 +9,51 @@ import {
   dbNamesOf,
   isDbReadonly,
 } from '../filter/filter-consumer-bridge-to-sql-request.js'
+import type { ClassType } from '../../classType.js'
 import type { FieldMetadata } from '../column-interfaces.js'
 import type { Filter, FilterConsumer } from '../filter/filter-interfaces.js'
-import type { EntityMetadata } from '../remult3/remult3.js'
+import type { EntityMetadata, MembersOnly } from '../remult3/remult3.js'
 import { isAutoIncrement } from '../remult3/RepositoryImplementation.js'
 import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
 
+export type IndexedDbIndexDef<entityType> =
+  | keyof MembersOnly<entityType>
+  | readonly (keyof MembersOnly<entityType>)[]
+
+export class IndexedDbIndexBuilder {
+  //@internal
+  readonly entries: {
+    entity: ClassType<any>
+    indexes: IndexedDbIndexDef<any>[]
+  }[] = []
+
+  ensureIndexes<entityType>(
+    entity: ClassType<entityType>,
+    indexes: readonly IndexedDbIndexDef<entityType>[],
+  ): this {
+    this.entries.push({ entity, indexes: [...indexes] })
+    return this
+  }
+}
+
+export type IndexedDbDataProviderOptions = {
+  indexes?: (x: IndexedDbIndexBuilder) => void
+}
+
 export class IndexedDbDataProvider implements DataProvider {
-  constructor(private dbName: string = 'remult') {}
+  //@internal
+  private declaredIndexes: IndexedDbIndexBuilder['entries'] = []
+
+  constructor(
+    private dbName: string = 'remult',
+    options?: IndexedDbDataProviderOptions,
+  ) {
+    if (options?.indexes) {
+      const builder = new IndexedDbIndexBuilder()
+      options.indexes(builder)
+      this.declaredIndexes = builder.entries
+    }
+  }
 
   //@internal
   db?: IDBDatabase
@@ -78,7 +115,11 @@ export class IndexedDbDataProvider implements DataProvider {
   //@internal
   private async loadRows(entity: EntityMetadata, where?: Filter) {
     const storeName = storeNameOf(entity)
-    const prefetch = idbPrefetchFromFilter(entity, where)
+    const prefetch = await idbPrefetchFromFilter(
+      entity,
+      where,
+      this.storeIndexes(storeName),
+    )
     this.lastFetch = prefetch
     if (prefetch.type === 'all') return this.getAll(storeName)
     const ops = prefetch.type === 'or' ? prefetch.parts : [prefetch]
@@ -86,26 +127,61 @@ export class IndexedDbDataProvider implements DataProvider {
   }
 
   //@internal
+  private storeIndexes(storeName: string): IdbIndexInfo[] {
+    const db = this.db
+    if (!db?.objectStoreNames.contains(storeName)) return []
+    const store = db.transaction(storeName).objectStore(storeName)
+    return [...store.indexNames].map((name) => ({
+      name,
+      keyPath: store.index(name).keyPath,
+    }))
+  }
+
+  //@internal
+  private indexesFor(entity: EntityMetadata): IndexedDbIndexDef<any>[] {
+    return this.declaredIndexes
+      .filter((e) => e.entity === entity.entityType)
+      .flatMap((e) => e.indexes)
+  }
+
+  //@internal
   async ensureStores(entities: EntityMetadata[]) {
     const wanted = await Promise.all(
-      entities.map(async (entity) => ({
-        name: storeNameOf(entity),
-        keyPath: await keyPathOf(entity),
-        autoIncrement: isAutoIncrement(entity.idMetadata.field),
-      })),
+      entities.map(async (entity) => {
+        const keyPath = await keyPathOf(entity)
+        return {
+          name: storeNameOf(entity),
+          keyPath,
+          autoIncrement: isAutoIncrement(entity.idMetadata.field),
+          indexes: await resolveIndexDefs(
+            entity,
+            this.indexesFor(entity),
+            keyPath,
+          ),
+        }
+      }),
     )
     const db = await this.open()
-    const missing = wanted.filter((w) => !db.objectStoreNames.contains(w.name))
-    if (missing.length === 0) return
+    const needsUpgrade = wanted.some((w) => {
+      if (!db.objectStoreNames.contains(w.name)) return true
+      const existing = this.storeIndexes(w.name).map((i) => i.name)
+      return w.indexes.some((idx) => !existing.includes(idx.name))
+    })
+    if (!needsUpgrade) return
 
     const nextVersion = db.version + 1
     this.forget(db)
     db.close()
 
-    await this.open(nextVersion, (upgradeDb) => {
-      for (const { name, keyPath, autoIncrement } of missing) {
-        if (!upgradeDb.objectStoreNames.contains(name)) {
-          upgradeDb.createObjectStore(name, { keyPath, autoIncrement })
+    await this.open(nextVersion, (upgradeDb, tx) => {
+      for (const { name, keyPath, autoIncrement, indexes } of wanted) {
+        const store = upgradeDb.objectStoreNames.contains(name)
+          ? tx.objectStore(name)
+          : upgradeDb.createObjectStore(name, { keyPath, autoIncrement })
+        for (const idx of indexes) {
+          if (!store.indexNames.contains(idx.name)) {
+            store.createIndex(idx.name, idx.keyPath)
+          }
         }
       }
     })
@@ -119,7 +195,7 @@ export class IndexedDbDataProvider implements DataProvider {
   //@internal
   private async open(
     version?: number,
-    upgrade?: (db: IDBDatabase) => void,
+    upgrade?: (db: IDBDatabase, tx: IDBTransaction) => void,
   ): Promise<IDBDatabase> {
     if (this.db && version == null) return this.db
     this.db = await new Promise<IDBDatabase>((resolve, reject) => {
@@ -128,7 +204,8 @@ export class IndexedDbDataProvider implements DataProvider {
           ? indexedDB.open(this.dbName)
           : indexedDB.open(this.dbName, version)
       request.onerror = () => reject(request.error)
-      request.onupgradeneeded = () => upgrade?.(request.result)
+      request.onupgradeneeded = () =>
+        upgrade?.(request.result, request.transaction!)
       request.onsuccess = () => {
         const db = request.result
         const forget = () => this.forget(db)
@@ -161,10 +238,17 @@ export class IndexedDbDataProvider implements DataProvider {
       const seen = new Set<string>()
       const rows: any[] = []
       for (const op of ops) {
+        const source = op.index ? store.index(op.index) : store
         const chunk =
           op.type === 'keys'
-            ? await Promise.all(op.keys.map((key) => idbReq(store.get(key))))
-            : await idbReq(store.getAll(op.range))
+            ? op.index
+              ? (
+                  await Promise.all(
+                    op.keys.map((key) => idbReq(source.getAll(key))),
+                  )
+                ).flat()
+              : await Promise.all(op.keys.map((key) => idbReq(store.get(key))))
+            : await idbReq(source.getAll(op.range))
         for (const row of chunk) {
           if (row == null) continue
           const k = JSON.stringify(row[idKey])
@@ -318,25 +402,130 @@ function storeNameOf(entity: EntityMetadata) {
 }
 
 export type IdbFetchOp =
-  | { type: 'keys'; keys: IDBValidKey[] }
-  | { type: 'range'; range: IDBKeyRange }
+  | { type: 'keys'; keys: IDBValidKey[]; index?: string }
+  | { type: 'range'; range: IDBKeyRange; index?: string }
 
 export type IdbPrefetch =
   | { type: 'all' }
   | IdbFetchOp
   | { type: 'or'; parts: IdbFetchOp[] }
 
+export type IdbIndexInfo = { name: string; keyPath: string | string[] }
+
 //@internal
-export function idbPrefetchFromFilter(
+export async function idbPrefetchFromFilter(
   entity: EntityMetadata,
   where?: Filter,
-): IdbPrefetch {
+  indexes: IdbIndexInfo[] = [],
+): Promise<IdbPrefetch> {
   if (!where) return { type: 'all' }
-  const fields = entity.idMetadata.fields
-  if (fields.length !== 1) return { type: 'all' }
-  const c = new IdbPrefetchCollector(fields[0])
-  where.__applyToConsumer(c)
-  return c.result()
+  const names = await dbNamesOf(entity, (x) => x)
+  if (entity.idMetadata.fields.length === 1) {
+    const c = new IdbPrefetchCollector(entity.idMetadata.fields[0])
+    where.__applyToConsumer(c)
+    const r = c.result()
+    if (r.type !== 'all') return r
+  }
+  const ordered = [...indexes].sort(
+    (a, b) => pathLen(b.keyPath) - pathLen(a.keyPath),
+  )
+  for (const idx of ordered) {
+    const r = prefetchForIndex(entity, names, where, idx)
+    if (r.type !== 'all') return withIndex(r, idx.name)
+  }
+  return { type: 'all' }
+}
+
+function prefetchForIndex(
+  entity: EntityMetadata,
+  names: EntityDbNamesBase,
+  where: Filter,
+  idx: IdbIndexInfo,
+): IdbPrefetch {
+  const path = Array.isArray(idx.keyPath) ? idx.keyPath : [idx.keyPath]
+  if (path.length === 1) {
+    const field = fieldByDbName(entity, names, path[0])
+    if (!field) return { type: 'all' }
+    const c = new IdbPrefetchCollector(field)
+    where.__applyToConsumer(c)
+    return c.result()
+  }
+  const parts = path.map((dbName) => {
+    const field = fieldByDbName(entity, names, dbName)
+    if (!field) return { type: 'all' } as IdbPrefetch
+    const c = new IdbPrefetchCollector(field)
+    where.__applyToConsumer(c)
+    return c.result()
+  })
+  if (parts.every((p) => p.type === 'keys')) {
+    return {
+      type: 'keys',
+      keys: cartesian(parts.map((p) => (p as { keys: IDBValidKey[] }).keys)),
+    }
+  }
+  const last = parts[parts.length - 1]
+  const prefix = parts.slice(0, -1)
+  if (
+    last.type === 'range' &&
+    prefix.every((p) => p.type === 'keys' && p.keys.length === 1)
+  ) {
+    const pre = prefix.map((p) => (p as { type: 'keys'; keys: IDBValidKey[] }).keys[0])
+    const r = last.range
+    try {
+      if (r.lower !== undefined && r.upper !== undefined)
+        return {
+          type: 'range',
+          range: IDBKeyRange.bound(
+            [...pre, r.lower],
+            [...pre, r.upper],
+            r.lowerOpen,
+            r.upperOpen,
+          ),
+        }
+      if (r.lower !== undefined)
+        return {
+          type: 'range',
+          range: IDBKeyRange.lowerBound([...pre, r.lower], r.lowerOpen),
+        }
+      if (r.upper !== undefined)
+        return {
+          type: 'range',
+          range: IDBKeyRange.upperBound([...pre, r.upper], r.upperOpen),
+        }
+    } catch {
+      return { type: 'keys', keys: [] }
+    }
+  }
+  return { type: 'all' }
+}
+
+function withIndex(prefetch: IdbPrefetch, index: string): IdbPrefetch {
+  if (prefetch.type === 'all') return prefetch
+  if (prefetch.type === 'or')
+    return { type: 'or', parts: prefetch.parts.map((p) => ({ ...p, index })) }
+  return { ...prefetch, index }
+}
+
+function pathLen(keyPath: string | string[]) {
+  return Array.isArray(keyPath) ? keyPath.length : 1
+}
+
+function fieldByDbName(
+  entity: EntityMetadata,
+  names: EntityDbNamesBase,
+  dbName: string,
+) {
+  for (const f of entity.fields) {
+    if (names.$dbNameOf(f) === dbName) return f
+  }
+}
+
+function cartesian(lists: IDBValidKey[][]): IDBValidKey[] {
+  let acc: IDBValidKey[][] = [[]]
+  for (const list of lists) {
+    acc = acc.flatMap((prefix) => list.map((v) => [...prefix, v]))
+  }
+  return acc
 }
 
 class IdbPrefetchCollector implements FilterConsumer {
@@ -478,22 +667,54 @@ class IdbPrefetchCollector implements FilterConsumer {
 }
 
 function mergeOps(ops: IdbFetchOp[]): IdbPrefetch {
-  const keys: IDBValidKey[] = []
-  const ranges: IDBKeyRange[] = []
+  const keyGroups = new Map<string, IDBValidKey[]>()
+  const ranges: IdbFetchOp[] = []
   for (const op of ops) {
-    if (op.type === 'keys') keys.push(...op.keys)
-    else ranges.push(op.range)
+    if (op.type === 'keys') {
+      const k = op.index ?? ''
+      keyGroups.set(k, [...(keyGroups.get(k) ?? []), ...op.keys])
+    } else ranges.push(op)
   }
-  const uniqueKeys = keys.filter(
-    (k, i) => keys.findIndex((x) => idbKeysEqual(x, k)) === i,
-  )
-  if (ranges.length === 0) return { type: 'keys', keys: uniqueKeys }
   const parts: IdbFetchOp[] = [
-    ...(uniqueKeys.length ? [{ type: 'keys' as const, keys: uniqueKeys }] : []),
-    ...ranges.map((range) => ({ type: 'range' as const, range })),
+    ...[...keyGroups.entries()].map(([index, keys]) => ({
+      type: 'keys' as const,
+      keys: keys.filter((k, i) => keys.findIndex((x) => idbKeysEqual(x, k)) === i),
+      ...(index ? { index } : {}),
+    })),
+    ...ranges,
   ]
   if (parts.length === 1) return parts[0]
   return { type: 'or', parts }
+}
+
+async function resolveIndexDefs(
+  entity: EntityMetadata,
+  defs: IndexedDbIndexDef<any>[],
+  storeKeyPath: string | string[],
+): Promise<IdbIndexInfo[]> {
+  if (defs.length === 0) return []
+  const names = await dbNamesOf(entity, (x) => x)
+  const result: IdbIndexInfo[] = []
+  const seen = new Set<string>()
+  const pk = JSON.stringify(storeKeyPath)
+  for (const def of defs) {
+    const keys = Array.isArray(def) ? [...def] : [def]
+    const keyPath = keys.map((key) => {
+      const field = [...entity.fields].find((f) => f.key === key)
+      if (!field)
+        throw new Error(
+          `IndexedDB index field "${key}" not found on entity "${entity.key}"`,
+        )
+      return names.$dbNameOf(field)
+    })
+    const path: string | string[] = keyPath.length === 1 ? keyPath[0] : keyPath
+    if (JSON.stringify(path) === pk) continue
+    const name = keyPath.join('_')
+    if (seen.has(name)) continue
+    seen.add(name)
+    result.push({ name, keyPath: path })
+  }
+  return result
 }
 
 async function keyPathOf(entity: EntityMetadata): Promise<string | string[]> {

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -9,7 +9,8 @@ import {
   dbNamesOf,
   isDbReadonly,
 } from '../filter/filter-consumer-bridge-to-sql-request.js'
-import type { Filter } from '../filter/filter-interfaces.js'
+import type { FieldMetadata } from '../column-interfaces.js'
+import type { Filter, FilterConsumer } from '../filter/filter-interfaces.js'
 import type { EntityMetadata } from '../remult3/remult3.js'
 import { isAutoIncrement } from '../remult3/RepositoryImplementation.js'
 import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
@@ -19,6 +20,8 @@ export class IndexedDbDataProvider implements DataProvider {
 
   //@internal
   db?: IDBDatabase
+  //@internal
+  lastFetch?: IdbPrefetch
   //@internal
   private tail: Promise<void> = Promise.resolve()
 
@@ -54,13 +57,32 @@ export class IndexedDbDataProvider implements DataProvider {
   //@internal
   async runWithRows<T>(
     entity: EntityMetadata,
+    where: Filter | undefined,
     what: (dp: ArrayEntityDataProvider) => Promise<T>,
   ): Promise<T> {
     return this.enqueue(async () => {
       await this.ensureStores([entity])
-      const rows = await this.getAll(storeNameOf(entity))
+      const rows = await this.loadRows(entity, where)
       return what(new ArrayEntityDataProvider(entity, () => rows))
     })
+  }
+
+  //@internal
+  async fetchRows(entity: EntityMetadata, where?: Filter) {
+    return this.enqueue(async () => {
+      await this.ensureStores([entity])
+      return this.loadRows(entity, where)
+    })
+  }
+
+  //@internal
+  private async loadRows(entity: EntityMetadata, where?: Filter) {
+    const storeName = storeNameOf(entity)
+    const prefetch = idbPrefetchFromFilter(entity, where)
+    this.lastFetch = prefetch
+    if (prefetch.type === 'all') return this.getAll(storeName)
+    const ops = prefetch.type === 'or' ? prefetch.parts : [prefetch]
+    return this.fetchOps(storeName, entity, ops)
   }
 
   //@internal
@@ -122,10 +144,37 @@ export class IndexedDbDataProvider implements DataProvider {
   }
 
   //@internal
-  private getAll(storeName: string): Promise<any[]> {
+  private getAll(storeName: string, range?: IDBKeyRange): Promise<any[]> {
     return this.withStore(storeName, 'readonly', (store) =>
-      idbReq(store.getAll()),
+      idbReq(range ? store.getAll(range) : store.getAll()),
     )
+  }
+
+  //@internal
+  private fetchOps(
+    storeName: string,
+    entity: EntityMetadata,
+    ops: IdbFetchOp[],
+  ): Promise<any[]> {
+    return this.withStore(storeName, 'readonly', async (store) => {
+      const idKey = entity.idMetadata.fields[0].key
+      const seen = new Set<string>()
+      const rows: any[] = []
+      for (const op of ops) {
+        const chunk =
+          op.type === 'keys'
+            ? await Promise.all(op.keys.map((key) => idbReq(store.get(key))))
+            : await idbReq(store.getAll(op.range))
+        for (const row of chunk) {
+          if (row == null) continue
+          const k = JSON.stringify(row[idKey])
+          if (seen.has(k)) continue
+          seen.add(k)
+          rows.push(row)
+        }
+      }
+      return rows
+    })
   }
 
   //@internal
@@ -168,13 +217,17 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
   ) {}
 
   find(options?: EntityDataProviderFindOptions): Promise<any[]> {
-    return this.provider.runWithRows(this.entity, (dp) => dp.find(options))
+    return this.provider.runWithRows(this.entity, options?.where, (dp) =>
+      dp.find(options),
+    )
   }
   count(where: Filter): Promise<number> {
-    return this.provider.runWithRows(this.entity, (dp) => dp.count(where))
+    return this.provider.runWithRows(this.entity, where, (dp) => dp.count(where))
   }
   groupBy(options?: EntityDataProviderGroupByOptions): Promise<any[]> {
-    return this.provider.runWithRows(this.entity, (dp) => dp.groupBy(options))
+    return this.provider.runWithRows(this.entity, options?.where, (dp) =>
+      dp.groupBy(options),
+    )
   }
 
   insert(data: any): Promise<any> {
@@ -262,6 +315,185 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
 
 function storeNameOf(entity: EntityMetadata) {
   return entity.dbName
+}
+
+export type IdbFetchOp =
+  | { type: 'keys'; keys: IDBValidKey[] }
+  | { type: 'range'; range: IDBKeyRange }
+
+export type IdbPrefetch =
+  | { type: 'all' }
+  | IdbFetchOp
+  | { type: 'or'; parts: IdbFetchOp[] }
+
+//@internal
+export function idbPrefetchFromFilter(
+  entity: EntityMetadata,
+  where?: Filter,
+): IdbPrefetch {
+  if (!where) return { type: 'all' }
+  const fields = entity.idMetadata.fields
+  if (fields.length !== 1) return { type: 'all' }
+  const c = new IdbPrefetchCollector(fields[0])
+  where.__applyToConsumer(c)
+  return c.result()
+}
+
+class IdbPrefetchCollector implements FilterConsumer {
+  private keys?: IDBValidKey[]
+  private lower?: { value: IDBValidKey; open: boolean }
+  private upper?: { value: IDBValidKey; open: boolean }
+  private orOps?: IdbFetchOp[]
+  private cannotNarrow = false
+
+  constructor(private idField: FieldMetadata) {}
+
+  result(): IdbPrefetch {
+    if (this.cannotNarrow) return { type: 'all' }
+    const andOp = this.andOp()
+    if (this.keys && andOp) return andOp
+    if (this.orOps) return mergeOps(this.orOps)
+    return andOp ?? { type: 'all' }
+  }
+
+  private hasIdConstraint() {
+    return this.keys != null || this.hasBounds || this.orOps != null
+  }
+  private get hasBounds() {
+    return this.lower != null || this.upper != null
+  }
+
+  private andOp(): IdbFetchOp | undefined {
+    if (this.keys) {
+      if (!this.hasBounds) return { type: 'keys', keys: this.keys }
+      try {
+        const range = this.toKeyRange()
+        return {
+          type: 'keys',
+          keys: this.keys.filter((k) => range.includes(k)),
+        }
+      } catch {
+        return { type: 'keys', keys: [] }
+      }
+    }
+    if (!this.hasBounds) return undefined
+    try {
+      return { type: 'range', range: this.toKeyRange() }
+    } catch {
+      return { type: 'keys', keys: [] }
+    }
+  }
+
+  private toKeyRange() {
+    if (this.lower && this.upper)
+      return IDBKeyRange.bound(
+        this.lower.value,
+        this.upper.value,
+        this.lower.open,
+        this.upper.open,
+      )
+    if (this.lower)
+      return IDBKeyRange.lowerBound(this.lower.value, this.lower.open)
+    return IDBKeyRange.upperBound(this.upper!.value, this.upper!.open)
+  }
+
+  private isId(col: FieldMetadata) {
+    return col.key === this.idField.key
+  }
+  private toKey(col: FieldMetadata, val: any) {
+    return col.valueConverter.toJson(val)
+  }
+  private intersectKeys(vals: IDBValidKey[]) {
+    if (!this.keys) this.keys = [...vals]
+    else
+      this.keys = this.keys.filter((k) =>
+        vals.some((v) => idbKeysEqual(k, v)),
+      )
+  }
+  private addLower(value: IDBValidKey, open: boolean) {
+    if (!this.lower) this.lower = { value, open }
+    else if (value > this.lower.value) this.lower = { value, open }
+    else if (value === this.lower.value)
+      this.lower = { value, open: this.lower.open || open }
+  }
+  private addUpper(value: IDBValidKey, open: boolean) {
+    if (!this.upper) this.upper = { value, open }
+    else if (value < this.upper.value) this.upper = { value, open }
+    else if (value === this.upper.value)
+      this.upper = { value, open: this.upper.open || open }
+  }
+
+  isEqualTo(col: FieldMetadata, val: any) {
+    if (this.isId(col)) this.intersectKeys([this.toKey(col, val)])
+  }
+  isIn(col: FieldMetadata, val: any[]) {
+    if (this.isId(col)) this.intersectKeys(val.map((v) => this.toKey(col, v)))
+  }
+  isGreaterThan(col: FieldMetadata, val: any) {
+    if (this.isId(col)) this.addLower(this.toKey(col, val), true)
+  }
+  isGreaterOrEqualTo(col: FieldMetadata, val: any) {
+    if (this.isId(col)) this.addLower(this.toKey(col, val), false)
+  }
+  isLessThan(col: FieldMetadata, val: any) {
+    if (this.isId(col)) this.addUpper(this.toKey(col, val), true)
+  }
+  isLessOrEqualTo(col: FieldMetadata, val: any) {
+    if (this.isId(col)) this.addUpper(this.toKey(col, val), false)
+  }
+  or(orElements: Filter[]) {
+    const results = orElements.map((el) => {
+      const c = new IdbPrefetchCollector(this.idField)
+      el.__applyToConsumer(c)
+      return c.result()
+    })
+    if (results.some((r) => r.type === 'all')) return
+    const ops = results.flatMap((r) =>
+      r.type === 'or' ? r.parts : r.type === 'all' ? [] : [r],
+    )
+    this.orOps = this.orOps ? [...this.orOps, ...ops] : ops
+  }
+  not(filter: Filter) {
+    const c = new IdbPrefetchCollector(this.idField)
+    filter.__applyToConsumer(c)
+    if (c.cannotNarrow || c.hasIdConstraint()) this.cannotNarrow = true
+  }
+  isNull(col: FieldMetadata) {
+    if (this.isId(col)) this.cannotNarrow = true
+  }
+  isNotNull(col: FieldMetadata) {
+    if (this.isId(col)) this.cannotNarrow = true
+  }
+  isDifferentFrom(_col: FieldMetadata, _val: any) {}
+  containsCaseInsensitive(_col: FieldMetadata, _val: any) {}
+  notContainsCaseInsensitive(_col: FieldMetadata, _val: any) {}
+  startsWithCaseInsensitive(_col: FieldMetadata, _val: any) {}
+  endsWithCaseInsensitive(_col: FieldMetadata, _val: any) {}
+  custom(_key: string, _customItem: any) {
+    this.cannotNarrow = true
+  }
+  databaseCustom(_databaseCustom: any) {
+    this.cannotNarrow = true
+  }
+}
+
+function mergeOps(ops: IdbFetchOp[]): IdbPrefetch {
+  const keys: IDBValidKey[] = []
+  const ranges: IDBKeyRange[] = []
+  for (const op of ops) {
+    if (op.type === 'keys') keys.push(...op.keys)
+    else ranges.push(op.range)
+  }
+  const uniqueKeys = keys.filter(
+    (k, i) => keys.findIndex((x) => idbKeysEqual(x, k)) === i,
+  )
+  if (ranges.length === 0) return { type: 'keys', keys: uniqueKeys }
+  const parts: IdbFetchOp[] = [
+    ...(uniqueKeys.length ? [{ type: 'keys' as const, keys: uniqueKeys }] : []),
+    ...ranges.map((range) => ({ type: 'range' as const, range })),
+  ]
+  if (parts.length === 1) return parts[0]
+  return { type: 'or', parts }
 }
 
 async function keyPathOf(entity: EntityMetadata): Promise<string | string[]> {

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -1,5 +1,6 @@
 import type {
   DataProvider,
+  DroppableDataProvider,
   EntityDataProvider,
   EntityDataProviderFindOptions,
   EntityDataProviderGroupByOptions,
@@ -13,7 +14,11 @@ import type { ClassType } from '../../classType.js'
 import type { FieldMetadata } from '../column-interfaces.js'
 import type { Filter, FilterConsumer } from '../filter/filter-interfaces.js'
 import type { EntityMetadata, MembersOnly } from '../remult3/remult3.js'
-import { isAutoIncrement } from '../remult3/RepositoryImplementation.js'
+import {
+  getEntityMetadata,
+  isAutoIncrement,
+  type EntityMetadataOverloads,
+} from '../remult3/RepositoryImplementation.js'
 import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
 
 export type IndexedDbIndexDef<entityType> =
@@ -66,7 +71,7 @@ const IDB_DEK_ID = 'dek'
 const IDB_ENC = '_enc'
 const IDB_IV = '_iv'
 
-export class IndexedDbDataProvider implements DataProvider {
+export class IndexedDbDataProvider implements DroppableDataProvider {
   //@internal
   private declaredIndexes: IndexedDbIndexBuilder['entries'] = []
   //@internal
@@ -118,6 +123,30 @@ export class IndexedDbDataProvider implements DataProvider {
   close() {
     this.db?.close()
     this.db = undefined
+  }
+
+  async dropDatabase(): Promise<void> {
+    await this.enqueue(async () => {
+      this.close()
+      this.dek = undefined
+      await idbDeleteDatabase(this.dbName)
+    })
+  }
+
+  async dropTable(entity: EntityMetadataOverloads): Promise<void> {
+    await this.enqueue(async () => {
+      const name = storeNameOf(getEntityMetadata(entity))
+      const db = await this.open()
+      if (!db.objectStoreNames.contains(name)) return
+      const nextVersion = db.version + 1
+      this.forget(db)
+      db.close()
+      await this.open(nextVersion, (upgradeDb) => {
+        if (upgradeDb.objectStoreNames.contains(name)) {
+          upgradeDb.deleteObjectStore(name)
+        }
+      })
+    })
   }
 
   //@internal
@@ -960,6 +989,17 @@ function idbReq<T>(request: IDBRequest<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => reject(request.error)
+  })
+}
+
+function idbDeleteDatabase(name: string) {
+  return new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => {
+      /* wait for onsuccess after other connections close */
+    }
   })
 }
 

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -4,9 +4,11 @@ import type {
   EntityDataProviderFindOptions,
   EntityDataProviderGroupByOptions,
 } from '../data-interfaces.js'
+import type { EntityDbNamesBase } from '../filter/filter-consumer-bridge-to-sql-request.js'
 import { dbNamesOf } from '../filter/filter-consumer-bridge-to-sql-request.js'
 import type { Filter } from '../filter/filter-interfaces.js'
 import type { EntityMetadata } from '../remult3/remult3.js'
+import { isAutoIncrement } from '../remult3/RepositoryImplementation.js'
 import { ArrayEntityDataProvider } from './array-entity-data-provider.js'
 
 export class IndexedDbDataProvider implements DataProvider {
@@ -49,16 +51,12 @@ export class IndexedDbDataProvider implements DataProvider {
   //@internal
   async runWithRows<T>(
     entity: EntityMetadata,
-    mutate: boolean,
     what: (dp: ArrayEntityDataProvider) => Promise<T>,
   ): Promise<T> {
     return this.enqueue(async () => {
       await this.ensureStores([entity])
-      const storeName = storeNameOf(entity)
-      const rows = await this.getAll(storeName)
-      const result = await what(new ArrayEntityDataProvider(entity, () => rows))
-      if (mutate) await this.replaceStore(storeName, rows)
-      return result
+      const rows = await this.getAll(storeNameOf(entity))
+      return what(new ArrayEntityDataProvider(entity, () => rows))
     })
   }
 
@@ -68,6 +66,7 @@ export class IndexedDbDataProvider implements DataProvider {
       entities.map(async (entity) => ({
         name: storeNameOf(entity),
         keyPath: await keyPathOf(entity),
+        autoIncrement: isAutoIncrement(entity.idMetadata.field),
       })),
     )
     const db = await this.open()
@@ -79,9 +78,9 @@ export class IndexedDbDataProvider implements DataProvider {
     db.close()
 
     await this.open(nextVersion, (upgradeDb) => {
-      for (const { name, keyPath } of missing) {
+      for (const { name, keyPath, autoIncrement } of missing) {
         if (!upgradeDb.objectStoreNames.contains(name)) {
-          upgradeDb.createObjectStore(name, { keyPath })
+          upgradeDb.createObjectStore(name, { keyPath, autoIncrement })
         }
       }
     })
@@ -121,34 +120,40 @@ export class IndexedDbDataProvider implements DataProvider {
 
   //@internal
   private getAll(storeName: string): Promise<any[]> {
-    return this.withStore(storeName, 'readonly', (store) => store.getAll())
+    return this.withStore(storeName, 'readonly', (store) =>
+      idbReq(store.getAll()),
+    )
   }
 
   //@internal
-  private replaceStore(storeName: string, rows: any[]): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const tx = this.db!.transaction(storeName, 'readwrite')
-      tx.oncomplete = () => resolve()
-      tx.onabort = () => reject(tx.error)
-      tx.onerror = () => reject(tx.error)
-      const store = tx.objectStore(storeName)
-      store.clear()
-      for (const row of rows) store.put(row)
-    })
-  }
-
-  //@internal
-  private withStore<T>(
+  withStore<T>(
     storeName: string,
     mode: IDBTransactionMode,
-    op: (store: IDBObjectStore) => IDBRequest<T>,
+    op: (store: IDBObjectStore) => Promise<T>,
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const tx = this.db!.transaction(storeName, mode)
-      tx.onabort = () => reject(tx.error)
-      const request = op(tx.objectStore(storeName))
-      request.onerror = () => reject(request.error)
-      request.onsuccess = () => resolve(request.result)
+      let result: T
+      let opErr: unknown
+      tx.oncomplete = () => {
+        if (opErr) reject(opErr)
+        else resolve(result)
+      }
+      tx.onabort = () => reject(opErr ?? tx.error)
+      tx.onerror = () => reject(opErr ?? tx.error)
+      Promise.resolve(op(tx.objectStore(storeName))).then(
+        (r) => {
+          result = r
+        },
+        (e) => {
+          opErr = e
+          try {
+            tx.abort()
+          } catch {
+            /* already aborted */
+          }
+        },
+      )
     })
   }
 }
@@ -160,30 +165,86 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
   ) {}
 
   find(options?: EntityDataProviderFindOptions): Promise<any[]> {
-    return this.provider.runWithRows(this.entity, false, (dp) =>
-      dp.find(options),
-    )
+    return this.provider.runWithRows(this.entity, (dp) => dp.find(options))
   }
   count(where: Filter): Promise<number> {
-    return this.provider.runWithRows(this.entity, false, (dp) =>
-      dp.count(where),
-    )
+    return this.provider.runWithRows(this.entity, (dp) => dp.count(where))
   }
   groupBy(options?: EntityDataProviderGroupByOptions): Promise<any[]> {
-    return this.provider.runWithRows(this.entity, false, (dp) =>
-      dp.groupBy(options),
-    )
+    return this.provider.runWithRows(this.entity, (dp) => dp.groupBy(options))
   }
+
   insert(data: any): Promise<any> {
-    return this.provider.runWithRows(this.entity, true, (dp) => dp.insert(data))
+    return this.provider.enqueue(async () => {
+      await this.provider.ensureStores([this.entity])
+      const helper = new ArrayEntityDataProvider(this.entity, () => [])
+      const names = await helper.init()
+      const json = helper.translateToJson(data, names)
+      helper.verifyThatRowHasAllNotNullColumns(json, names)
+      const auto = isAutoIncrement(this.entity.idMetadata.field)
+      const idName = names.$dbNameOf(this.entity.idMetadata.field)
+      if (auto) delete json[idName]
+      return this.provider.withStore(
+        storeNameOf(this.entity),
+        'readwrite',
+        async (store) => {
+          try {
+            const key = await idbReq(store.add(json))
+            if (auto) json[idName] = json[idName] ?? key
+          } catch (e: any) {
+            if (e?.name === 'ConstraintError') throw Error('id already exists')
+            throw e
+          }
+          return helper.translateFromJson(json, names)
+        },
+      )
+    })
   }
+
   update(id: any, data: any): Promise<any> {
-    return this.provider.runWithRows(this.entity, true, (dp) =>
-      dp.update(id, data),
-    )
+    return this.provider.enqueue(async () => {
+      await this.provider.ensureStores([this.entity])
+      const names = await dbNamesOf(this.entity, (x) => x)
+      const key = toIdbKey(this.entity, id)
+      const storeName = storeNameOf(this.entity)
+      const existing = await this.provider.withStore(
+        storeName,
+        'readonly',
+        (store) => idbReq(store.get(key)),
+      )
+      const rows = existing != null ? [existing] : []
+      const rowHelper = new ArrayEntityDataProvider(this.entity, () => rows)
+      const result = await rowHelper.update(id, data)
+      const newRow = rows[0]
+      const newKey = keyFromRow(this.entity, names, newRow)
+      await this.provider.withStore(storeName, 'readwrite', async (store) => {
+        if (!idbKeysEqual(key, newKey)) {
+          const conflict = await idbReq(store.get(newKey))
+          if (conflict != null) throw Error('id already exists')
+          await idbReq(store.delete(key))
+        }
+        await idbReq(store.put(newRow))
+      })
+      return result
+    })
   }
+
   delete(id: any): Promise<void> {
-    return this.provider.runWithRows(this.entity, true, (dp) => dp.delete(id))
+    return this.provider.enqueue(async () => {
+      await this.provider.ensureStores([this.entity])
+      const key = toIdbKey(this.entity, id)
+      const storeName = storeNameOf(this.entity)
+      const existing = await this.provider.withStore(
+        storeName,
+        'readonly',
+        (store) => idbReq(store.get(key)),
+      )
+      const rows = existing != null ? [existing] : []
+      await new ArrayEntityDataProvider(this.entity, () => rows).delete(id)
+      await this.provider.withStore(storeName, 'readwrite', (store) =>
+        idbReq(store.delete(key)),
+      )
+    })
   }
 }
 
@@ -196,4 +257,42 @@ async function keyPathOf(entity: EntityMetadata): Promise<string | string[]> {
   const fields = entity.idMetadata.fields
   if (fields.length === 1) return names.$dbNameOf(fields[0])
   return fields.map((f) => names.$dbNameOf(f))
+}
+
+function toIdbKey(entity: EntityMetadata, id: any): IDBValidKey {
+  const fields = entity.idMetadata.fields
+  if (fields.length === 1) return fields[0].valueConverter.toJson(id)
+  const values =
+    typeof id === 'object' && id !== null
+      ? id
+      : Object.fromEntries(
+          String(id)
+            .split(',')
+            .map((part, i) => [
+              fields[i].key,
+              fields[i].valueConverter.fromJson(part),
+            ]),
+        )
+  return fields.map((f) => f.valueConverter.toJson(values[f.key]))
+}
+
+function keyFromRow(
+  entity: EntityMetadata,
+  names: EntityDbNamesBase,
+  row: any,
+): IDBValidKey {
+  const fields = entity.idMetadata.fields
+  if (fields.length === 1) return row[names.$dbNameOf(fields[0])]
+  return fields.map((f) => row[names.$dbNameOf(f)])
+}
+
+function idbKeysEqual(a: IDBValidKey, b: IDBValidKey) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function idbReq<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
 }

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -37,8 +37,27 @@ export class IndexedDbIndexBuilder {
 }
 
 export type IndexedDbDataProviderOptions = {
+  /** IDB-only indexes (not unique). PK is skipped. Compound names join db names with `_`. */
   indexes?: (x: IndexedDbIndexBuilder) => void
+  /**
+   * AES-GCM 256 on non-indexed fields (`_enc` + `_iv`). Requires `crypto.subtle`.
+   *
+   * Not full security. Stops casual disk/profile dump and other origins
+   * (non-extractable `CryptoKey` wrapped by the browser). Does **not** protect
+   * against same-origin XSS / any JS that can use the stored `CryptoKey` to decrypt.
+   *
+   * PK + `ensureIndexes` fields stay plaintext (required for IDB keyPath/indexes).
+   * Only non-indexed fields go into `_enc`.
+   *
+   * Default auto-key is origin-bound theater vs XSS. Pass `getEncryptionKey` for
+   * a stronger secret you control.
+   */
   encrypt?: boolean
+  /**
+   * Your AES-GCM `CryptoKey` (or Promise). Skips `__remult_keys`. Stronger than
+   * the default origin-bound auto-key — still not XSS-safe if same-origin JS can
+   * call this and decrypt.
+   */
   getEncryptionKey?: () => CryptoKey | Promise<CryptoKey>
 }
 

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -131,10 +131,16 @@ export class IndexedDbDataProvider implements DataProvider {
     const db = this.db
     if (!db?.objectStoreNames.contains(storeName)) return []
     const store = db.transaction(storeName).objectStore(storeName)
-    return [...store.indexNames].map((name) => ({
-      name,
-      keyPath: store.index(name).keyPath,
-    }))
+    const names = store.indexNames
+    const result: IdbIndexInfo[] = []
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i]
+      result.push({
+        name,
+        keyPath: store.index(name).keyPath,
+      })
+    }
+    return result
   }
 
   //@internal
@@ -314,28 +320,35 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
     )
   }
 
-  insert(data: any): Promise<any> {
+  insert(data: any[]): Promise<any[]> {
     return this.provider.enqueue(async () => {
       await this.provider.ensureStores([this.entity])
       const helper = new ArrayEntityDataProvider(this.entity, () => [])
       const names = await helper.init()
-      const json = helper.translateToJson(data, names)
-      helper.verifyThatRowHasAllNotNullColumns(json, names)
       const auto = isAutoIncrement(this.entity.idMetadata.field)
       const idName = names.$dbNameOf(this.entity.idMetadata.field)
-      if (auto) delete json[idName]
+      const rows = data.map((row) => {
+        const json = helper.translateToJson(row, names)
+        helper.verifyThatRowHasAllNotNullColumns(json, names)
+        if (auto) delete json[idName]
+        return json
+      })
       return this.provider.withStore(
         storeNameOf(this.entity),
         'readwrite',
         async (store) => {
-          try {
-            const key = await idbReq(store.add(json))
-            if (auto) json[idName] = json[idName] ?? key
-          } catch (e: any) {
-            if (e?.name === 'ConstraintError') throw Error('id already exists')
-            throw e
+          const result: any[] = []
+          for (const json of rows) {
+            try {
+              const key = await idbReq(store.add(json))
+              if (auto) json[idName] = json[idName] ?? key
+            } catch (e: any) {
+              if (e?.name === 'ConstraintError') throw Error('id already exists')
+              throw e
+            }
+            result.push(helper.translateFromJson(json, names))
           }
-          return helper.translateFromJson(json, names)
+          return result
         },
       )
     })
@@ -377,20 +390,23 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
     })
   }
 
-  delete(id: any): Promise<void> {
+  delete(ids: any[]): Promise<void> {
+    if (ids.length === 0) return Promise.resolve()
     return this.provider.enqueue(async () => {
       await this.provider.ensureStores([this.entity])
-      const key = toIdbKey(this.entity, id)
       return this.provider.withStore(
         storeNameOf(this.entity),
         'readwrite',
         async (store) => {
-          const existing = await idbReq(store.get(key))
-          if (existing == null)
-            throw new Error(
-              `Couldn't find row with id "${id}" in entity "${this.entity.key}" to delete`,
-            )
-          await idbReq(store.delete(key))
+          for (const id of ids) {
+            const key = toIdbKey(this.entity, id)
+            const existing = await idbReq(store.get(key))
+            if (existing == null)
+              throw new Error(
+                `Couldn't find row with id "${id}" in entity "${this.entity.key}" to delete`,
+              )
+            await idbReq(store.delete(key))
+          }
         },
       )
     })

--- a/projects/core/src/data-providers/indexed-db-data-provider.ts
+++ b/projects/core/src/data-providers/indexed-db-data-provider.ts
@@ -5,7 +5,10 @@ import type {
   EntityDataProviderGroupByOptions,
 } from '../data-interfaces.js'
 import type { EntityDbNamesBase } from '../filter/filter-consumer-bridge-to-sql-request.js'
-import { dbNamesOf } from '../filter/filter-consumer-bridge-to-sql-request.js'
+import {
+  dbNamesOf,
+  isDbReadonly,
+} from '../filter/filter-consumer-bridge-to-sql-request.js'
 import type { Filter } from '../filter/filter-interfaces.js'
 import type { EntityMetadata } from '../remult3/remult3.js'
 import { isAutoIncrement } from '../remult3/RepositoryImplementation.js'
@@ -204,28 +207,36 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
   update(id: any, data: any): Promise<any> {
     return this.provider.enqueue(async () => {
       await this.provider.ensureStores([this.entity])
-      const names = await dbNamesOf(this.entity, (x) => x)
+      const helper = new ArrayEntityDataProvider(this.entity, () => [])
+      const names = await helper.init()
       const key = toIdbKey(this.entity, id)
-      const storeName = storeNameOf(this.entity)
-      const existing = await this.provider.withStore(
-        storeName,
-        'readonly',
-        (store) => idbReq(store.get(key)),
+      return this.provider.withStore(
+        storeNameOf(this.entity),
+        'readwrite',
+        async (store) => {
+          const existing = await idbReq(store.get(key))
+          if (existing == null)
+            throw new Error(
+              `Couldn't find row with id "${id}" in entity "${this.entity.key}" to update`,
+            )
+          const json = { ...existing }
+          const keys = Object.keys(data)
+          for (const f of this.entity.fields) {
+            if (!isDbReadonly(f, names) && keys.includes(f.key)) {
+              json[names.$dbNameOf(f)] = f.valueConverter.toJson(data[f.key])
+            }
+          }
+          helper.verifyThatRowHasAllNotNullColumns(json, names)
+          const newKey = keyFromRow(this.entity, names, json)
+          if (!idbKeysEqual(key, newKey)) {
+            const conflict = await idbReq(store.get(newKey))
+            if (conflict != null) throw Error('id already exists')
+            await idbReq(store.delete(key))
+          }
+          await idbReq(store.put(json))
+          return helper.translateFromJson(json, names)
+        },
       )
-      const rows = existing != null ? [existing] : []
-      const rowHelper = new ArrayEntityDataProvider(this.entity, () => rows)
-      const result = await rowHelper.update(id, data)
-      const newRow = rows[0]
-      const newKey = keyFromRow(this.entity, names, newRow)
-      await this.provider.withStore(storeName, 'readwrite', async (store) => {
-        if (!idbKeysEqual(key, newKey)) {
-          const conflict = await idbReq(store.get(newKey))
-          if (conflict != null) throw Error('id already exists')
-          await idbReq(store.delete(key))
-        }
-        await idbReq(store.put(newRow))
-      })
-      return result
     })
   }
 
@@ -233,16 +244,17 @@ class IndexedDbEntityDataProvider implements EntityDataProvider {
     return this.provider.enqueue(async () => {
       await this.provider.ensureStores([this.entity])
       const key = toIdbKey(this.entity, id)
-      const storeName = storeNameOf(this.entity)
-      const existing = await this.provider.withStore(
-        storeName,
-        'readonly',
-        (store) => idbReq(store.get(key)),
-      )
-      const rows = existing != null ? [existing] : []
-      await new ArrayEntityDataProvider(this.entity, () => rows).delete(id)
-      await this.provider.withStore(storeName, 'readwrite', (store) =>
-        idbReq(store.delete(key)),
+      return this.provider.withStore(
+        storeNameOf(this.entity),
+        'readwrite',
+        async (store) => {
+          const existing = await idbReq(store.get(key))
+          if (existing == null)
+            throw new Error(
+              `Couldn't find row with id "${id}" in entity "${this.entity.key}" to delete`,
+            )
+          await idbReq(store.delete(key))
+        },
       )
     })
   }

--- a/projects/core/src/data-providers/json-data-provider.ts
+++ b/projects/core/src/data-providers/json-data-provider.ts
@@ -82,17 +82,17 @@ class JsonEntityDataProvider implements EntityDataProvider {
       ),
     ))
   }
-  delete(id: any): Promise<void> {
+  delete(ids: any[]): Promise<void> {
     return (this.p = this.p.then(() =>
       this.loadEntityData((dp, save) =>
-        dp.delete(id).then(async (x) => {
+        dp.delete(ids).then(async (x) => {
           await save()
           return x
         }),
       ),
     ))
   }
-  async insert(data: any): Promise<any> {
+  async insert(data: any[]): Promise<any[]> {
     return (this.p = this.p.then(() =>
       this.loadEntityData((dp, save) =>
         dp.insert(data).then(async (x) => {

--- a/projects/core/src/data-providers/rest-data-provider.ts
+++ b/projects/core/src/data-providers/rest-data-provider.ts
@@ -353,32 +353,32 @@ export class RestEntityDataProvider
     return result
   }
 
-  async delete(id: any): Promise<void> {
-    if (id == '')
-      await this.deleteMany(
-        Filter.fromEntityFilter(
-          this.entity,
-          this.entity.idMetadata.getIdFilter(id),
-        ),
+  async delete(ids: any[]): Promise<void> {
+    if (ids.length === 0) return
+    if (ids.length === 1 && ids[0] !== '')
+      return this.http().delete(
+        this.url() + '/' + encodeURIComponent(ids[0]),
       )
-    else return this.http().delete(this.url() + '/' + encodeURIComponent(id))
+    await this.deleteMany(
+      Filter.fromEntityFilter(
+        this.entity,
+        this.entity.idMetadata.getIdFilter(...ids),
+      ),
+    )
   }
 
-  public insert(data: any, options?: InsertOrUpdateOptions): Promise<any> {
+  public insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]> {
     return this.http()
       .post(
         this.url() + (options?.select === 'none' ? '?_select=$none' : ''),
-        this.translateToJson(data),
+        data.map((row) => this.translateToJson(row)),
       )
-      .then((y) => this.translateFromJson(y))
-  }
-  insertMany(data: any[], options?: InsertOrUpdateOptions): Promise<any[]> {
-    return this.http()
-      .post(
-        this.url() + (options?.select === 'none' ? '?_select=$none' : ''),
-        data.map((data) => this.translateToJson(data)),
-      )
-      .then((y) => y.map((y: any) => this.translateFromJson(y)))
+      .then((y) => {
+        const rows = Array.isArray(y) ? y : [y]
+        return rows.map((row: any) =>
+          row ? this.translateFromJson(row) : undefined,
+        )
+      })
   }
 }
 

--- a/projects/core/src/data-providers/sql-database.ts
+++ b/projects/core/src/data-providers/sql-database.ts
@@ -182,6 +182,9 @@ export class SqlDatabase
             doesNotSupportReturningSyntaxOnlyForUpdate:
               this.sql.doesNotSupportReturningSyntaxOnlyForUpdate,
             orderByNullsFirst: this.sql.orderByNullsFirst,
+            afterMutation: this.sql.afterMutation,
+            maxParametersInOneSqlStatement:
+              this.sql.maxParametersInOneSqlStatement,
           }),
         )
       } finally {
@@ -272,6 +275,43 @@ export class SqlDatabase
   private createdEntities: string[] = []
 
   end!: () => Promise<void>
+}
+
+const defaultMaxParametersInOneSqlStatement = 2000
+
+function splitByMaxParameters<T>(
+  items: T[],
+  parametersInItem: (item: T) => number,
+  maxParameters: number,
+): T[][] {
+  const batches: T[][] = []
+  let batch: T[] = []
+  let params = 0
+  for (const item of items) {
+    const n = parametersInItem(item)
+    if (batch.length > 0 && params + n > maxParameters) {
+      batches.push(batch)
+      batch = []
+      params = 0
+    }
+    batch.push(item)
+    params += n
+  }
+  if (batch.length) batches.push(batch)
+  return batches
+}
+
+function countInsertBindParameters(
+  entity: EntityMetadata,
+  e: EntityDbNamesBase,
+  row: any,
+): number {
+  let n = 0
+  for (const x of entity.fields) {
+    if (isDbReadonly(x, e)) continue
+    if (x.valueConverter.toDb(row[x.key]) != undefined) n++
+  }
+  return n
 }
 
 const icons = new Map<string, string>([
@@ -553,13 +593,14 @@ class ActualSQLEntityDataProvider implements EntityDataProvider {
     })
   }
 
-  async delete(id: any): Promise<void> {
+  async delete(ids: any[]): Promise<void> {
+    if (ids.length === 0) return
     let e = await this.init()
     let r = this.sql.createCommand()
     let f = new FilterConsumerBridgeToSqlRequest(r, e)
     Filter.fromEntityFilter(
       this.entity,
-      this.entity.idMetadata.getIdFilter(id),
+      this.entity.idMetadata.getIdFilter(...ids),
     ).__applyToConsumer(f)
     let statement = 'delete from ' + e.$entityName
     statement += await f.resolveWhere()
@@ -567,62 +608,108 @@ class ActualSQLEntityDataProvider implements EntityDataProvider {
       this.sql._getSourceSql().afterMutation?.()
     })
   }
-  async insert(data: any, options?: InsertOrUpdateOptions): Promise<any> {
+  async insert(data: any[], options?: InsertOrUpdateOptions): Promise<any[]> {
+    if (data.length === 0) return []
     let e = await this.init()
+    const maxParams =
+      this.strategy.maxParametersInOneSqlStatement ??
+      defaultMaxParametersInOneSqlStatement
+    const batches = splitByMaxParameters(
+      data,
+      (row) => countInsertBindParameters(this.entity, e, row),
+      maxParams,
+    )
+    const result: any[] = []
+    for (const batch of batches)
+      result.push(...(await this.insertBatch(batch, e, options)))
+    return result
+  }
+  //@internal
+  async insertOne(data: any, options?: InsertOrUpdateOptions): Promise<any> {
+    return (await this.insert([data], options))[0]
+  }
 
+  private async insertBatch(
+    batch: any[],
+    e: EntityDbNamesBase,
+    options?: InsertOrUpdateOptions,
+  ): Promise<any[]> {
     let r = this.sql.createCommand()
-    let cols = ''
-    let vals = ''
-    let added = false
-
+    const cols: FieldMetadata[] = []
     for (const x of this.entity.fields) {
-      if (isDbReadonly(x, e)) {
-      } else {
-        let v = x.valueConverter.toDb(data[x.key])
-        if (v != undefined) {
-          if (!added) added = true
-          else {
-            cols += ', '
-            vals += ', '
-          }
-
-          cols += e.$dbNameOf(x)
-          vals += toDbSql(r, x, v)
-        }
-      }
+      if (isDbReadonly(x, e)) continue
+      if (batch.some((row) => x.valueConverter.toDb(row[x.key]) != undefined))
+        cols.push(x)
     }
 
-    let statement = `insert into ${e.$entityName} (${cols}) values (${vals})`
-
-    let { colKeys, select } = await this.buildSelect(e, r, undefined, undefined)
-    if (
-      !this.sql._getSourceSql().doesNotSupportReturningSyntax &&
-      !(options?.select === 'none')
-    )
-      statement += ' returning ' + select
-    return await r.execute(statement).then((sql) => {
-      this.sql._getSourceSql().afterMutation?.()
-      if (this.sql._getSourceSql().doesNotSupportReturningSyntax) {
-        if (isAutoIncrement(this.entity.idMetadata.field)) {
-          const id = sql.rows[0] as Number
-          if (typeof id !== 'number')
-            throw new Error(
-              'Auto increment, for a database that is does not support returning syntax, should return an array with the single last added id. Instead it returned: ' +
-                JSON.stringify(id),
-            )
-          if (options?.select === 'none') return undefined!
-          return this.find({
-            where: new Filter((x) =>
-              x.isEqualTo(this.entity.idMetadata.field, id),
-            ),
-          }).then((r) => r[0])
-        } else {
-          if (options?.select === 'none') return undefined!
-          return getRowAfterUpdate(this.entity, this, data, undefined, 'insert')
-        }
+    let colSql = ''
+    let vals = ''
+    for (let i = 0; i < cols.length; i++) {
+      if (i) colSql += ', '
+      colSql += e.$dbNameOf(cols[i])
+    }
+    for (let i = 0; i < batch.length; i++) {
+      if (i) vals += ','
+      vals += '('
+      for (let j = 0; j < cols.length; j++) {
+        if (j) vals += ', '
+        const x = cols[j]
+        const v = x.valueConverter.toDb(batch[i][x.key])
+        if (v != undefined) vals += toDbSql(r, x, v)
+        else if (x.allowNull) vals += 'null'
+        else vals += 'DEFAULT'
       }
-      if (options?.select === 'none') return undefined!
-      return this.buildResultRow(colKeys, sql.rows[0], sql)
+      vals += ')'
+    }
+
+    let statement = `insert into ${e.$entityName} (${colSql}) values ${vals}`
+    let { colKeys, select } = await this.buildSelect(e, r, undefined, undefined)
+    const source = this.sql._getSourceSql()
+    const wantRows = options?.select !== 'none'
+    if (!source.doesNotSupportReturningSyntax && wantRows)
+      statement += ' returning ' + select
+
+    const sql = await r.execute(statement)
+    source.afterMutation?.()
+    if (!wantRows) return batch.map(() => undefined!)
+
+    if (source.doesNotSupportReturningSyntax) {
+      if (isAutoIncrement(this.entity.idMetadata.field)) {
+        const lastId = sql.rows[0] as number
+        if (typeof lastId !== 'number')
+          throw new Error(
+            'Auto increment, for a database that is does not support returning syntax, should return an array with the single last added id. Instead it returned: ' +
+              JSON.stringify(lastId),
+          )
+        const ids: number[] = []
+        for (let id = lastId - batch.length + 1; id <= lastId; id++)
+          ids.push(id)
+        return this.loadRowsByIds(ids)
+      }
+      return this.loadRowsByIds(
+        batch.map((row) => this.entity.idMetadata.getId(row)),
+      )
+    }
+    return sql.rows.map((row) => this.buildResultRow(colKeys, row, sql))
+  }
+
+  private async loadRowsByIds(ids: any[]): Promise<any[]> {
+    const found = await this.find({
+      where: Filter.fromEntityFilter(
+        this.entity,
+        this.entity.idMetadata.getIdFilter(...ids),
+      ),
+    })
+    const byId = new Map(
+      found.map((row) => [this.entity.idMetadata.getId(row) + '', row]),
+    )
+    return ids.map((id) => {
+      const row = byId.get(id + '')
+      if (!row)
+        throw new Error(
+          `Failed to insert row - result contained ${found.length} rows`,
+        )
+      return row
     })
   }
 }

--- a/projects/core/src/remult3/RepositoryImplementation.ts
+++ b/projects/core/src/remult3/RepositoryImplementation.ts
@@ -487,7 +487,7 @@ export class RepositoryImplementation<entityType>
     if (ref) return ref.delete()
 
     if (typeof item === 'string' || typeof item === 'number')
-      if (this._dataProvider.isProxy) return this._edp.delete(item)
+      if (this._dataProvider.isProxy) return this._edp.delete([item])
       else {
         let ref2 = await this.findId(item)
         if (!ref2) throw this._notFoundError(item)
@@ -542,44 +542,30 @@ export class RepositoryImplementation<entityType>
     options?: InsertOrUpdateOptions,
   ): Promise<entityType | entityType[]> {
     if (Array.isArray(entity)) {
-      if (this._dataProvider.isProxy) {
-        let refs: rowHelperImplementation<entityType>[] = []
-        let raw: any[] = []
-        for (const item of entity) {
-          this.__cleanupPartialObject(item)
-          let ref = getEntityRef(
-            entity,
-            false,
-          ) as unknown as rowHelperImplementation<entityType>
-          if (ref) {
-            if (!ref.isNew()) throw 'Item is not new'
-          } else {
-            ref = (await this.getEntityRef(
-              this.create(item),
-            )) as rowHelperImplementation<entityType>
-          }
-          refs.push(ref)
-          raw.push(
-            await (
-              ref as rowHelperImplementation<entityType>
-            ).buildDtoForInsert(),
-          )
+      let refs: rowHelperImplementation<entityType>[] = []
+      let raw: any[] = []
+      for (const item of entity) {
+        this.__cleanupPartialObject(item)
+        let ref = getEntityRef(
+          item,
+          false,
+        ) as unknown as rowHelperImplementation<entityType>
+        if (ref) {
+          if (!ref.isNew()) throw 'Item is not new'
+        } else {
+          ref = this.getEntityRef(
+            this.create(item),
+          ) as rowHelperImplementation<entityType>
         }
-        const inserted = await (
-          this._edp as any as ProxyEntityDataProvider
-        ).insertMany(raw, options)
-        if (options?.select === 'none') return undefined!
-        return promiseAll(inserted, (item, i) =>
-          refs[i].processInsertResponseDto(item),
-        )
-      } else {
-        let r: entityType[] = []
-        for (const item of entity) {
-          r.push(await this.insert(item, options))
-        }
-        if (options?.select === 'none') return undefined!
-        return r
+        refs.push(ref)
+        raw.push(await ref.buildDtoForInsert())
       }
+      const inserted = await this._edp.insert(raw, options)
+      const result = await promiseAll(inserted, (row, i) =>
+        refs[i].processInsertResponseDto(row),
+      )
+      if (options?.select === 'none') return undefined!
+      return result
     } else {
       let ref = getEntityRef(entity, false) as unknown as EntityRef<entityType>
       let result = undefined
@@ -1278,13 +1264,20 @@ export class RepositoryImplementation<entityType>
         where === 'all' ? 'all' : await this._translateWhereToFilter(where),
       )
     } else {
-      let deleted = 0
       if (where === 'all') where = undefined!
+      const prepared: {
+        ref: rowHelperImplementation<entityType>
+        event: LifecycleEvent<entityType>
+        doDelete: boolean
+      }[] = []
       for await (const item of this.query({ where, aggregate: undefined! })) {
-        await getEntityRef(item).delete()
-        deleted++
+        const ref = getEntityRef(item) as rowHelperImplementation<entityType>
+        prepared.push({ ref, ...(await ref.__prepareDelete()) })
       }
-      return deleted
+      const ids = prepared.filter((x) => x.doDelete).map((x) => x.ref.id)
+      if (ids.length) await this._edp.delete(ids)
+      for (const x of prepared) await x.ref.__finishDelete(x.event)
+      return prepared.length
     }
   }
 
@@ -2042,7 +2035,7 @@ export class rowHelperImplementation<T>
             updatedRow = (updatedRow = await this.edp.find({
               where: await this.getIdFilter(),
             }))[0]
-          } else updatedRow = await this.edp.insert(d, options)
+          } else updatedRow = (await this.edp.insert([d], options))[0]
         } else {
           let changesOnly: any = {}
           let wasChanged = false
@@ -2099,13 +2092,41 @@ export class rowHelperImplementation<T>
     }
   }
   async processInsertResponseDto(updatedRow: any): Promise<T> {
-    await this.loadDataFrom(updatedRow)
-    this.saveOriginalData()
-    this._isNew = false
-    return this.instance
+    try {
+      if (updatedRow) await this.loadDataFrom(updatedRow)
+      const e = this.buildLifeCycleEvent()
+      e.id = this.getId()
+      if (!this.repo._dataProvider.isProxy) {
+        if (this.info.entityInfo.saved)
+          await this.info.entityInfo.saved(this.instance, e)
+        if (this.repo.listeners)
+          for (const listener of this.repo.listeners) {
+            await listener.saved?.(this.instance, true)
+          }
+      }
+      this.repo._remult.liveQueryPublisher.itemChanged(
+        this.repo.metadata.key,
+        [{ id: this.getId(), oldId: this.getOriginalId(), deleted: false }],
+      )
+      this.saveOriginalData()
+      this._isNew = false
+      return this.instance
+    } catch (err) {
+      throw await this.catchSaveErrors(err)
+    }
   }
   async buildDtoForInsert(): Promise<any> {
     await this.__validateEntity()
+    const e = this.buildLifeCycleEvent()
+    if (!this.repo._dataProvider.isProxy) {
+      for (const col of this.fields) {
+        if (col.metadata.options.saving)
+          await col.metadata.options.saving(this.instance, col, e as any)
+      }
+      if (this.info.entityInfo.saving) {
+        await this.info.entityInfo.saving(this.instance, e)
+      }
+    }
     this.__assertValidity()
 
     let d = this.copyDataToObject(this.isNew())
@@ -2140,37 +2161,44 @@ export class rowHelperImplementation<T>
   }
 
   async delete() {
-    this.__clearErrorsAndReportChanged()
-    let doDelete = true
-    let e = this.buildLifeCycleEvent(() => (doDelete = false))
-    if (!this.repo._dataProvider.isProxy) {
-      if (this.info.entityInfo.deleting)
-        await this.info.entityInfo.deleting(this.instance, e)
-    }
-    this.__assertValidity()
     try {
-      if (doDelete) {
-        if (this.id === undefined)
-          throw new Error('Invalid operation, id is undefined')
-        await this.edp.delete(this.id)
-      }
-      if (!this.repo._dataProvider.isProxy) {
-        if (this.info.entityInfo.deleted)
-          await this.info.entityInfo.deleted(this.instance, e)
-      }
-
-      if (this.repo.listeners)
-        for (const listener of this.repo.listeners) {
-          await listener.deleted?.(this.instance)
-        }
-      this.repo._remult.liveQueryPublisher.itemChanged(this.repo.metadata.key, [
-        { id: this.getId(), oldId: this.getOriginalId(), deleted: true },
-      ])
-
-      this._wasDeleted = true
+      const { doDelete, event } = await this.__prepareDelete()
+      if (doDelete) await this.edp.delete([this.id])
+      await this.__finishDelete(event)
     } catch (err) {
       throw await this.catchSaveErrors(err)
     }
+  }
+  //@internal
+  async __prepareDelete() {
+    this.__clearErrorsAndReportChanged()
+    let doDelete = true
+    const event = this.buildLifeCycleEvent(() => (doDelete = false))
+    if (!this.repo._dataProvider.isProxy) {
+      if (this.info.entityInfo.deleting)
+        await this.info.entityInfo.deleting(this.instance, event)
+    }
+    this.__assertValidity()
+    if (doDelete && this.id === undefined)
+      throw new Error('Invalid operation, id is undefined')
+    return { doDelete, event }
+  }
+  //@internal
+  async __finishDelete(e: LifecycleEvent<T>) {
+    if (!this.repo._dataProvider.isProxy) {
+      if (this.info.entityInfo.deleted)
+        await this.info.entityInfo.deleted(this.instance, e)
+    }
+
+    if (this.repo.listeners)
+      for (const listener of this.repo.listeners) {
+        await listener.deleted?.(this.instance)
+      }
+    this.repo._remult.liveQueryPublisher.itemChanged(this.repo.metadata.key, [
+      { id: this.getId(), oldId: this.getOriginalId(), deleted: true },
+    ])
+
+    this._wasDeleted = true
   }
 
   async loadDataFrom(data: any, loadItems?: FieldMetadata[]) {

--- a/projects/core/src/remult3/RepositoryImplementation.ts
+++ b/projects/core/src/remult3/RepositoryImplementation.ts
@@ -542,6 +542,12 @@ export class RepositoryImplementation<entityType>
     options?: InsertOrUpdateOptions,
   ): Promise<entityType | entityType[]> {
     if (Array.isArray(entity)) {
+      if (!options?.bulk) {
+        const r = []
+        for (const item of entity) r.push(await this.insert(item, options))
+        if (options?.select === 'none') return undefined!
+        return r
+      }
       let refs: rowHelperImplementation<entityType>[] = []
       let raw: any[] = []
       for (const item of entity) {

--- a/projects/core/src/remult3/RepositoryImplementation.ts
+++ b/projects/core/src/remult3/RepositoryImplementation.ts
@@ -3273,7 +3273,7 @@ class cacheEntityInfo<entityType> {
   value?: entityType = {} as entityType
   promise?: Promise<entityType | undefined>
 }
-export function getEntityMetadata<entityType>(
+export function getEntityMetadata<entityType = unknown>(
   entity: EntityMetadataOverloads<entityType>,
 ): EntityMetadata<entityType> {
   if ((entity as Repository<entityType>).metadata)
@@ -3293,7 +3293,7 @@ export function getRepository<entityType>(
   }
   return entity as Repository<entityType>
 }
-export type EntityMetadataOverloads<entityType> =
+export type EntityMetadataOverloads<entityType = unknown> =
   | Repository<entityType>
   | EntityMetadata<entityType>
   | ClassType<entityType>

--- a/projects/core/src/remult3/RepositoryImplementation.ts
+++ b/projects/core/src/remult3/RepositoryImplementation.ts
@@ -599,7 +599,7 @@ export class RepositoryImplementation<entityType>
   }
   async validate(
     entity: Partial<MembersOnly<entityType>>,
-    ...fields: Extract<keyof MembersOnly<entityType>, string>[]
+    ...fields: (keyof MembersOnly<entityType>)[]
   ): Promise<ErrorInfo<entityType> | undefined> {
     {
       let ref: rowHelperImplementation<any> = getEntityRef(entity, false) as any

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -311,7 +311,9 @@ export interface EntityMetadata<entityType = unknown> {
 export declare type MembersOnly<T> = {
   [K in keyof Omit<T, keyof EntityBase> as T[K] extends Function
     ? never
-    : K]: T[K]
+    : K extends string
+      ? K
+      : never]: T[K]
 }
 //Pick<
 //   T,
@@ -740,7 +742,7 @@ export interface Repository<entityType> {
    */
   validate(
     item: Partial<entityType>,
-    ...fields: Extract<keyof MembersOnly<entityType>, string>[]
+    ...fields: (keyof MembersOnly<entityType>)[]
   ): Promise<ErrorInfo<entityType> | undefined>
   /** saves an item or item[] to the data source. It assumes that if an `id` value exists, it's an existing row - otherwise it's a new row
    * @example

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -758,11 +758,14 @@ export interface Repository<entityType> {
     options?: InsertOrUpdateOptions,
   ): Promise<entityType>
 
-  /**Insert an item or item[] to the data source
+  /**Insert an item or item[] to the data source.
+   * Arrays insert one-by-one by default. Pass `{ bulk: true }` for one provider statement/txn.
    * @example
    * await taskRepo.insert({title:"task a"})
    * @example
    * await taskRepo.insert([{title:"task a"}, {title:"task b", completed:true }])
+   * @example
+   * await taskRepo.insert([{title:"a"}, {title:"b"}], { bulk: true })
    */
   insert(
     item: Partial<MembersOnly<entityType>>[],
@@ -1515,7 +1518,19 @@ export declare type EntityIdFields<entityType> = {
 export declare type EntitySelectFields<entityType> = {
   [Properties in keyof Partial<MembersOnly<entityType>>]?: boolean
 }
-export declare type InsertOrUpdateOptions = { select: 'none' }
+export declare type InsertOrUpdateOptions = {
+  select?: 'none'
+  /**
+   * One provider statement/txn (SQL multi-row `INSERT`, IDB one txn).
+   *
+   * Default / omitted (`false`): `insert([a,b,c])` inserts one-by-one so
+   * `saving` and `Validators.unique` see prior rows in the same call.
+   *
+   * When `true`: all `saving` hooks run before any write; `Validators.unique`
+   * / `count()` only see the DB, not siblings in the same array.
+   */
+  bulk?: boolean
+}
 
 export interface ClassFieldDecoratorContextStub<entityType, valueType> {
   readonly access: {

--- a/projects/core/src/sql-command.ts
+++ b/projects/core/src/sql-command.ts
@@ -11,6 +11,8 @@ export interface SqlImplementation extends HasWrapIdentifier {
   doesNotSupportReturningSyntax?: boolean
   doesNotSupportReturningSyntaxOnlyForUpdate?: boolean
   orderByNullsFirst?: boolean
+  /** Bound-variable cap per statement. Default 2000 (SQL Server is 2100). */
+  maxParametersInOneSqlStatement?: number
   end(): Promise<void>
 
   afterMutation?: VoidFunction

--- a/projects/core/src/standard-schema/index.ts
+++ b/projects/core/src/standard-schema/index.ts
@@ -29,7 +29,7 @@ interface RemultEntitySchema<entityType, fields extends string[] = []>
  */
 export function standardSchema<
   entityType,
-  fieldsType extends Extract<keyof MembersOnly<entityType>, string>[] = [],
+  fieldsType extends (keyof MembersOnly<entityType>)[] = [],
 >(
   repo: Repository<entityType>,
   ...fields: fieldsType

--- a/projects/test-servers/nuxt-server/nuxt.config.ts
+++ b/projects/test-servers/nuxt-server/nuxt.config.ts
@@ -3,6 +3,9 @@ export default defineNuxtConfig({
   build: {},
   nitro: {
     preset: 'node',
+    // vue <-> @vue/server-renderer peer cycle creates nested symlinks
+    // in .output; CI then dies with ELOOP on scandir.
+    noExternals: true,
     esbuild: {
       options: {
         tsconfigRaw: {

--- a/projects/test-servers/nuxt-server/nuxt.config.ts
+++ b/projects/test-servers/nuxt-server/nuxt.config.ts
@@ -3,9 +3,23 @@ export default defineNuxtConfig({
   build: {},
   nitro: {
     preset: 'node',
-    // vue <-> @vue/server-renderer peer cycle creates nested symlinks
-    // in .output; CI then dies with ELOOP on scandir.
-    noExternals: true,
+    // Inline vue so Nitro does not trace vue <-> @vue/server-renderer
+    // into circular .output symlinks (ELOOP on CI scandir).
+    // Keep remult external: noExternals pulls get-remult-admin-html.js
+    // into Rollup, which cannot parse the inlined admin bundle.
+    externals: {
+      inline: [
+        'vue',
+        '@vue/server-renderer',
+        '@vue/compiler-core',
+        '@vue/compiler-dom',
+        '@vue/runtime-core',
+        '@vue/runtime-dom',
+        '@vue/shared',
+        '@vue/reactivity',
+      ],
+      external: ['remult'],
+    },
     esbuild: {
       options: {
         tsconfigRaw: {

--- a/projects/tests/browser-setup.ts
+++ b/projects/tests/browser-setup.ts
@@ -1,0 +1,10 @@
+const g = globalThis as typeof globalThis & {
+  process?: { env?: Record<string, string | undefined> }
+}
+g.process = {
+  ...g.process,
+  env: {
+    ...g.process?.env,
+    IGNORE_GLOBAL_REMULT_IN_TESTS: 'true',
+  },
+}

--- a/projects/tests/dbs/inMemory.spec.ts
+++ b/projects/tests/dbs/inMemory.spec.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import type { DataProvider } from '../../core'
 import {
   Entity,
   Fields,
@@ -9,6 +8,7 @@ import {
   describeEntity,
 } from '../../core'
 import { allDbTests } from './shared-tests'
+import { droppableDataProviderTests } from './shared-tests/droppable'
 
 describe('In Memory Tests', () => {
   var db: InMemoryDataProvider
@@ -32,6 +32,10 @@ describe('In Memory Tests', () => {
       excludeTransactions: true,
       excludeLiveQuery: true,
     },
+  )
+  droppableDataProviderTests(
+    () => db,
+    () => remult,
   )
   it("test doesn't store server expressions and db readonly", async () => {
     const c = class {

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { Entity, Fields, IndexedDbDataProvider, Remult } from '../../core'
+import {
+  Entity,
+  Fields,
+  Filter,
+  IndexedDbDataProvider,
+  Remult,
+} from '../../core'
 import { allDbTests } from './shared-tests'
 
 async function deleteIndexedDb(name: string) {
@@ -115,6 +121,121 @@ describe('IndexedDB Data Provider', () => {
     expect(await idbGet(db.db!, 'items', 1)).toMatchObject({
       id: 1,
       title: 'aa',
+    })
+  })
+
+  describe('fetch by id filter', () => {
+    @Entity('fetch_items')
+    class Item {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      title = ''
+    }
+
+    async function seed() {
+      const repo = remult.repo(Item)
+      await repo.insert([
+        { id: 1, title: 'a' },
+        { id: 2, title: 'b' },
+        { id: 3, title: 'c' },
+      ])
+      return repo
+    }
+
+    /** extra `title: 'nope'` would empty find() — raw rows show if we over-fetched */
+    async function raw(where: { id?: any; $or?: any }) {
+      const repo = remult.repo(Item)
+      return db.fetchRows(
+        repo.metadata,
+        Filter.fromEntityFilter(repo.metadata, { title: 'nope', ...where }),
+      )
+    }
+
+    function ids(rows: any[]) {
+      return rows.map((r) => r.id)
+    }
+
+    it('eq', async () => {
+      await seed()
+      expect(ids(await raw({ id: 1 }))).toEqual([1])
+      expect(db.lastFetch).toMatchObject({ type: 'keys', keys: [1] })
+    })
+
+    it('in', async () => {
+      await seed()
+      expect(ids(await raw({ id: [1, 3] }))).toEqual([1, 3])
+      expect(db.lastFetch).toMatchObject({ type: 'keys', keys: [1, 3] })
+    })
+
+    it('or of eq', async () => {
+      await seed()
+      expect(ids(await raw({ $or: [{ id: 1 }, { id: 2 }] }))).toEqual([1, 2])
+      expect(db.lastFetch).toMatchObject({ type: 'keys', keys: [1, 2] })
+    })
+
+    it('gt', async () => {
+      await seed()
+      expect(ids(await raw({ id: { $gt: 1 } }))).toEqual([2, 3])
+      expect(db.lastFetch).toMatchObject({ type: 'range' })
+      const range = db.lastFetch as { type: 'range'; range: IDBKeyRange }
+      expect(range.range.lower).toBe(1)
+      expect(range.range.lowerOpen).toBe(true)
+    })
+
+    it('lt', async () => {
+      await seed()
+      expect(ids(await raw({ id: { $lt: 3 } }))).toEqual([1, 2])
+      const range = db.lastFetch as { type: 'range'; range: IDBKeyRange }
+      expect(range.range.upper).toBe(3)
+      expect(range.range.upperOpen).toBe(true)
+    })
+
+    it('gte + lte', async () => {
+      await seed()
+      expect(ids(await raw({ id: { $gte: 2, $lte: 3 } }))).toEqual([2, 3])
+      const range = db.lastFetch as { type: 'range'; range: IDBKeyRange }
+      expect(range.range.lower).toBe(2)
+      expect(range.range.lowerOpen).toBe(false)
+      expect(range.range.upper).toBe(3)
+      expect(range.range.upperOpen).toBe(false)
+    })
+
+    it('ne is a full scan (over-fetch visible)', async () => {
+      await seed()
+      expect(ids(await raw({ id: { $ne: 1 } }))).toEqual([1, 2, 3])
+      expect(db.lastFetch).toEqual({ type: 'all' })
+    })
+
+    it('no id is a full scan (over-fetch visible)', async () => {
+      await seed()
+      expect(ids(await raw({}))).toEqual([1, 2, 3])
+      expect(db.lastFetch).toEqual({ type: 'all' })
+    })
+
+    it('or of ranges fetches each and merges', async () => {
+      await seed()
+      expect(
+        ids(await raw({ $or: [{ id: { $gt: 2 } }, { id: { $lt: 2 } }] })).sort(),
+      ).toEqual([1, 3])
+      expect(db.lastFetch?.type).toBe('or')
+      expect((db.lastFetch as { parts: unknown[] }).parts).toHaveLength(2)
+    })
+
+    it('or of eq and range', async () => {
+      await seed()
+      expect(
+        ids(await raw({ $or: [{ id: 1 }, { id: { $gt: 2 } }] })).sort(),
+      ).toEqual([1, 3])
+      expect(db.lastFetch?.type).toBe('or')
+    })
+
+    it('or with a branch that is not id-narrowed is a full scan', async () => {
+      await seed()
+      expect(
+        ids(await raw({ $or: [{ id: { $gt: 2 } }, { title: 'a' }] })),
+      ).toEqual([1, 2, 3])
+      expect(db.lastFetch).toEqual({ type: 'all' })
     })
   })
 

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -90,8 +90,9 @@ describe('IndexedDB Data Provider', () => {
       @Fields.string()
       title = ''
     }
-    await remult.repo(Item).insert({ id: 1, title: 'a' })
-    await remult.repo(Item).insert({ id: 2, title: 'b' })
+    const repo = remult.repo(Item)
+    await repo.insert({ id: 1, title: 'a' })
+    await repo.insert({ id: 2, title: 'b' })
     expect(await idbGet(db.db!, 'items', 1)).toMatchObject({
       id: 1,
       title: 'a',
@@ -99,6 +100,21 @@ describe('IndexedDB Data Provider', () => {
     expect(await idbGet(db.db!, 'items', 2)).toMatchObject({
       id: 2,
       title: 'b',
+    })
+    await repo.update(1, { title: 'aa' })
+    expect(await idbGet(db.db!, 'items', 1)).toMatchObject({
+      id: 1,
+      title: 'aa',
+    })
+    expect(await idbGet(db.db!, 'items', 2)).toMatchObject({
+      id: 2,
+      title: 'b',
+    })
+    await repo.delete(2)
+    expect(await idbGet(db.db!, 'items', 2)).toBeUndefined()
+    expect(await idbGet(db.db!, 'items', 1)).toMatchObject({
+      id: 1,
+      title: 'aa',
     })
   })
 

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -257,3 +257,108 @@ describe('IndexedDB Data Provider', () => {
     db2.close()
   })
 })
+
+describe('IndexedDB indexes', () => {
+  @Entity('idx_items')
+  class Item {
+    @Fields.integer()
+    id = 0
+    @Fields.string()
+    title = ''
+    @Fields.string()
+    status = ''
+    @Fields.string()
+    tag = ''
+  }
+
+  let db: IndexedDbDataProvider
+  let remult: Remult
+  let dbName: string
+
+  beforeEach(() => {
+    dbName = `remult-idb-idx-${crypto.randomUUID()}`
+    db = new IndexedDbDataProvider(dbName, {
+      indexes: (x) => x.ensureIndexes(Item, ['title', ['status', 'title']]),
+    })
+    remult = new Remult(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+  })
+
+  async function seed() {
+    const repo = remult.repo(Item)
+    await repo.insert([
+      { id: 1, title: 'a', status: 'open', tag: 'x' },
+      { id: 2, title: 'b', status: 'open', tag: 'y' },
+      { id: 3, title: 'a', status: 'done', tag: 'z' },
+    ])
+    return repo
+  }
+
+  async function raw(where: { title?: any; status?: any; $or?: any }) {
+    const repo = remult.repo(Item)
+    return db.fetchRows(
+      repo.metadata,
+      Filter.fromEntityFilter(repo.metadata, { tag: 'nope', ...where }),
+    )
+  }
+
+  function ids(rows: any[]) {
+    return rows.map((r) => r.id).sort((a, b) => a - b)
+  }
+
+  function indexNames() {
+    const store = db
+      .db!.transaction('idx_items')
+      .objectStore('idx_items')
+    return [...store.indexNames]
+  }
+
+  it('creates declared indexes', async () => {
+    await seed()
+    expect(indexNames()).toEqual(expect.arrayContaining(['title', 'status_title']))
+  })
+
+  it('eq on title uses the title index', async () => {
+    await seed()
+    expect(ids(await raw({ title: 'a' }))).toEqual([1, 3])
+    expect(db.lastFetch).toMatchObject({
+      type: 'keys',
+      keys: ['a'],
+      index: 'title',
+    })
+  })
+
+  it('in on title uses the title index', async () => {
+    await seed()
+    expect(ids(await raw({ title: ['a', 'b'] }))).toEqual([1, 2, 3])
+    expect(db.lastFetch).toMatchObject({ type: 'keys', index: 'title' })
+  })
+
+  it('gt on title uses a range on the title index', async () => {
+    await seed()
+    expect(ids(await raw({ title: { $gt: 'a' } }))).toEqual([2])
+    expect(db.lastFetch).toMatchObject({ type: 'range', index: 'title' })
+  })
+
+  it('or of titles uses the title index', async () => {
+    await seed()
+    expect(
+      ids(await raw({ $or: [{ title: 'a' }, { title: 'b' }] })),
+    ).toEqual([1, 2, 3])
+    expect(db.lastFetch).toMatchObject({ type: 'keys', index: 'title' })
+  })
+
+  it('eq on status+title uses the compound index', async () => {
+    await seed()
+    expect(ids(await raw({ status: 'open', title: 'a' }))).toEqual([1])
+    expect(db.lastFetch).toMatchObject({
+      type: 'keys',
+      keys: [['open', 'a']],
+      index: 'status_title',
+    })
+  })
+})

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -4,6 +4,7 @@ import {
   Fields,
   Filter,
   IndexedDbDataProvider,
+  IndexedDbIndexBuilder,
   Remult,
 } from '../../core'
 import { allDbTests } from './shared-tests'
@@ -22,6 +23,15 @@ function idbGet(db: IDBDatabase, storeName: string, key: IDBValidKey) {
     const req = db.transaction(storeName).objectStore(storeName).get(key)
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)
+  })
+}
+
+function idbPut(db: IDBDatabase, storeName: string, value: any) {
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+    tx.objectStore(storeName).put(value)
   })
 }
 
@@ -80,6 +90,7 @@ describe('IndexedDB Data Provider', () => {
     await remult.repo(Customer).insert({ id: 1, name: 'c' })
     const names = [...db.db!.objectStoreNames]
     expect(names).toEqual(expect.arrayContaining(['orders', 'customers']))
+    expect(names).not.toContain('__remult_keys')
     expect(await remult.repo(Order).find()).toMatchObject([
       { id: 1, name: 'o' },
     ])
@@ -361,4 +372,185 @@ describe('IndexedDB indexes', () => {
       index: 'status_title',
     })
   })
+})
+
+describe('IndexedDB encryption', () => {
+  @Entity('enc_tasks')
+  class Task {
+    @Fields.integer()
+    id = 0
+    @Fields.string()
+    status = ''
+    @Fields.string()
+    secret = ''
+    @Fields.createdAt()
+    createdAt = new Date()
+  }
+
+  let db: IndexedDbDataProvider
+  let remult: Remult
+  let dbName: string
+
+  function encOptions() {
+    return {
+      indexes: (x: IndexedDbIndexBuilder) =>
+        x.ensureIndexes(Task, ['status', 'createdAt']),
+      encrypt: true as const,
+    }
+  }
+
+  beforeEach(() => {
+    dbName = `remult-idb-enc-${crypto.randomUUID()}`
+    db = new IndexedDbDataProvider(dbName, encOptions())
+    remult = new Remult(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+  })
+
+  it('encrypts non-indexed fields at rest and decrypts on find', async () => {
+    const createdAt = new Date('2024-01-02T00:00:00.000Z')
+    await remult.repo(Task).insert({
+      id: 1,
+      status: 'open',
+      secret: 's3cret',
+      createdAt,
+    })
+    const raw = await idbGet(db.db!, 'enc_tasks', 1)
+    expect(raw._enc).toBeInstanceOf(ArrayBuffer)
+    expect(raw._iv).toHaveLength(12)
+    expect(raw.id).toBe(1)
+    expect(raw.status).toBe('open')
+    expect(raw.createdAt).toBeTruthy()
+    expect(raw.secret).toBeUndefined()
+    expect(JSON.stringify(raw)).not.toContain('s3cret')
+    const dek = await idbGet(db.db!, '__remult_keys', 'dek')
+    expect(dek.key).toBeInstanceOf(CryptoKey)
+    expect(dek.key.extractable).toBe(false)
+    expect(await remult.repo(Task).find()).toMatchObject([
+      { id: 1, status: 'open', secret: 's3cret' },
+    ])
+  })
+
+  it('find by indexed field still prefetches', async () => {
+    const repo = remult.repo(Task)
+    await repo.insert([
+      { id: 1, status: 'open', secret: 'a' },
+      { id: 2, status: 'done', secret: 'b' },
+    ])
+    const rows = await db.fetchRows(
+      repo.metadata,
+      Filter.fromEntityFilter(repo.metadata, { status: 'open', secret: 'nope' }),
+    )
+    expect(rows.map((r) => r.id)).toEqual([1])
+    expect(db.lastFetch).toMatchObject({
+      type: 'keys',
+      keys: ['open'],
+      index: 'status',
+    })
+    expect(await repo.find({ where: { status: 'open' } })).toMatchObject([
+      { id: 1, secret: 'a' },
+    ])
+  })
+
+  it('auto key persists across provider instances', async () => {
+    await remult.repo(Task).insert({ id: 1, status: 'open', secret: 'keep' })
+    db.close()
+    const db2 = new IndexedDbDataProvider(dbName, encOptions())
+    const remult2 = new Remult(db2)
+    expect(await remult2.repo(Task).find()).toMatchObject([
+      { id: 1, status: 'open', secret: 'keep' },
+    ])
+    db2.close()
+  })
+
+  it('reads unencrypted rows and encrypts on write', async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+    const plain = new IndexedDbDataProvider(dbName)
+    const remultPlain = new Remult(plain)
+    await remultPlain.repo(Task).insert({
+      id: 1,
+      status: 'open',
+      secret: 'old',
+    })
+    plain.close()
+    db = new IndexedDbDataProvider(dbName, encOptions())
+    remult = new Remult(db)
+    expect(await remult.repo(Task).find()).toMatchObject([
+      { id: 1, secret: 'old' },
+    ])
+    await remult.repo(Task).update(1, { secret: 'new' })
+    const raw = await idbGet(db.db!, 'enc_tasks', 1)
+    expect(raw._enc).toBeInstanceOf(ArrayBuffer)
+    expect(raw.secret).toBeUndefined()
+    expect(await remult.repo(Task).findId(1)).toMatchObject({ secret: 'new' })
+  })
+
+  it('throws if decrypt fails', async () => {
+    await remult.repo(Task).insert({ id: 1, status: 'open', secret: 'x' })
+    const raw = await idbGet(db.db!, 'enc_tasks', 1)
+    raw._enc = new Uint8Array([1, 2, 3, 4]).buffer
+    await idbPut(db.db!, 'enc_tasks', raw)
+    await expect(remult.repo(Task).find()).rejects.toThrow(
+      /Failed to decrypt IndexedDB row/,
+    )
+  })
+
+  it('uses getEncryptionKey and skips the key store', async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+    const key = await crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+    db = new IndexedDbDataProvider(dbName, {
+      ...encOptions(),
+      getEncryptionKey: () => key,
+    })
+    remult = new Remult(db)
+    await remult.repo(Task).insert({ id: 1, status: 'open', secret: 'k' })
+    expect([...db.db!.objectStoreNames]).not.toContain('__remult_keys')
+    expect(await remult.repo(Task).find()).toMatchObject([{ secret: 'k' }])
+  })
+})
+
+describe('IndexedDB encryption (all db tests)', () => {
+  let db: IndexedDbDataProvider
+  let remult: Remult
+  let dbName: string
+
+  beforeEach(() => {
+    dbName = `remult-idb-enc-all-${crypto.randomUUID()}`
+    db = new IndexedDbDataProvider(dbName, { encrypt: true })
+    remult = new Remult(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+  })
+
+  allDbTests(
+    {
+      getDb() {
+        return db
+      },
+      getRemult() {
+        return remult
+      },
+      createEntity: async (entity) => {
+        const repo = remult.repo(entity)
+        await db.ensureSchema([repo.metadata])
+        return repo
+      },
+    },
+    {
+      excludeTransactions: true,
+      excludeLiveQuery: true,
+    },
+  )
 })

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Entity, Fields, IndexedDbDataProvider, Remult } from '../../core'
+import { allDbTests } from './shared-tests'
+
+async function deleteIndexedDb(name: string) {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => resolve()
+  })
+}
+
+function idbGet(db: IDBDatabase, storeName: string, key: IDBValidKey) {
+  return new Promise<any>((resolve, reject) => {
+    const req = db.transaction(storeName).objectStore(storeName).get(key)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('IndexedDB Data Provider', () => {
+  let db: IndexedDbDataProvider
+  let remult: Remult
+  let dbName: string
+
+  beforeEach(() => {
+    dbName = `remult-idb-native-${crypto.randomUUID()}`
+    db = new IndexedDbDataProvider(dbName)
+    remult = new Remult(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await deleteIndexedDb(dbName)
+  })
+
+  allDbTests(
+    {
+      getDb() {
+        return db
+      },
+      getRemult() {
+        return remult
+      },
+      createEntity: async (entity) => {
+        const repo = remult.repo(entity)
+        await db.ensureSchema([repo.metadata])
+        return repo
+      },
+    },
+    {
+      excludeTransactions: true,
+      excludeLiveQuery: true,
+    },
+  )
+
+  it('uses a store per entity', async () => {
+    @Entity('orders')
+    class Order {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      name = ''
+    }
+    @Entity('customers')
+    class Customer {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      name = ''
+    }
+    await remult.repo(Order).insert({ id: 1, name: 'o' })
+    await remult.repo(Customer).insert({ id: 1, name: 'c' })
+    const names = [...db.db!.objectStoreNames]
+    expect(names).toEqual(expect.arrayContaining(['orders', 'customers']))
+    expect(await remult.repo(Order).find()).toMatchObject([
+      { id: 1, name: 'o' },
+    ])
+    expect(await remult.repo(Customer).find()).toMatchObject([
+      { id: 1, name: 'c' },
+    ])
+  })
+
+  it('stores each row by id', async () => {
+    @Entity('items')
+    class Item {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      title = ''
+    }
+    await remult.repo(Item).insert({ id: 1, title: 'a' })
+    await remult.repo(Item).insert({ id: 2, title: 'b' })
+    expect(await idbGet(db.db!, 'items', 1)).toMatchObject({
+      id: 1,
+      title: 'a',
+    })
+    expect(await idbGet(db.db!, 'items', 2)).toMatchObject({
+      id: 2,
+      title: 'b',
+    })
+  })
+
+  it('persists across remult instances', async () => {
+    @Entity('persist')
+    class Persist {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      name = ''
+    }
+    await remult.repo(Persist).insert({ id: 1, name: 'a' })
+    db.close()
+    const db2 = new IndexedDbDataProvider(dbName)
+    const remult2 = new Remult(db2)
+    expect(await remult2.repo(Persist).find()).toMatchObject([
+      { id: 1, name: 'a' },
+    ])
+    db2.close()
+  })
+})

--- a/projects/tests/dbs/indexeddb-native.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb-native.spec-browser.ts
@@ -8,15 +8,7 @@ import {
   Remult,
 } from '../../core'
 import { allDbTests } from './shared-tests'
-
-async function deleteIndexedDb(name: string) {
-  await new Promise<void>((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(name)
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-    req.onblocked = () => resolve()
-  })
-}
+import { droppableDataProviderTests } from './shared-tests/droppable'
 
 function idbGet(db: IDBDatabase, storeName: string, key: IDBValidKey) {
   return new Promise<any>((resolve, reject) => {
@@ -47,8 +39,7 @@ describe('IndexedDB Data Provider', () => {
   })
 
   afterEach(async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
   })
 
   allDbTests(
@@ -69,6 +60,11 @@ describe('IndexedDB Data Provider', () => {
       excludeTransactions: true,
       excludeLiveQuery: true,
     },
+  )
+
+  droppableDataProviderTests(
+    () => db,
+    () => remult,
   )
 
   it('uses a store per entity', async () => {
@@ -295,8 +291,7 @@ describe('IndexedDB indexes', () => {
   })
 
   afterEach(async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
   })
 
   async function seed() {
@@ -331,6 +326,22 @@ describe('IndexedDB indexes', () => {
   it('creates declared indexes', async () => {
     await seed()
     expect(indexNames()).toEqual(expect.arrayContaining(['title', 'status_title']))
+  })
+
+  it('dropTable recreates indexes on next use', async () => {
+    await seed()
+    await db.dropTable(Item)
+    expect([...db.db!.objectStoreNames]).not.toContain('idx_items')
+    await seed()
+    expect(indexNames()).toEqual(
+      expect.arrayContaining(['title', 'status_title']),
+    )
+    expect(ids(await raw({ title: 'a' }))).toEqual([1, 3])
+    expect(db.lastFetch).toMatchObject({
+      type: 'keys',
+      keys: ['a'],
+      index: 'title',
+    })
   })
 
   it('eq on title uses the title index', async () => {
@@ -406,8 +417,7 @@ describe('IndexedDB encryption', () => {
   })
 
   afterEach(async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
   })
 
   it('encrypts non-indexed fields at rest and decrypts on find', async () => {
@@ -467,8 +477,7 @@ describe('IndexedDB encryption', () => {
   })
 
   it('reads unencrypted rows and encrypts on write', async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
     const plain = new IndexedDbDataProvider(dbName)
     const remultPlain = new Remult(plain)
     await remultPlain.repo(Task).insert({
@@ -500,8 +509,7 @@ describe('IndexedDB encryption', () => {
   })
 
   it('uses getEncryptionKey and skips the key store', async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
     const key = await crypto.subtle.generateKey(
       { name: 'AES-GCM', length: 256 },
       false,
@@ -530,8 +538,7 @@ describe('IndexedDB encryption (all db tests)', () => {
   })
 
   afterEach(async () => {
-    db.close()
-    await deleteIndexedDb(dbName)
+    await db.dropDatabase()
   })
 
   allDbTests(

--- a/projects/tests/dbs/indexeddb.spec-browser.ts
+++ b/projects/tests/dbs/indexeddb.spec-browser.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { DataProvider } from '../../core'
+import {
+  Entity,
+  Fields,
+  JsonDataProvider,
+  JsonEntityIndexedDbStorage,
+  Remult,
+} from '../../core'
+import { allDbTests } from './shared-tests'
+
+async function deleteIndexedDb(name: string) {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => resolve()
+  })
+}
+
+describe('IndexedDB', () => {
+  let db: DataProvider
+  let remult: Remult
+  let storage: JsonEntityIndexedDbStorage
+  let dbName: string
+
+  beforeEach(() => {
+    dbName = `remult-idb-${crypto.randomUUID()}`
+    storage = new JsonEntityIndexedDbStorage(dbName)
+    db = new JsonDataProvider(storage)
+    remult = new Remult(db)
+  })
+
+  afterEach(async () => {
+    storage.db?.close()
+    storage.db = undefined
+    await deleteIndexedDb(dbName)
+  })
+
+  allDbTests(
+    {
+      getDb() {
+        return db
+      },
+      getRemult() {
+        return remult
+      },
+      createEntity: async (entity) => remult.repo(entity),
+    },
+    {
+      excludeTransactions: true,
+      excludeLiveQuery: true,
+    },
+  )
+
+  it('persists across remult instances', async () => {
+    @Entity('persist')
+    class Persist {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      name = ''
+    }
+    await remult.repo(Persist).insert({ id: 1, name: 'a' })
+    const storage2 = new JsonEntityIndexedDbStorage(dbName)
+    const remult2 = new Remult(new JsonDataProvider(storage2))
+    expect(await remult2.repo(Persist).find()).toMatchObject([
+      { id: 1, name: 'a' },
+    ])
+    storage2.db?.close()
+  })
+})

--- a/projects/tests/dbs/shared-tests/droppable.ts
+++ b/projects/tests/dbs/shared-tests/droppable.ts
@@ -1,0 +1,76 @@
+import { expect, it } from 'vitest'
+import {
+  Entity,
+  Fields,
+  type DroppableDataProvider,
+  type Remult,
+} from '../../../core'
+
+@Entity('droppable_orders')
+class Order {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  name = ''
+}
+
+@Entity('droppable_customers')
+class Customer {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  name = ''
+}
+
+@Entity('droppable_auto')
+class Auto {
+  @Fields.autoIncrement()
+  id = 0
+  @Fields.string()
+  name = ''
+}
+
+export function droppableDataProviderTests(
+  getDb: () => DroppableDataProvider,
+  getRemult: () => Remult,
+) {
+  it('dropTable removes one entity and recreates on next insert', async () => {
+    const remult = getRemult()
+    const db = getDb()
+    await remult.repo(Order).insert({ id: 1, name: 'a' })
+    await remult.repo(Customer).insert({ id: 1, name: 'c' })
+    await db.dropTable(Order)
+    expect(await remult.repo(Order).find()).toEqual([])
+    expect(await remult.repo(Customer).find()).toMatchObject([
+      { id: 1, name: 'c' },
+    ])
+    await remult.repo(Order).insert({ id: 2, name: 'b' })
+    expect(await remult.repo(Order).find()).toMatchObject([{ id: 2, name: 'b' }])
+  })
+
+  it('dropTable is a no-op when the table was never created', async () => {
+    await getDb().dropTable(Order)
+    expect(await getRemult().repo(Order).find()).toEqual([])
+  })
+
+  it('dropTable resets autoincrement', async () => {
+    const remult = getRemult()
+    const repo = remult.repo(Auto)
+    expect((await repo.insert({ name: 'a' })).id).toBe(1)
+    expect((await repo.insert({ name: 'b' })).id).toBe(2)
+    await getDb().dropTable(Auto)
+    expect((await repo.insert({ name: 'c' })).id).toBe(1)
+  })
+
+  it('dropDatabase removes all tables and stays usable', async () => {
+    const remult = getRemult()
+    const db = getDb()
+    await remult.repo(Order).insert({ id: 1, name: 'a' })
+    await remult.repo(Customer).insert({ id: 1, name: 'c' })
+    await db.dropDatabase()
+    expect(await remult.repo(Order).find()).toEqual([])
+    expect(await remult.repo(Customer).find()).toEqual([])
+    await remult.repo(Order).insert({ id: 3, name: 'z' })
+    expect(await remult.repo(Order).find()).toMatchObject([{ id: 3, name: 'z' }])
+  })
+}

--- a/projects/tests/dbs/shared-tests/many-operations.ts
+++ b/projects/tests/dbs/shared-tests/many-operations.ts
@@ -31,5 +31,32 @@ export function manyOperations({ createEntity }: DbTestProps) {
       expect(await r.updateMany({ where: 'all', set: { name: 'yo' } })).toBe(3)
       expect(await r.count()).toBe(3)
     })
+
+    it('insert many select none', async () => {
+      const result = await r.insert([{ name: 'a' }, { name: 'b' }], {
+        select: 'none',
+      })
+      expect(result).toBeUndefined()
+      expect(await r.count()).toBe(2)
+    })
+
+    it('insert many autoincrement', async () => {
+      let e = class {
+        id!: number
+        name?: string
+      }
+      describeClass(e, Entity('many_ai', { allowApiCrud: true }), {
+        id: Fields.autoIncrement(),
+        name: Fields.string(),
+      })
+      const repo = await createEntity(e)
+      const inserted = await repo.insert([
+        { name: 'a' },
+        { name: 'b' },
+        { name: 'c' },
+      ])
+      expect(inserted.map((x: any) => x.name)).toEqual(['a', 'b', 'c'])
+      expect(inserted.map((x: any) => x.id)).toEqual([1, 2, 3])
+    })
   })
 }

--- a/projects/tests/dbs/sql-js.spec.ts
+++ b/projects/tests/dbs/sql-js.spec.ts
@@ -75,4 +75,45 @@ describe('Sql JS', () => {
       '"alter table `my` add column `name` text default \'\' not null "',
     )
   })
+  it('multi-row insert batches by bind limit', async () => {
+    @Entity('batch_ins')
+    class BatchIns {
+      @Fields.integer()
+      id = 0
+      @Fields.string()
+      name = ''
+    }
+    const repo = remult.repo(BatchIns)
+    await db.ensureSchema([repo.metadata])
+    db._getSourceSql().maxParametersInOneSqlStatement = 7
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      name: 'n' + i,
+    }))
+    const inserted = await repo.insert(rows)
+    expect(inserted.map((x) => ({ id: x.id, name: x.name }))).toEqual(rows)
+    expect(await repo.count()).toBe(10)
+  })
+  it('multi-row insert unions sparse columns', async () => {
+    @Entity('sparse_ins')
+    class SparseIns {
+      @Fields.integer()
+      id = 0
+      @Fields.string({ allowNull: true })
+      a?: string
+      @Fields.string({ allowNull: true })
+      b?: string
+    }
+    const repo = remult.repo(SparseIns)
+    await db.ensureSchema([repo.metadata])
+    await db.getEntityDataProvider(repo.metadata).insert([
+      { id: 1, a: 'x' },
+      { id: 2, b: 'y' },
+    ])
+    const found = await repo.find({ orderBy: { id: 'asc' } })
+    expect(found.map((x) => ({ id: x.id, a: x.a, b: x.b }))).toEqual([
+      { id: 1, a: 'x', b: null },
+      { id: 2, a: null, b: 'y' },
+    ])
+  })
 })

--- a/projects/tests/graphql.spec.ts
+++ b/projects/tests/graphql.spec.ts
@@ -36,8 +36,7 @@ class Category {
   @Fields.string({
     allowApiUpdate: false,
     saving: async (_, ref, { repository }) => {
-      // created a consistent id for testing
-      ref.value = (await repository.count()).toString()
+      if (!ref.value) ref.value = (await repository.count()).toString()
     },
   })
   id = ''
@@ -139,7 +138,7 @@ describe('graphql', () => {
   it('test nodes', async () => {
     const cat = await remult
       .repo(Category)
-      .insert([{ name: 'c1' }, { name: 'c2' }])
+      .insert([{ id: '0', name: 'c1' }, { id: '1', name: 'c2' }])
 
     const catMore = await remult
       .repo(CategoryMore)
@@ -443,7 +442,7 @@ describe('graphql', () => {
   it('gets related entities', async () => {
     const cat = await remult
       .repo(Category)
-      .insert([{ name: 'c1' }, { name: 'c2' }])
+      .insert([{ id: '0', name: 'c1' }, { id: '1', name: 'c2' }])
     await remult.repo(Task).insert({
       title: 'task a',
       category: cat[0],

--- a/projects/tests/tests/basicRowFunctionality.spec.ts
+++ b/projects/tests/tests/basicRowFunctionality.spec.ts
@@ -1871,21 +1871,23 @@ describe('test rest data provider translates data correctly', () => {
         get: () => undefined!,
         post: async (x, data) => {
           done.ok()
-          expect(data.a).toBe(1)
-          expect(data.b).toBe('2021-05-16T08:32:19.905Z')
+          expect(data[0].a).toBe(1)
+          expect(data[0].b).toBe('2021-05-16T08:32:19.905Z')
           return data
         },
         put: () => undefined!,
       },
     }))
     let x = z.getEntityDataProvider(c.metadata)
-    let r = await x.insert({
-      a: 1,
-      b: new Date('2021-05-16T08:32:19.905Z'),
-    })
-    expect(r.a).toBe(1)
-    expect(r.b instanceof Date).toBe(true)
-    expect(r.b.toISOString()).toBe('2021-05-16T08:32:19.905Z')
+    let r = await x.insert([
+      {
+        a: 1,
+        b: new Date('2021-05-16T08:32:19.905Z'),
+      },
+    ])
+    expect(r[0].a).toBe(1)
+    expect(r[0].b instanceof Date).toBe(true)
+    expect(r[0].b.toISOString()).toBe('2021-05-16T08:32:19.905Z')
     done.test()
   })
 })

--- a/projects/tests/tests/test-many-operations.spec.ts
+++ b/projects/tests/tests/test-many-operations.spec.ts
@@ -48,10 +48,13 @@ describe('test rest many operations', () => {
   })
   it('Insert many works', async () => {
     await expect(() =>
-      r.insert([
-        { id: 1, name: 'a' },
-        { id: 2, name: '' },
-      ]),
+      r.insert(
+        [
+          { id: 1, name: 'a' },
+          { id: 2, name: '' },
+        ],
+        { bulk: true },
+      ),
     ).rejects.toMatchObject({
       message: 'Name: Should not be empty',
       modelState: {


### PR DESCRIPTION
## Summary
- Vitest browser runner (`*.spec-browser.ts`, webdriverio/chrome) so IndexedDB providers can use `allDbTests`
- `JsonEntityIndexedDbStorage` now runs that suite
- CircleCI `test-browser` job uploads coverage to Codecov (istanbul; v8 does not work with webdriverio)
- `export type` for type-only re-exports in `projects/core/index.ts` so Vite browser ESM can load the barrel

## Test plan
- [ ] CircleCI `test-browser` passes
- [ ] Codecov merge includes `json-entity-indexed-db-data-provider.ts`
- [ ] `npm run test:browser:ci` locally

Made with [Cursor](https://cursor.com)