### PR TITLE
SSE / live query resilience follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,17 @@ All notable changes to this project will be documented in this file.
 
 ## [3.4.0] - 2026-09-07
 
-- Fixed live query silently stopping updates when the SSE stream died while the HTTP keep-alive still looked healthy. Each server-side query now carries a version that is sent with every change; the client refetches the snapshot on a version gap, and the keep-alive returns versions so a stale connection is detected and recovered
-- Fixed `liveQuery` first `next()` hanging when the EventSource never connected. The REST snapshot no longer waits for the SSE `connectionId`
-- Fixed `SseSubscriptionClient` giving up after 4 EventSource errors. It now reconnects indefinitely with exponential backoff, resets the backoff once connected, and reconnects immediately on `visibilitychange`, `online` and `pageshow`
-- Fixed a half-open EventSource (open socket, no bytes) never being recreated. The client now forces a reconnect and polls versions with backoff while no server event arrives for `flags.sseStaleMs`
-- Fixed a leaked keep-alive interval and foreground listeners when `openConnection` rejected
-- Fixed a refetch racing its own `endLiveQuery` and deleting the new registration. Re-subscribing now replaces the stored query in place; `InMemoryLiveQueryStorage.add` replaces an existing query with the same id
-- SSE server ping is now every 15s (was 45s) to stay under proxy and Heroku idle timeouts. Exported as `ssePingMs`
-- Added `flags.sseStaleMs`, `flags.liveQueryKeepAliveMs` and `flags.liveQueryPollWhenStaleMs`
-- `LiveQueryChange` has a new `{ type: 'version', from, to }` member. It is consumed internally and not passed to `liveQuery` listeners
-- **Breaking** for custom `LiveQueryStorage` implementations: `keepAliveAndReturnUnknownQueryIds` now returns `{ unknownQueryIds: string[], versions: Record<string, number> }` instead of `string[]`. The keep-alive route still accepts and answers the old array body for older clients
-- `SubscriptionClientConnection` gained optional `lastServerEvent` and `resume(force?)`. Custom subscription clients (e.g. Ably) can ignore them
-- `SubscriptionListener` gained an optional `reconnect()` so `SubscriptionChannel` subscribers can refetch state after a dropped connection
+Live query / SSE resilience. The client no longer loses updates when the SSE stream dies while HTTP still works.
+
+- Each server-side live query carries a version, sent with every change and returned by the keep-alive. The client refetches the snapshot on any version gap, so a dead socket, a half-open socket or a missed message is recovered within one keep-alive
+- `SseSubscriptionClient` reconnects forever with backoff (was 4 tries), reconnects on `visibilitychange` / `online` / `pageshow`, and recreates a socket that stops delivering events for `flags.sseStaleMs`
+- `liveQuery` first `next()` no longer waits for the SSE connection
+- Server SSE ping every 15s (was 45s), exported as `ssePingMs`
+- New `flags.sseStaleMs` (40s), `flags.liveQueryKeepAliveMs` (30s), `flags.liveQueryPollWhenStaleMs` (1s)
+- `SubscriptionListener.reconnect?()` lets `SubscriptionChannel` subscribers refetch state after a dropped connection
+- `LiveQueryChange` has an internal `{ type: 'version', from, to }` member, filtered out before reaching `liveQuery` listeners
+- **Breaking** for custom `LiveQueryStorage`: `keepAliveAndReturnUnknownQueryIds` returns `{ unknownQueryIds, versions }` instead of `string[]`. The keep-alive route still accepts the old array body from older clients
+- `SubscriptionClientConnection` gained optional `lastServerEvent` and `resume(force?)`; custom clients (Ably, ...) can ignore them
 
 ## [3.3.18] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - `LiveQueryChange` has a new `{ type: 'version', from, to }` member. It is consumed internally and not passed to `liveQuery` listeners
 - **Breaking** for custom `LiveQueryStorage` implementations: `keepAliveAndReturnUnknownQueryIds` now returns `{ unknownQueryIds: string[], versions: Record<string, number> }` instead of `string[]`. The keep-alive route still accepts and answers the old array body for older clients
 - `SubscriptionClientConnection` gained optional `lastServerEvent` and `resume(force?)`. Custom subscription clients (e.g. Ably) can ignore them
+- `SubscriptionListener` gained an optional `reconnect()` so `SubscriptionChannel` subscribers can refetch state after a dropped connection
 
 ## [3.3.18] - 2026-08-30
 

--- a/docs/docs/ref_subscriptionchannel.md
+++ b/docs/docs/ref_subscriptionchannel.md
@@ -63,6 +63,16 @@ notif.subscribe((message) => {
    console.log(`Chart updated: ${message.kind}`, message.data);
  });
  ```
+
+ #### Recovering after a dropped connection
+ Messages published while the connection was down are not replayed.
+ Use the `reconnect` listener to refetch state:
+ ```ts
+ chart.subscribe({
+   next: (message) => (chartData = message.data),
+   reconnect: () => loadChartData(),
+ });
+ ```
 ## constructor
 Constructs a new `SubscriptionChannel` instance.
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3278,6 +3278,8 @@ export interface SubscriptionListener<type> {
   next(message: type): void
   error(err: any): void
   complete(): void
+  /** The connection was re-established; messages published meanwhile were lost, refetch state if needed. */
+  reconnect?(): void
 }
 export interface SubscriptionServer {
   publishMessage<T>(channel: string, message: T): Promise<void>
@@ -4913,7 +4915,7 @@ export const fieldOptionsEnricher: {
 }
 export const flags: {
   error500RetryCount: number
-  /** Client treats SSE as dead if no event for this long */
+  /** Client treats SSE as dead if no event for this long. Server pings every 15s; two missed pings plus slack, so a stalled event loop does not trigger a reconnect storm */
   sseStaleMs: number
   /** HTTP keep-alive while SSE is healthy (touches lastUsed) */
   liveQueryKeepAliveMs: number

--- a/projects/core/internals.ts
+++ b/projects/core/internals.ts
@@ -26,5 +26,6 @@ export { isOfType } from './src/isOfType.js'
 export type { ClassType } from './classType.js'
 
 export { flags } from './src/remult3/remult3.js'
+export { SseSubscriptionClient } from './src/live-query/SseSubscriptionClient.js'
 export { DataProviderPromiseWrapper } from './src/data-interfaces.js'
 export { pagedQueryResult } from './src/remult3/pagedQueryResult.js'

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -342,6 +342,9 @@ export class LiveQueryClient {
             for (const q of this.queries.values()) {
               q.subscribeCode!()
             }
+            for (const c of this.channels.values()) {
+              for (const l of c.listeners) l.reconnect?.()
+            }
           })
           .then((c) => {
             this.openedConnection = c

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -64,7 +64,11 @@ export class LiveQueryClient {
             },
           )
         } catch (err: any) {
-          onResult.error(err)
+          // drop the half-registered channel so the next subscribe retries
+          // instead of joining a channel that was never subscribed
+          this.channels.delete(key)
+          q.listeners.forEach((l) => l.error(err))
+          this.closeIfNoListeners()
           throw err
         }
       }

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -228,7 +228,7 @@ export class LiveQueryClient {
   interval: any
   lastKeepAliveAt = 0
   private keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
-  private keepAliveInFlight?: Promise<void>
+  private keepAliveInFlight?: Promise<boolean>
   private foregroundKeepAliveTimer: ReturnType<typeof setTimeout> | undefined
   isSseStale() {
     const conn = this.openedConnection
@@ -242,13 +242,14 @@ export class LiveQueryClient {
     })
     return this.keepAliveInFlight
   }
+  /** Resolves true when a query was refetched. */
   private async sendKeepAlive() {
     const ids: string[] = []
     for (const q of this.queries.values()) {
       if (!q.snapshotReady) continue
       ids.push(q.queryChannel)
     }
-    if (ids.length === 0) return
+    if (ids.length === 0) return false
     let p = this.apiProvider()
     const raw: unknown = await this.runPromise(
       remultStatic.actionInfo.runActionWithoutBlockingUI(() =>
@@ -278,13 +279,7 @@ export class LiveQueryClient {
         q.subscribeCode!()
       }
     }
-    if (this.isSseStale()) {
-      this.keepAliveBackoffMs = reloaded
-        ? flags.liveQueryPollWhenStaleMs
-        : Math.min(this.keepAliveBackoffMs * 2, flags.liveQueryKeepAliveMs)
-    } else {
-      this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
-    }
+    return reloaded
   }
   private async maybeKeepAlive() {
     const stale = this.isSseStale()
@@ -295,7 +290,12 @@ export class LiveQueryClient {
     if (Date.now() - this.lastKeepAliveAt < interval) return
     this.lastKeepAliveAt = Date.now()
     if (stale) this.openedConnection?.resume?.(true)
-    await this.runKeepAlive()
+    const reloaded = await this.runKeepAlive()
+    // backoff lives here so channel-only clients (no query ids) back off too
+    if (this.isSseStale())
+      this.keepAliveBackoffMs = reloaded
+        ? flags.liveQueryPollWhenStaleMs
+        : Math.min(this.keepAliveBackoffMs * 2, flags.liveQueryKeepAliveMs)
   }
   private detachForeground = () => {}
   private attachForeground() {
@@ -320,18 +320,22 @@ export class LiveQueryClient {
       this.detachForeground = () => {}
     }
   }
+  private startKeepAlive() {
+    // openConnection may reject and be retried with queries still alive
+    if (this.interval !== undefined) return
+    this.lastKeepAliveAt = Date.now()
+    this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
+    this.attachForeground()
+    this.interval = setInterval(
+      () => {
+        this.runPromise(this.maybeKeepAlive())
+      },
+      Math.min(flags.liveQueryPollWhenStaleMs, flags.liveQueryKeepAliveMs),
+    )
+  }
   private openIfNoOpened() {
     if (!this.client) {
-      this.lastKeepAliveAt = Date.now()
-      this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
-      this.attachForeground()
-      this.interval = setInterval(
-        () => {
-          this.runPromise(this.maybeKeepAlive())
-        },
-        Math.min(flags.liveQueryPollWhenStaleMs, flags.liveQueryKeepAliveMs),
-      )
-
+      this.startKeepAlive()
       return this.runPromise(
         (this.client = this.apiProvider()
           .subscriptionClient!.openConnection(() => {

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -337,7 +337,8 @@ export class LiveQueryClient {
     this.attachForeground()
     this.interval = setInterval(
       () => {
-        this.runPromise(this.maybeKeepAlive())
+        // a failed post is transient: the backoff covers it, next tick retries
+        this.runPromise(this.maybeKeepAlive().catch(() => {}))
       },
       Math.min(flags.liveQueryPollWhenStaleMs, flags.liveQueryKeepAliveMs),
     )

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -132,6 +132,7 @@ export class LiveQueryClient {
             )
             q.subscribeCode = () => {
               q.snapshotReady = false
+              q.droppedWhilePending = false
               q.unsubscribeChannel()
 
               let unsubscribeToChannel: Unsubscribe = () => {}
@@ -158,7 +159,11 @@ export class LiveQueryClient {
                   this.runPromise(r.unsubscribe())
                 }
                 snapshotDone = true
-                return this.runPromise(q.setAllItems(r.result))
+                return this.runPromise(
+                  q.setAllItems(r.result).then(() => {
+                    if (q.droppedWhilePending) return this.runKeepAlive()
+                  }),
+                )
               }
 
               this.runPromise(
@@ -176,9 +181,7 @@ export class LiveQueryClient {
                     }
                     unsubscribeToChannel = unsub
                     if (snapshotDone)
-                      return this.runPromise(
-                        this.runKeepAlive({ checkVersions: true }),
-                      )
+                      return this.runPromise(this.runKeepAlive())
                   })
                   .catch((err) => {
                     q.listeners.forEach((l) => l.error(err))
@@ -232,14 +235,14 @@ export class LiveQueryClient {
     if (!conn || conn.lastServerEvent === undefined) return false
     return Date.now() - conn.lastServerEvent > flags.sseStaleMs
   }
-  async runKeepAlive(opts?: { checkVersions?: boolean }) {
+  async runKeepAlive() {
     if (this.keepAliveInFlight) return this.keepAliveInFlight
-    this.keepAliveInFlight = this.sendKeepAlive(opts).finally(() => {
+    this.keepAliveInFlight = this.sendKeepAlive().finally(() => {
       this.keepAliveInFlight = undefined
     })
     return this.keepAliveInFlight
   }
-  private async sendKeepAlive(opts?: { checkVersions?: boolean }) {
+  private async sendKeepAlive() {
     const ids: string[] = []
     for (const q of this.queries.values()) {
       if (!q.snapshotReady) continue
@@ -261,13 +264,14 @@ export class LiveQueryClient {
     const versions: Record<string, number> = Array.isArray(raw)
       ? {}
       : ((raw as { versions?: Record<string, number> })?.versions ?? {})
-    const stale = opts?.checkVersions || this.isSseStale()
     let reloaded = false
     for (const q of this.queries.values()) {
       const serverVersion = versions[q.queryChannel]
       const unknown = unknownIds.includes(q.queryChannel)
+      // server returns versions on every keep-alive, so a missed message is
+      // caught even while SSE pings look healthy
       const mismatch =
-        stale && serverVersion !== undefined && serverVersion !== q.version
+        serverVersion !== undefined && serverVersion !== q.version
       if (unknown || mismatch) {
         reloaded = true
         if (serverVersion !== undefined) q.version = serverVersion
@@ -277,10 +281,7 @@ export class LiveQueryClient {
     if (this.isSseStale()) {
       this.keepAliveBackoffMs = reloaded
         ? flags.liveQueryPollWhenStaleMs
-        : Math.min(
-            this.keepAliveBackoffMs * 2,
-            flags.liveQueryKeepAliveMs,
-          )
+        : Math.min(this.keepAliveBackoffMs * 2, flags.liveQueryKeepAliveMs)
     } else {
       this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
     }
@@ -307,7 +308,7 @@ export class LiveQueryClient {
         this.foregroundKeepAliveTimer = undefined
         this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
         this.lastKeepAliveAt = 0
-        this.runPromise(this.runKeepAlive({ checkVersions: true }))
+        this.runPromise(this.runKeepAlive())
       }, 300)
     })
     this.detachForeground = () => {
@@ -324,9 +325,12 @@ export class LiveQueryClient {
       this.lastKeepAliveAt = Date.now()
       this.keepAliveBackoffMs = flags.liveQueryPollWhenStaleMs
       this.attachForeground()
-      this.interval = setInterval(() => {
-        this.runPromise(this.maybeKeepAlive())
-      }, Math.min(flags.liveQueryPollWhenStaleMs, flags.liveQueryKeepAliveMs))
+      this.interval = setInterval(
+        () => {
+          this.runPromise(this.maybeKeepAlive())
+        },
+        Math.min(flags.liveQueryPollWhenStaleMs, flags.liveQueryKeepAliveMs),
+      )
 
       return this.runPromise(
         (this.client = this.apiProvider()

--- a/projects/core/src/live-query/LiveQueryClient.ts
+++ b/projects/core/src/live-query/LiveQueryClient.ts
@@ -294,12 +294,17 @@ export class LiveQueryClient {
     if (Date.now() - this.lastKeepAliveAt < interval) return
     this.lastKeepAliveAt = Date.now()
     if (stale) this.openedConnection?.resume?.(true)
-    const reloaded = await this.runKeepAlive()
-    // backoff lives here so channel-only clients (no query ids) back off too
-    if (this.isSseStale())
-      this.keepAliveBackoffMs = reloaded
-        ? flags.liveQueryPollWhenStaleMs
-        : Math.min(this.keepAliveBackoffMs * 2, flags.liveQueryKeepAliveMs)
+    let reloaded = false
+    try {
+      reloaded = await this.runKeepAlive()
+    } finally {
+      // runs on a failed post too, so an unreachable server is not polled
+      // every second; channel-only clients (no query ids) back off as well
+      if (this.isSseStale())
+        this.keepAliveBackoffMs = reloaded
+          ? flags.liveQueryPollWhenStaleMs
+          : Math.min(this.keepAliveBackoffMs * 2, flags.liveQueryKeepAliveMs)
+    }
   }
   private detachForeground = () => {}
   private attachForeground() {

--- a/projects/core/src/live-query/SseSubscriptionClient.ts
+++ b/projects/core/src/live-query/SseSubscriptionClient.ts
@@ -14,11 +14,13 @@ export class SseSubscriptionClient implements SubscriptionClient {
   ): Promise<SubscriptionClientConnection> {
     let connectionId: string
     const channels = new Map<string, ((value: any) => void)[]>()
+    const errorHandlers = new Map<string, ((err: any) => void)[]>()
     const provider = buildRestDataProvider(remult.apiClient.httpClient)
     let source: EventSource
     let retryCount = 0
     let closed = false
     let connected = false
+    let everConnected = false
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined
     let lastConnectAt = 0
     let connectionReady!: () => void
@@ -66,17 +68,31 @@ export class SseSubscriptionClient implements SubscriptionClient {
         clearReconnectTimer()
         source?.close()
       },
-      async subscribe(channel, handler) {
+      async subscribe(channel, handler, onError) {
         let listeners = channels.get(channel)!
+        let onErrors = errorHandlers.get(channel)!
 
         if (!listeners) {
           channels.set(channel, (listeners = []))
-          await connectionPromise
-          if (!closed) await subscribeToChannel(channel)
+          errorHandlers.set(channel, (onErrors = []))
+          try {
+            await connectionPromise
+            if (!closed) await subscribeToChannel(channel)
+          } catch (err) {
+            // otherwise the next subscribe sees the entry and never retries
+            channels.delete(channel)
+            errorHandlers.delete(channel)
+            throw err
+          }
         }
         listeners.push(handler)
+        onErrors.push(onError)
         return () => {
-          listeners.splice(listeners.indexOf(handler, 1))
+          const i = listeners.indexOf(handler)
+          if (i >= 0) {
+            listeners.splice(i, 1)
+            onErrors.splice(i, 1)
+          }
           if (listeners.length == 0) {
             remultStatic.actionInfo.runActionWithoutBlockingUI(() =>
               provider.post(
@@ -88,6 +104,7 @@ export class SseSubscriptionClient implements SubscriptionClient {
               ),
             )
             channels.delete(channel)
+            errorHandlers.delete(channel)
           }
         }
       },
@@ -127,15 +144,22 @@ export class SseSubscriptionClient implements SubscriptionClient {
         retryCount = 0
         noteServerEvent()
 
-        if (connected) {
-          for (const channel of channels.keys()) {
-            await subscribeToChannel(channel)
+        // a connection the server forgot counts as a reconnect too: every
+        // channel must be re-subscribed and live queries refetched
+        const wasConnected = everConnected
+        connected = everConnected = true
+        if (wasConnected) {
+          for (const channel of [...channels.keys()]) {
+            try {
+              await subscribeToChannel(channel)
+            } catch (err) {
+              // one refused channel must not block the others
+              errorHandlers.get(channel)?.forEach((f) => f(err))
+            }
           }
           onReconnect()
-        } else {
-          connected = true
-          connectionReady()
         }
+        connectionReady()
       })
     }
 
@@ -154,14 +178,13 @@ export class SseSubscriptionClient implements SubscriptionClient {
           )
         },
       )
-      if (result === ConnectionNotFoundError) {
+      if (result === ConnectionNotFoundError && connected) {
         connected = false
         connectionPromise = new Promise<void>((res) => {
           connectionReady = res
         })
         createConnection()
         await connectionPromise
-        if (!closed) await subscribeToChannel(channel)
       }
     }
   }

--- a/projects/core/src/live-query/SseSubscriptionClient.ts
+++ b/projects/core/src/live-query/SseSubscriptionClient.ts
@@ -1,6 +1,7 @@
 import { buildRestDataProvider } from '../buildRestDataProvider.js'
 import { remult } from '../remult-proxy.js'
 import { remultStatic } from '../remult-static.js'
+import { flags } from '../remult3/remult3.js'
 import type {
   ServerEventChannelSubscribeDTO,
   SubscriptionClient,
@@ -19,6 +20,7 @@ export class SseSubscriptionClient implements SubscriptionClient {
     let closed = false
     let connected = false
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined
+    let lastConnectAt = 0
     let connectionReady!: () => void
     let connectionPromise = new Promise<void>((res) => {
       connectionReady = res
@@ -44,16 +46,15 @@ export class SseSubscriptionClient implements SubscriptionClient {
 
     function resume(force?: boolean) {
       if (closed) return
-      retryCount = 0
-      clearReconnectTimer()
+      const open = source && source.readyState !== EVENT_SOURCE_CLOSED
       if (force) {
+        // a source still inside its handshake window is not a zombie yet
+        if (open && Date.now() - lastConnectAt < flags.sseStaleMs) return
         createConnection()
         return
       }
-      const open =
-        source &&
-        typeof EventSource !== 'undefined' &&
-        source.readyState !== EventSource.CLOSED
+      retryCount = 0
+      clearReconnectTimer()
       if (!open) createConnection()
     }
 
@@ -100,6 +101,7 @@ export class SseSubscriptionClient implements SubscriptionClient {
       if (closed) return
       clearReconnectTimer()
       if (source) source.close()
+      lastConnectAt = Date.now()
       source = SseSubscriptionClient.createEventSource(
         remult.apiClient.url + '/' + streamUrl,
       )
@@ -171,3 +173,5 @@ export class SseSubscriptionClient implements SubscriptionClient {
 }
 
 export const ConnectionNotFoundError = 'client connection not found'
+// EventSource.CLOSED; the global is absent in Node
+const EVENT_SOURCE_CLOSED = 2

--- a/projects/core/src/live-query/SubscriptionChannel.ts
+++ b/projects/core/src/live-query/SubscriptionChannel.ts
@@ -106,6 +106,9 @@ export class LiveQuerySubscriber<entityType> {
       this.subscribeCode?.()
       return
     }
+    // bump before the await below, so a second message delivered in the same
+    // tick is judged against this one and not mistaken for a gap
+    if (ver) this.version = ver.to
     const data = messages.filter((m) => m.type !== 'version')
     {
       let x = data.filter(({ type }) => type == 'add' || type == 'replace')
@@ -154,7 +157,7 @@ export class LiveQuerySubscriber<entityType> {
         return items
       })
     }, data)
-    this.version = ver ? ver.to : this.version + (data.length > 0 ? 1 : 0)
+    if (!ver && data.length > 0) this.version++
   }
 
   defaultQueryState: entityType[] = []

--- a/projects/core/src/live-query/SubscriptionChannel.ts
+++ b/projects/core/src/live-query/SubscriptionChannel.ts
@@ -25,7 +25,11 @@ export class LiveQuerySubscriber<entityType> {
   unsubscribeChannel: VoidFunction = () => {}
   unsubscribeQuery: VoidFunction = () => {}
   snapshotReady = false
+  droppedWhilePending = false
   async setAllItems(result: any[]) {
+    // server re-registers the query at version 0; reset before the await so a
+    // version message landing mid-parse is judged against the new baseline
+    this.version = 0
     const items = await getRepositoryInternals(this.repo)._fromJsonArray(
       result,
       this.query.options,
@@ -35,7 +39,6 @@ export class LiveQuerySubscriber<entityType> {
         return items
       })
     }, this.allItemsMessage(items))
-    this.version = 0
     this.snapshotReady = true
   }
 
@@ -86,17 +89,22 @@ export class LiveQuerySubscriber<entityType> {
   }
 
   async handle(messages: LiveQueryChange[]) {
+    // the pending snapshot supersedes anything in flight; the keep-alive
+    // after it lands catches whatever was dropped here
+    if (!this.snapshotReady) {
+      this.droppedWhilePending = true
+      return
+    }
     const ver = messages.find(
       (m): m is Extract<LiveQueryChange, { type: 'version' }> =>
         m.type === 'version',
     )
-    if (ver) {
-      if (ver.from < this.version) return
-      if (ver.from > this.version) {
-        this.version = ver.to
-        this.subscribeCode?.()
-        return
-      }
+    // any gap, forward or backward, means a message was missed or two servers
+    // published the same version with different diffs: refetch instead of drop
+    if (ver && ver.from !== this.version) {
+      this.version = ver.to
+      this.subscribeCode?.()
+      return
     }
     const data = messages.filter((m) => m.type !== 'version')
     {

--- a/projects/core/src/live-query/SubscriptionChannel.ts
+++ b/projects/core/src/live-query/SubscriptionChannel.ts
@@ -175,6 +175,8 @@ export interface SubscriptionListener<type> {
   next(message: type): void
   error(err: any): void
   complete(): void
+  /** The connection was re-established; messages published meanwhile were lost, refetch state if needed. */
+  reconnect?(): void
 }
 
 export type Unsubscribe = VoidFunction
@@ -318,6 +320,16 @@ export interface ServerEventChannelSubscribeDTO {
  *  // Frontend: in the chart component, we can subscribe to messages
  *  chart.subscribe((message) => {
  *    chartData = message.data;
+ *  });
+ *  ```
+ *
+ *  #### Recovering after a dropped connection
+ *  Messages published while the connection was down are not replayed.
+ *  Use the `reconnect` listener to refetch state:
+ *  ```ts
+ *  chart.subscribe({
+ *    next: (message) => (chartData = message.data),
+ *    reconnect: () => loadChartData(),
  *  });
  *  ```
  *

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -1545,8 +1545,8 @@ export type ClassFieldDecorator<entityType, valueType> = ((
 
 export const flags = {
   error500RetryCount: 4,
-  /** Client treats SSE as dead if no event for this long */
-  sseStaleMs: 20_000,
+  /** Client treats SSE as dead if no event for this long. Server pings every 15s; two missed pings plus slack, so a stalled event loop does not trigger a reconnect storm */
+  sseStaleMs: 40_000,
   /** HTTP keep-alive while SSE is healthy (touches lastUsed) */
   liveQueryKeepAliveMs: 30_000,
   /** Version poll while SSE is stale */

--- a/projects/tests/dbs/duckdb.spec.ts
+++ b/projects/tests/dbs/duckdb.spec.ts
@@ -6,7 +6,9 @@ import type { DbTestProps } from './shared-tests/db-tests-props.js'
 import { DuckDBInstance } from '@duckdb/node-api'
 import { allDbTests } from './shared-tests/index.js'
 
-describe.skipIf(process.env['SKIP_DUCKDB_TESTS'])('duckdb', () => {
+const duckdb = describe.skipIf(process.env['SKIP_DUCKDB_TESTS'])
+// in-memory duckdb is flaky under parallel prepared statements
+duckdb('duckdb', { retry: 2 }, () => {
   let db: SqlDatabase
   let remult: Remult
   beforeEach(async () => {

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -2582,3 +2582,98 @@ describe('live query keep-alive during refetch', () => {
     u()
   })
 })
+
+describe('live query message ordering and channel retry', () => {
+  it('two pushes delivered in the same tick apply in order without a refetch', async () => {
+    actionInfo.runningOnServer = false
+    let gets = 0
+    let send: (x: any) => void = () => {}
+    const lqc = new LiveQueryClient(
+      () => ({
+        subscriptionClient: {
+          async openConnection() {
+            return {
+              close() {},
+              async subscribe(_c: string, onMessage: (x: any) => void) {
+                send = onMessage
+                return () => {}
+              },
+            }
+          },
+        },
+        httpClient: {
+          get: async () => {
+            gets++
+            return [{ id: 1, title: 'a' }]
+          },
+          put: () => undefined!,
+          delete: () => undefined!,
+          post: async () => ({ unknownQueryIds: [], versions: {} }),
+        },
+      }),
+      () => undefined,
+    )
+    const r = new Remult(new InMemoryDataProvider())
+    r.liveQuerySubscriber = lqc
+    let items: eventTestEntity[] = []
+    const u = r
+      .repo(eventTestEntity)
+      .liveQuery()
+      .subscribe(({ applyChanges }) => (items = applyChanges(items)))
+    await vi.waitFor(() => expect(items.length).toBe(1))
+    send([
+      { type: 'replace', data: { oldId: 1, item: { id: 1, title: 'v1' } } },
+      { type: 'version', from: 0, to: 1 },
+    ])
+    send([
+      { type: 'replace', data: { oldId: 1, item: { id: 1, title: 'v2' } } },
+      { type: 'version', from: 1, to: 2 },
+    ])
+    await new Promise((r) => setTimeout(r, 50))
+    expect(items[0].title).toBe('v2')
+    expect(gets).toBe(1)
+    u()
+  })
+
+  it('a refused channel subscribe is retried by the next subscribeChannel', async () => {
+    actionInfo.runningOnServer = false
+    let attempts = 0
+    const lqc = new LiveQueryClient(
+      () => ({
+        subscriptionClient: {
+          async openConnection() {
+            return {
+              close() {},
+              async subscribe() {
+                attempts++
+                if (attempts === 1) throw new Error('forbidden')
+                return () => {}
+              },
+            }
+          },
+        },
+        httpClient: {
+          get: async () => [],
+          put: () => undefined!,
+          delete: () => undefined!,
+          post: async () => ({}),
+        },
+      }),
+      () => undefined,
+    )
+    const errors: any[] = []
+    const listener = {
+      next: () => {},
+      error: (e: any) => errors.push(e),
+      complete: () => {},
+    }
+    await expect(lqc.subscribeChannel('inbox', listener)).rejects.toThrow(
+      'forbidden',
+    )
+    expect(attempts).toBe(1)
+    expect(errors.length).toBe(1)
+    const unsub = await lqc.subscribeChannel('inbox', listener)
+    expect(attempts).toBe(2)
+    unsub()
+  })
+})

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -1330,7 +1330,8 @@ describe('live query resilience', () => {
     await p.flush()
     expect(get).toBe(1)
     expect(items[0].title).toBe('noam')
-    lqc.openedConnection!.lastServerEvent = 0
+    // SSE looks healthy (recent server event) yet the server is ahead
+    lqc.openedConnection!.lastServerEvent = Date.now()
     await lqc.runKeepAlive()
     await p.flush()
     expect(get).toBe(2)
@@ -1447,7 +1448,7 @@ describe('live query resilience', () => {
     u()
   })
 
-  it('stale SSE version is ignored', async () => {
+  it('duplicate SSE version with different diff refetches', async () => {
     let get = 0
     let send: (x: any) => void = () => {}
     const lqc = new LiveQueryClient(
@@ -1466,7 +1467,7 @@ describe('live query resilience', () => {
         httpClient: {
           get: async () => {
             get++
-            return [{ id: 1, title: 'noam' }]
+            return [{ id: 1, title: get === 1 ? 'noam' : 'refetched' }]
           },
           put: () => undefined!,
           post: async () => {},
@@ -1500,8 +1501,10 @@ describe('live query resilience', () => {
       { type: 'version', from: 0, to: 1 },
     ])
     await p.flush()
-    expect(get).toBe(1)
-    expect(items[0].title).toBe('v1')
+    // same version twice with different diffs (two servers publishing):
+    // the second diff is not applied, the snapshot is refetched instead
+    expect(get).toBe(2)
+    expect(items[0].title).toBe('refetched')
     u()
   })
 
@@ -1549,6 +1552,65 @@ describe('live query resilience', () => {
     u()
   })
 
+
+  it('message during a pending snapshot is held, then versions are checked', async () => {
+    const gets: ((x: any) => void)[] = []
+    let keepAlives = 0
+    let send: (x: any) => void = () => {}
+    const lqc = new LiveQueryClient(
+      () => ({
+        subscriptionClient: {
+          async openConnection() {
+            return {
+              close() {},
+              async subscribe(_channel: string, onMessage: (x: any) => void) {
+                send = onMessage
+                return () => {}
+              },
+            }
+          },
+        },
+        httpClient: {
+          get: () => new Promise((res) => gets.push(res)),
+          put: () => undefined!,
+          post: async (url: string, body: any) => {
+            if (String(url).includes('_liveQueryKeepAlive')) {
+              keepAlives++
+              return { unknownQueryIds: [], versions: { [body.queryIds[0]]: 0 } }
+            }
+          },
+          delete: () => undefined!,
+        },
+      }),
+      () => undefined,
+    )
+    const tick = () => new Promise((r) => setTimeout(r, 5))
+    const remult = new Remult(new InMemoryDataProvider())
+    remult.liveQuerySubscriber = lqc
+    let items: eventTestEntity[] = []
+    const u = remult
+      .repo(eventTestEntity)
+      .liveQuery()
+      .subscribe(({ applyChanges }) => (items = applyChanges(items)))
+    await tick()
+    gets[0]([{ id: 1, title: 'first' }])
+    await tick()
+    send([{ type: 'version', from: 5, to: 6 }])
+    await tick()
+    expect(gets.length).toBe(2)
+    // arrives while the refetch is in flight: not applied, no second refetch
+    send([
+      { type: 'add', data: { item: { id: 9, title: 'held' } } },
+      { type: 'version', from: 0, to: 1 },
+    ])
+    await tick()
+    expect(gets.length).toBe(2)
+    gets[1]([{ id: 1, title: 'newest' }])
+    await tick()
+    expect(items.map((x) => x.title)).toEqual(['newest'])
+    expect(keepAlives).toBe(1)
+    u()
+  })
 
   it('keep-alive matching version does not reload', async () => {
     let get = 0

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -1630,17 +1630,22 @@ describe('live query resilience', () => {
             }
           },
         },
-        httpClient: createMockHttpDataProvider(new Remult()),
+        httpClient: {
+          get: async () => [],
+          put: () => undefined!,
+          post: async () => ({}),
+          delete: () => undefined!,
+        },
       }),
       () => undefined,
     )
-    const remult = new Remult(new InMemoryDataProvider())
-    remult.liveQuerySubscriber = lqc
     let reconnects = 0
-    const unsub = await new SubscriptionChannel('chan').subscribe(
-      { next: () => {}, reconnect: () => reconnects++ },
-      remult,
-    )
+    const unsub = await lqc.subscribeChannel('chan', {
+      next: () => {},
+      error: () => {},
+      complete: () => {},
+      reconnect: () => reconnects++,
+    })
     onReconnect()
     expect(reconnects).toBe(1)
     unsub()
@@ -2566,11 +2571,11 @@ describe('live query keep-alive during refetch', () => {
     await vi.waitFor(() => expect(gets).toBe(1))
     onReconnect()
     await vi.waitFor(() => expect(gets).toBe(2))
-    await lqc.runKeepAlive({ checkVersions: true })
+    await lqc.runKeepAlive()
     expect(posted).toEqual([])
     releaseGet()
     await new Promise((r) => setTimeout(r, 20))
-    await lqc.runKeepAlive({ checkVersions: true })
+    await lqc.runKeepAlive()
     expect(posted.length).toBe(1)
     await new Promise((r) => setTimeout(r, 20))
     expect(gets).toBe(3)

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -1615,6 +1615,37 @@ describe('live query resilience', () => {
     u()
   })
 
+  it('channel listeners are told about a reconnect', async () => {
+    let onReconnect: () => void = () => {}
+    const lqc = new LiveQueryClient(
+      () => ({
+        subscriptionClient: {
+          async openConnection(reconnect) {
+            onReconnect = reconnect
+            return {
+              close() {},
+              async subscribe() {
+                return () => {}
+              },
+            }
+          },
+        },
+        httpClient: createMockHttpDataProvider(new Remult()),
+      }),
+      () => undefined,
+    )
+    const remult = new Remult(new InMemoryDataProvider())
+    remult.liveQuerySubscriber = lqc
+    let reconnects = 0
+    const unsub = await new SubscriptionChannel('chan').subscribe(
+      { next: () => {}, reconnect: () => reconnects++ },
+      remult,
+    )
+    onReconnect()
+    expect(reconnects).toBe(1)
+    unsub()
+  })
+
   it('keep-alive matching version does not reload', async () => {
     let get = 0
     const lqc = new LiveQueryClient(

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -1733,9 +1733,12 @@ describe('live query resilience', () => {
     const orig = SseSubscriptionClient.createEventSource
     SseSubscriptionClient.createEventSource = () => {
       const src = {
+        readyState: 1,
         onmessage: undefined as any,
         onerror: undefined as any,
-        close() {},
+        close() {
+          src.readyState = 2
+        },
         addEventListener(_name: string, _fn: any) {},
       }
       sources.push(src)
@@ -1750,6 +1753,11 @@ describe('live query resilience', () => {
         await vi.advanceTimersByTimeAsync(30_000)
       }
       expect(sources.length).toBe(6)
+      // open source: foreground resume leaves it alone
+      conn.resume?.()
+      expect(sources.length).toBe(6)
+      // errored source with a backoff timer pending: resume reconnects now
+      sources[5].onerror?.(new Event('error'))
       conn.resume?.()
       expect(sources.length).toBe(7)
     } finally {
@@ -2052,6 +2060,55 @@ describe('live query resilience gaps', () => {
     }
   })
 
+  it('channel-only client backs off forced reconnects while SSE is stale', async () => {
+    vi.useFakeTimers()
+    const sources = fakeEventSources()
+    const origEs = SseSubscriptionClient.createEventSource
+    SseSubscriptionClient.createEventSource = () => sources.create()
+    let posts = 0
+    const http = {
+      get: async () => [],
+      put: () => undefined!,
+      delete: () => undefined!,
+      post: async () => {
+        posts++
+        return {}
+      },
+    }
+    const prevHttp = remult.apiClient.httpClient
+    const prevUrl = remult.apiClient.url
+    remult.apiClient.httpClient = http
+    remult.apiClient.url = 'http://x/api'
+    try {
+      const lqc = new LiveQueryClient(
+        () => ({
+          subscriptionClient: new SseSubscriptionClient(),
+          httpClient: http,
+          url: 'http://x/api',
+        }),
+        () => undefined,
+      )
+      const r = new Remult(new InMemoryDataProvider())
+      r.liveQuerySubscriber = lqc
+      const unsubP = new SubscriptionChannel('chan').subscribe(() => {}, r)
+      await vi.advanceTimersByTimeAsync(10)
+      sources.all[0].fire('connectionId', 'c1')
+      await vi.advanceTimersByTimeAsync(10)
+      const unsub = await unsubP
+      posts = 0
+      // no server event ever again: must reconnect, but not once per second
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(sources.all.length).toBeGreaterThan(1)
+      expect(sources.all.length).toBeLessThanOrEqual(5)
+      expect(posts).toBe(0)
+      unsub()
+    } finally {
+      SseSubscriptionClient.createEventSource = origEs
+      remult.apiClient.httpClient = prevHttp
+      remult.apiClient.url = prevUrl
+    }
+  })
+
   it('stale keep-alive polling backs off while versions match', async () => {
     vi.useFakeTimers()
     let posts = 0
@@ -2125,16 +2182,32 @@ describe('live query resilience gaps', () => {
       )
       const r = new Remult(new InMemoryDataProvider())
       r.liveQuerySubscriber = lqc
+      const noop = { next: () => {}, error: () => {}, complete: () => {} }
       for (let i = 0; i < 2; i++) {
-        const u = r.repo(eventTestEntity).liveQuery().subscribe({
-          next: () => {},
-          error: () => {},
-          complete: () => {},
-        })
+        const u = r.repo(eventTestEntity).liveQuery().subscribe(noop)
         await vi.advanceTimersByTimeAsync(10)
         u()
         await vi.advanceTimersByTimeAsync(10)
       }
+      expect(lqc.hasQueriesForTesting()).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(listeners).toBe(0)
+
+      // second open attempt while a query is still alive must not stack timers
+      const u1 = r.repo(eventTestEntity).liveQuery().subscribe(noop)
+      await vi.advanceTimersByTimeAsync(10)
+      const timersAfterFirst = vi.getTimerCount()
+      const listenersAfterFirst = listeners
+      const u2 = r
+        .repo(eventTestEntity)
+        .liveQuery({ where: { id: 1 } })
+        .subscribe(noop)
+      await vi.advanceTimersByTimeAsync(10)
+      expect(vi.getTimerCount()).toBe(timersAfterFirst)
+      expect(listeners).toBe(listenersAfterFirst)
+      u1()
+      u2()
+      await vi.advanceTimersByTimeAsync(10)
       expect(lqc.hasQueriesForTesting()).toBe(false)
       expect(vi.getTimerCount()).toBe(0)
       expect(listeners).toBe(0)

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -2352,6 +2352,52 @@ describe('live query resilience gaps', () => {
     u()
   })
 
+  it('keep-alive backs off while the server is unreachable', async () => {
+    vi.useFakeTimers()
+    let posts = 0
+    const lqc = new LiveQueryClient(
+      () => ({
+        subscriptionClient: {
+          async openConnection() {
+            return {
+              lastServerEvent: Date.now(),
+              close() {},
+              async subscribe() {
+                return () => {}
+              },
+            }
+          },
+        },
+        httpClient: {
+          get: async () => [{ id: 1, title: 'noam' }],
+          put: () => undefined!,
+          delete: () => undefined!,
+          post: async (url: string) => {
+            if (String(url).includes('_liveQueryKeepAlive')) {
+              posts++
+              throw new Error('ECONNREFUSED')
+            }
+            return {}
+          },
+        },
+      }),
+      () => undefined,
+    )
+    const r = new Remult(new InMemoryDataProvider())
+    r.liveQuerySubscriber = lqc
+    const u = r.repo(eventTestEntity).liveQuery().subscribe({
+      next: () => {},
+      error: () => {},
+      complete: () => {},
+    })
+    await vi.advanceTimersByTimeAsync(10)
+    lqc.openedConnection!.lastServerEvent = 0
+    posts = 0
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(posts).toBeLessThanOrEqual(8)
+    u()
+  })
+
   it('failed openConnection does not leak the keep-alive interval or foreground listeners', async () => {
     vi.useFakeTimers()
     const g = globalThis as any

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -6,7 +6,10 @@ import {
   findOptionsToJson,
 } from '../../core/src/data-providers/rest-data-provider'
 import { LiveQueryClient } from '../../core/src/live-query/LiveQueryClient'
-import { SseSubscriptionClient } from '../../core/src/live-query/SseSubscriptionClient'
+import {
+  ConnectionNotFoundError,
+  SseSubscriptionClient,
+} from '../../core/src/live-query/SseSubscriptionClient'
 import type { LiveQueryChange } from '../../core/src/live-query/SubscriptionChannel'
 import { SubscriptionChannel } from '../../core/src/live-query/SubscriptionChannel'
 import {
@@ -2007,6 +2010,171 @@ describe('live query resilience gaps', () => {
       },
     }
   }
+
+  it('failed channel subscribe is retried on the next subscribe', async () => {
+    const sources = fakeEventSources()
+    const origEs = SseSubscriptionClient.createEventSource
+    SseSubscriptionClient.createEventSource = () => sources.create()
+    let subscribePosts = 0
+    let fail = true
+    const http = {
+      get: async () => [],
+      put: () => undefined!,
+      delete: () => undefined!,
+      post: async (url: string) => {
+        if (String(url).endsWith('/subscribe')) {
+          subscribePosts++
+          if (fail) throw new Error('network')
+        }
+        return {}
+      },
+    }
+    const prevHttp = remult.apiClient.httpClient
+    const prevUrl = remult.apiClient.url
+    remult.apiClient.httpClient = http
+    remult.apiClient.url = 'http://x/api'
+    try {
+      const conn = await new SseSubscriptionClient().openConnection(() => {})
+      sources.all[0].fire('connectionId', 'c1')
+      await expect(
+        conn.subscribe(
+          'chan',
+          () => {},
+          () => {},
+        ),
+      ).rejects.toThrow('network')
+      fail = false
+      const a = () => {}
+      const b = () => {}
+      const unsubA = await conn.subscribe('chan', a, () => {})
+      const unsubB = await conn.subscribe('chan', b, () => {})
+      expect(subscribePosts).toBe(2)
+      let got: any[] = []
+      sources.all[0].onmessage({
+        data: JSON.stringify({ channel: 'chan', data: 1 }),
+      })
+      unsubA()
+      const unsubC = await conn.subscribe(
+        'chan',
+        (x) => got.push(x),
+        () => {},
+      )
+      sources.all[0].onmessage({
+        data: JSON.stringify({ channel: 'chan', data: 2 }),
+      })
+      // removing the first listener must not wipe the others
+      expect(got).toEqual([2])
+      unsubB()
+      unsubC()
+    } finally {
+      SseSubscriptionClient.createEventSource = origEs
+      remult.apiClient.httpClient = prevHttp
+      remult.apiClient.url = prevUrl
+    }
+  })
+
+  it('ConnectionNotFoundError on subscribe reconnects and resubscribes every channel once', async () => {
+    const sources = fakeEventSources()
+    const origEs = SseSubscriptionClient.createEventSource
+    SseSubscriptionClient.createEventSource = () => sources.create()
+    const posts: { clientId: string; channel: string }[] = []
+    let lostClient = 'c1'
+    const http = {
+      get: async () => [],
+      put: () => undefined!,
+      delete: () => undefined!,
+      post: async (url: string, body: any) => {
+        if (String(url).endsWith('/subscribe')) {
+          posts.push(body)
+          if (body.clientId === lostClient) return ConnectionNotFoundError
+        }
+        return {}
+      },
+    }
+    const prevHttp = remult.apiClient.httpClient
+    const prevUrl = remult.apiClient.url
+    remult.apiClient.httpClient = http
+    remult.apiClient.url = 'http://x/api'
+    try {
+      let reconnects = 0
+      const conn = await new SseSubscriptionClient().openConnection(
+        () => reconnects++,
+      )
+      lostClient = ''
+      sources.all[0].fire('connectionId', 'c1')
+      await conn.subscribe(
+        'a',
+        () => {},
+        () => {},
+      )
+      await new Promise((r) => setTimeout(r, 5))
+      // server forgot c1: next subscribe must open a new source
+      lostClient = 'c1'
+      const errors: any[] = []
+      const subB = conn.subscribe(
+        'b',
+        () => {},
+        (e) => errors.push(e),
+      )
+      await new Promise((r) => setTimeout(r, 5))
+      expect(sources.all.length).toBe(2)
+      sources.all[1].fire('connectionId', 'c2')
+      await subB
+      await new Promise((r) => setTimeout(r, 5))
+      expect(
+        posts
+          .filter((p) => p.clientId === 'c2')
+          .map((p) => p.channel)
+          .sort(),
+      ).toEqual(['a', 'b'])
+      expect(reconnects).toBe(1)
+      expect(errors).toEqual([])
+    } finally {
+      SseSubscriptionClient.createEventSource = origEs
+      remult.apiClient.httpClient = prevHttp
+      remult.apiClient.url = prevUrl
+    }
+  })
+
+  it('subscribe failure during reconnect reaches onError', async () => {
+    const sources = fakeEventSources()
+    const origEs = SseSubscriptionClient.createEventSource
+    SseSubscriptionClient.createEventSource = () => sources.create()
+    let fail = false
+    const http = {
+      get: async () => [],
+      put: () => undefined!,
+      delete: () => undefined!,
+      post: async (url: string) => {
+        if (String(url).endsWith('/subscribe') && fail) throw new Error('403')
+        return {}
+      },
+    }
+    const prevHttp = remult.apiClient.httpClient
+    const prevUrl = remult.apiClient.url
+    remult.apiClient.httpClient = http
+    remult.apiClient.url = 'http://x/api'
+    try {
+      const conn = await new SseSubscriptionClient().openConnection(() => {})
+      sources.all[0].fire('connectionId', 'c1')
+      const errors: any[] = []
+      await conn.subscribe(
+        'a',
+        () => {},
+        (e) => errors.push(e),
+      )
+      fail = true
+      sources.all[0].onerror(new Event('error'))
+      await new Promise((r) => setTimeout(r, 600))
+      sources.all[1].fire('connectionId', 'c2')
+      await new Promise((r) => setTimeout(r, 5))
+      expect(errors.length).toBe(1)
+    } finally {
+      SseSubscriptionClient.createEventSource = origEs
+      remult.apiClient.httpClient = prevHttp
+      remult.apiClient.url = prevUrl
+    }
+  })
 
   it('recreates the EventSource when no server event arrives past sseStaleMs', async () => {
     vi.useFakeTimers()


### PR DESCRIPTION
Follow-ups to the 3.4.0 SSE / live query resilience work. 4 commits, each fixing a concrete failure found while reviewing `aee1e218`. All are behaviour fixes inside the same 3.4.0 entry; one new optional public API (`SubscriptionListener.reconnect?()`).

## 1. Live query versioning

- **Version mismatch was only checked while SSE looked stale.** One failed `/stream/subscribe` post with healthy pings = server publishes to nobody, keep-alive returns `versions: {q: 3}` vs client `0`, ignored forever. Now compared on every keep-alive.
- **Message during an in-flight snapshot triggered another refetch** (up to 5 GETs for one event). Now held while `snapshotReady === false`; one version check after the snapshot lands.
- **`from < version` dropped the message silently.** Only reachable multi-instance (two servers publish `{3→4}` with different diffs); the second diff was lost until the next change. Any gap now refetches.

## 2. Backoff / stale

- **Channel-only clients (no `liveQuery`) recreated an EventSource every second** while SSE was stale: `sendKeepAlive` returned early with no query ids, before the backoff update. Backoff moved to `maybeKeepAlive`.
- Forced reconnect killed a source still handshaking and reset the retry backoff. A fresh source now gets `sseStaleMs` before it is treated as a zombie.
- `sseStaleMs` 20s vs 15s ping left 5s margin: a short event-loop stall on the server turned into a reconnect storm. Now 40s (two missed pings).
- `openConnection` rejected + retried with queries alive stacked a second keep-alive interval.

## 3. SSE client channels

- **After `ConnectionNotFoundError` only the channel that hit it was re-subscribed**; the new `connectionId` took the "first connect" branch, other channels stayed deaf and `onReconnect` never fired. Any connect after the first is now a reconnect.
- Re-subscribe loop had no try/catch: one refused channel (ACL) aborted the rest and became an unhandled rejection. Now per-channel, delivered to the `onError` callback `subscribe()` already received.
- `listeners.splice(listeners.indexOf(handler, 1))` removed the wrong listeners.
- A failed subscribe post left the channel registered client-side, never retried.

## 4. `SubscriptionListener.reconnect?()`

SSE has no replay. Live queries resync internally on reconnect; `SubscriptionChannel` subscribers had no way to know they were ever disconnected. `reconnect` is the signal to refetch whatever state the channel drives.

```ts
inbox.subscribe({ next: () => recount(), reconnect: () => recount() })
```
